### PR TITLE
Supports managing a team's LDAP DN in GitHub Enterprise

### DIFF
--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -33,6 +33,10 @@ func resourceGithubTeam() *schema.Resource {
 				Default:      "secret",
 				ValidateFunc: validateValueFunc([]string{"secret", "closed"}),
 			},
+			"ldap_dn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -50,6 +54,17 @@ func resourceGithubTeamCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	if ldapDN := d.Get("ldap_dn").(string); ldapDN != "" {
+		mapping := &github.TeamLDAPMapping{
+			LDAPDN: github.String(ldapDN),
+		}
+		_, _, err = client.Admin.UpdateTeamLDAPMapping(context.TODO(), *githubTeam.ID, mapping)
+		if err != nil {
+			return err
+		}
+	}
+
 	d.SetId(fromGithubID(githubTeam.ID))
 	return resourceGithubTeamRead(d, meta)
 }
@@ -65,6 +80,7 @@ func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", team.Description)
 	d.Set("name", team.Name)
 	d.Set("privacy", team.Privacy)
+	d.Set("ldap_dn", team.GetLDAPDN())
 	return nil
 }
 
@@ -88,6 +104,18 @@ func resourceGithubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	if d.HasChange("ldap_dn") {
+		ldapDN := d.Get("ldap_dn").(string)
+		mapping := &github.TeamLDAPMapping{
+			LDAPDN: github.String(ldapDN),
+		}
+		_, _, err = client.Admin.UpdateTeamLDAPMapping(context.TODO(), *team.ID, mapping)
+		if err != nil {
+			return err
+		}
+	}
+
 	d.SetId(fromGithubID(team.ID))
 	return resourceGithubTeamRead(d, meta)
 }

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 * `description` - (Optional) A description of the team.
 * `privacy` - (Optional) The level of privacy for the team. Must be one of `secret` or `closed`.
                Defaults to `secret`.
+* `ldan_dn` - (Optional) The LDAP Distinguished Name of the group where membership will be synchronized. Only available in GitHub Enterprise.
 
 ## Attributes Reference
 


### PR DESCRIPTION
We've applied this patch to our terraform installation for a while now to codify LDAP-synced teams.