### PR TITLE
Update acceptance test users

### DIFF
--- a/github/resource_github_membership_test.go
+++ b/github/resource_github_membership_test.go
@@ -129,4 +129,4 @@ var testAccGithubMembershipConfig string = fmt.Sprintf(`
     username = "%s"
     role = "member"
   }
-`, testUser)
+`, testCollaborator)

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -31,7 +31,7 @@ func TestAccGithubTeamMembership_basic(t *testing.T) {
 			username = "%s"
 			role = "maintainer"
 		}
-	`, testUser, randString, testUser)
+	`, testCollaborator, randString, testCollaborator)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -39,7 +39,7 @@ func TestAccGithubTeamMembership_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGithubTeamMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamMembershipConfig(randString, testUser),
+				Config: testAccGithubTeamMembershipConfig(randString, testCollaborator),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamMembershipExists("github_team_membership.test_team_membership", &membership),
 					testAccCheckGithubTeamMembershipRoleState("github_team_membership.test_team_membership", "member", &membership),
@@ -65,7 +65,7 @@ func TestAccGithubTeamMembership_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckGithubTeamMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamMembershipConfig(randString, testUser),
+				Config: testAccGithubTeamMembershipConfig(randString, testCollaborator),
 			},
 			{
 				ResourceName:      "github_team_membership.test_team_membership",


### PR DESCRIPTION
Fixes acceptance tests:

```
$ make testacc TEST=./github TESTARGS="-run=TestAccGithub"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./github -v -run=TestAccGithub -timeout 120m
=== RUN   TestAccGithubTeamDataSource_noMatchReturnsError
--- PASS: TestAccGithubTeamDataSource_noMatchReturnsError (0.52s)
=== RUN   TestAccGithubUserDataSource_noMatchReturnsError
--- PASS: TestAccGithubUserDataSource_noMatchReturnsError (0.39s)
=== RUN   TestAccGithubUserDataSource_existing
--- PASS: TestAccGithubUserDataSource_existing (4.02s)
=== RUN   TestAccGithubBranchProtection_basic
--- PASS: TestAccGithubBranchProtection_basic (7.99s)
=== RUN   TestAccGithubBranchProtection_emptyItems
--- PASS: TestAccGithubBranchProtection_emptyItems (4.54s)
=== RUN   TestAccGithubBranchProtection_importBasic
--- PASS: TestAccGithubBranchProtection_importBasic (3.56s)
=== RUN   TestAccGithubIssueLabel_basic
--- PASS: TestAccGithubIssueLabel_basic (4.61s)
=== RUN   TestAccGithubIssueLabel_existingLabel
--- PASS: TestAccGithubIssueLabel_existingLabel (3.90s)
=== RUN   TestAccGithubIssueLabel_importBasic
--- PASS: TestAccGithubIssueLabel_importBasic (3.21s)
=== RUN   TestAccGithubMembership_basic
--- PASS: TestAccGithubMembership_basic (1.88s)
=== RUN   TestAccGithubMembership_importBasic
--- PASS: TestAccGithubMembership_importBasic (1.81s)
=== RUN   TestAccGithubOrganizationWebhook_basic
--- PASS: TestAccGithubOrganizationWebhook_basic (2.37s)
=== RUN   TestAccGithubRepositoryCollaborator_basic
--- PASS: TestAccGithubRepositoryCollaborator_basic (4.12s)
=== RUN   TestAccGithubRepositoryCollaborator_importBasic
--- PASS: TestAccGithubRepositoryCollaborator_importBasic (3.82s)
=== RUN   TestAccGithubRepositoryDeployKey_basic
--- PASS: TestAccGithubRepositoryDeployKey_basic (1.44s)
=== RUN   TestAccGithubRepositoryDeployKey_importBasic
--- PASS: TestAccGithubRepositoryDeployKey_importBasic (1.54s)
=== RUN   TestAccGithubRepository_basic
--- PASS: TestAccGithubRepository_basic (6.22s)
=== RUN   TestAccGithubRepository_importBasic
--- PASS: TestAccGithubRepository_importBasic (1.95s)
=== RUN   TestAccGithubRepository_defaultBranch
--- PASS: TestAccGithubRepository_defaultBranch (11.18s)
=== RUN   TestAccGithubRepository_templates
--- PASS: TestAccGithubRepository_templates (3.06s)
=== RUN   TestAccGithubRepositoryWebhook_basic
--- PASS: TestAccGithubRepositoryWebhook_basic (6.72s)
=== RUN   TestAccGithubRepositoryWebhook_importBasic
--- PASS: TestAccGithubRepositoryWebhook_importBasic (3.14s)
=== RUN   TestAccGithubTeamMembership_basic
--- PASS: TestAccGithubTeamMembership_basic (5.16s)
=== RUN   TestAccGithubTeamMembership_importBasic
--- PASS: TestAccGithubTeamMembership_importBasic (2.66s)
=== RUN   TestAccGithubTeamRepository_basic
--- PASS: TestAccGithubTeamRepository_basic (5.06s)
=== RUN   TestAccGithubTeamRepository_importBasic
--- PASS: TestAccGithubTeamRepository_importBasic (3.30s)
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (4.14s)
=== RUN   TestAccGithubTeam_importBasic
--- PASS: TestAccGithubTeam_importBasic (2.03s)
=== RUN   TestAccGithubUtilRole_validation
--- PASS: TestAccGithubUtilRole_validation (0.00s)
=== RUN   TestAccGithubUtilTwoPartID
--- PASS: TestAccGithubUtilTwoPartID (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-github/github 104.350s
```