### PR TITLE
resource/github_branch_protection: Add support for require_code_owners_review

### DIFF
--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 * `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
 * `dismissal_users`: (Optional) The list of user logins with dismissal access
 * `dismissal_teams`: (Optional) The list of team slugs with dismissal access
+* `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
 
 ### Restrictions
 


### PR DESCRIPTION
This resolves terraform-providers/terraform-provider-github#50

~Blocked until google/go-github#744 is merged adding support for require_code_owners_review~

Requires #60 to be merged.  I can rebase afterwards.