### PR TITLE
r/github_repository_webhook: Add import

### DIFF
--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -14,6 +16,17 @@ func resourceGithubRepositoryWebhook() *schema.Resource {
 		Read:   resourceGithubRepositoryWebhookRead,
 		Update: resourceGithubRepositoryWebhookUpdate,
 		Delete: resourceGithubRepositoryWebhookDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				combined := strings.Split(d.Id(), "/")
+				if len(combined) != 2 {
+					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<webhook_id>")
+				}
+				d.Set("repository", combined[0])
+				d.SetId(combined[1])
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -26,7 +39,7 @@ func resourceGithubRepositoryWebhook() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"events": &schema.Schema{
+			"events": {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/github/resource_github_repository_webhook_test.go
+++ b/github/resource_github_repository_webhook_test.go
@@ -59,6 +59,27 @@ func TestAccGithubRepositoryWebhook_basic(t *testing.T) {
 	})
 }
 
+func TestAccGithubRepositoryWebhook_importBasic(t *testing.T) {
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubRepositoryWebhookConfig(randString),
+			},
+			{
+				ResourceName:        "github_repository_webhook.foo",
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("foo-%s/", randString),
+			},
+		},
+	})
+}
+
 func testAccCheckGithubRepositoryWebhookExists(n string, repoName string, hook *github.Hook) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/website/docs/r/repository_webhook.html.markdown
+++ b/website/docs/r/repository_webhook.html.markdown
@@ -61,3 +61,14 @@ The following arguments are supported:
 The following additional attributes are exported:
 
 * `url` - URL of the webhook
+
+## Import
+
+Repository Webhooks can be imported using the `name` of the repository, combined with the `id` of the webhook`, separated by a `/` character.
+The `id` of the webhook can be found in the URL of the webhook. For example: `"https://github.com/foo-org/foo-repo/settings/hooks/14711452"`.
+
+Importing uses the name of the repository, as well as the ID of the webhook, e.g.
+
+```
+$ terraform import github_repository_webhook.terraform terraform/11235813
+```


### PR DESCRIPTION
Adds import functionality to the `github_repository_webhook` resource.

```
$ make testacc TEST=./github TESTARGS="-run=TestAccGithubRepositoryWebhook_importBasic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./github -v -run=TestAccGithubRepositoryWebhook_importBasic -timeout 120m
=== RUN   TestAccGithubRepositoryWebhook_importBasic
--- PASS: TestAccGithubRepositoryWebhook_importBasic (3.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-github/github 3.753s
```
Fixes: #12 