### PR TITLE
Remove mention of defaults for webhook events

### DIFF
--- a/website/docs/r/organization_webhook.html.markdown
+++ b/website/docs/r/organization_webhook.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `name` - (Required) The type of the webhook. See a list of [available hooks](https://api.github.com/hooks).
 
-* `events` - (Required) A list of events which should trigger the webhook. Defaults to `["push"]`. See a list of [available events](https://developer.github.com/v3/activity/events/types/)
+* `events` - (Required) A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/)
 
 * `configuration` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`.
 

--- a/website/docs/r/repository_webhook.html.markdown
+++ b/website/docs/r/repository_webhook.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `repository` - (Required) The repository of the webhook.
 
-* `events` - (Required) A list of events which should trigger the webhook. Defaults to `["push"]`. See a list of [available events](https://developer.github.com/v3/activity/events/types/)
+* `events` - (Required) A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/)
 
 * `configuration` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`.
 


### PR DESCRIPTION
'Defaults to' doesn't make sense for arguments that are '(Required)'.