### PR TITLE
chore(docs): add undocumented attribute to issue_label resource

### DIFF
--- a/website/docs/r/issue_label.html.markdown
+++ b/website/docs/r/issue_label.html.markdown
@@ -42,6 +42,8 @@ The following arguments are supported:
 
 * `color` - (Required) A 6 character hex code, **without the leading #**, identifying the color of the label.
 
+* `url` - (Computed) The URL to the issue label
+
 ## Import
 
 Github Issue Labels can be imported using an id made up of `repository:name`, e.g.


### PR DESCRIPTION
this PR adds a previously undocumented attribute to the `issue_label` resource