### PR TITLE
r/github_repository: Allow updating default_branch

### DIFF
--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -216,7 +216,7 @@ func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testA
 
 		if repo.AutoInit != nil {
 			if *repo.AutoInit != want.AutoInit {
-				return fmt.Errorf("got auto init %q; want %q", *repo.AutoInit, want.AutoInit)
+				return fmt.Errorf("got auto init %t; want %t", *repo.AutoInit, want.AutoInit)
 			}
 		}
 

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -56,13 +56,15 @@ The following arguments are supported:
 * `auto_init` - (Optional) Meaningful only during create; set to `true` to
   produce an initial commit in the repository.
 
+* `default_branch` - (Optional) The name of the default branch of the repository. **NOTE:** This can only be set after a repository has already been created,
+and after a correct reference has been created for the target branch inside the repository. This means a user will have to omit this parameter from the
+initial repository creation and create the target branch inside of the repository prior to setting this attribute.
+
 ## Attributes Reference
 
 The following additional attributes are exported:
 
 * `full_name` - A string of the form "orgname/reponame".
-
-* `default_branch` - The name of the repository's default branch.
 
 * `ssh_clone_url` - URL that can be provided to `git clone` to clone the
   repository via SSH.


### PR DESCRIPTION
Allows a user to update the default branch for a repository. This cannot be set during initial creation of the repository, and can only be configured during Updates to an existing repository. The GitHub API will also omit an error during Update if a corresponding ref is not found for the target branch.

```
$ make testacc TEST=./github TESTARGS="-run=TestAccGithubRepository_defaultBranch"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./github -v -run=TestAccGithubRepository_defaultBranch -timeout 120m
=== RUN   TestAccGithubRepository_defaultBranch
--- PASS: TestAccGithubRepository_defaultBranch (5.82s)
PASS
ok      github.com/terraform-providers/terraform-provider-github/github 5.826s
```
Fixes: #22 