### PR TITLE
r/github_repository: Add license_template and gitignore_template

### DIFF
--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -56,6 +56,10 @@ The following arguments are supported:
 * `auto_init` - (Optional) Meaningful only during create; set to `true` to
   produce an initial commit in the repository.
 
+* `gitignore_template` - (Optional) Meaningful only during create, will be ignored after repository creation. Use the [name of the template](https://github.com/github/gitignore) without the extension. For example, "Haskell".
+
+* `license_template` - (Optional) Meaningful only during create, will be ignored after repository creation. Use the [name of the template](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses) without the extension. For example, "mit" or "mozilla".
+
 * `default_branch` - (Optional) The name of the default branch of the repository. **NOTE:** This can only be set after a repository has already been created,
 and after a correct reference has been created for the target branch inside the repository. This means a user will have to omit this parameter from the
 initial repository creation and create the target branch inside of the repository prior to setting this attribute.


### PR DESCRIPTION
Allows a user to specify a `license_template` as well as a `gitignore_template`. These attributes can only be set during `Create`. Otherwise they are ignored.

```
$ make testacc TEST=./github TESTARGS="-run=TestAccGithubRepository_templates"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./github -v -run=TestAccGithubRepository_templates -timeout 120m
=== RUN   TestAccGithubRepository_templates
--- PASS: TestAccGithubRepository_templates (2.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-github/github 2.745s
```
Fixes: #20, #21 