### PR TITLE
chore(docs): ensure attribute names are correct

### DIFF
--- a/website/docs/r/organization_webhook.html.markdown
+++ b/website/docs/r/organization_webhook.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `events` - (Required) A list of events which should trigger the webhook. Defaults to `["push"]`. See a list of [available events](https://developer.github.com/v3/activity/events/types/)
 
-* `config` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`.
+* `configuration` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`.
 
 * `active` - (Optional) Indicate of the webhook should receive events. Defaults to `true`.
 

--- a/website/docs/r/repository_webhook.html.markdown
+++ b/website/docs/r/repository_webhook.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `events` - (Required) A list of events which should trigger the webhook. Defaults to `["push"]`. See a list of [available events](https://developer.github.com/v3/activity/events/types/)
 
-* `config` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`.
+* `configuration` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`.
 
 * `active` - (Optional) Indicate of the webhook should receive events. Defaults to `true`.
 


### PR DESCRIPTION
the webhook resources don't have a config attribute, but a configuration
attribute.