### PR TITLE
`github_repository` - adding support for `archived` repositories

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -83,6 +83,11 @@ func resourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"archived": {
+				Type: schema.TypeBool,
+				Optional: true,
+				Default: false,
+			},
 
 			"full_name": {
 				Type:     schema.TypeString,
@@ -122,6 +127,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 	autoInit := d.Get("auto_init").(bool)
 	licenseTemplate := d.Get("license_template").(string)
 	gitIgnoreTemplate := d.Get("gitignore_template").(string)
+	archived := d.Get("archived").(bool)
 
 	repo := &github.Repository{
 		Name:              &name,
@@ -137,6 +143,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 		AutoInit:          &autoInit,
 		LicenseTemplate:   &licenseTemplate,
 		GitignoreTemplate: &gitIgnoreTemplate,
+		Archived: &archived,
 	}
 
 	return repo
@@ -157,7 +164,7 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	}
 	d.SetId(*repo.Name)
 
-	return resourceGithubRepositoryRead(d, meta)
+	return resourceGithubRepositoryUpdate(d, meta)
 }
 
 func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) error {
@@ -178,6 +185,8 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 		}
 		return err
 	}
+
+
 	d.Set("name", repoName)
 	d.Set("description", repo.Description)
 	d.Set("homepage_url", repo.Homepage)
@@ -194,6 +203,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("svn_url", repo.SVNURL)
 	d.Set("git_clone_url", repo.GitURL)
 	d.Set("http_clone_url", repo.CloneURL)
+	d.Set("archived", repo.Archived)
 	return nil
 }
 

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -84,9 +84,9 @@ func resourceGithubRepository() *schema.Resource {
 				Optional: true,
 			},
 			"archived": {
-				Type: schema.TypeBool,
+				Type:     schema.TypeBool,
 				Optional: true,
-				Default: false,
+				Default:  false,
 			},
 
 			"full_name": {
@@ -143,7 +143,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 		AutoInit:          &autoInit,
 		LicenseTemplate:   &licenseTemplate,
 		GitignoreTemplate: &gitIgnoreTemplate,
-		Archived: &archived,
+		Archived:          &archived,
 	}
 
 	return repo
@@ -185,7 +185,6 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 		}
 		return err
 	}
-
 
 	d.Set("name", repoName)
 	d.Set("description", repo.Description)

--- a/github/resource_github_repository_deploy_key_test.go
+++ b/github/resource_github_repository_deploy_key_test.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/hashicorp/terraform/helper/acctest"
 )
 
 func TestAccGithubRepositoryDeployKey_basic(t *testing.T) {

--- a/github/resource_github_repository_deploy_key_test.go
+++ b/github/resource_github_repository_deploy_key_test.go
@@ -8,22 +8,23 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/helper/acctest"
 )
 
-const testRepo string = "test-repo"
-
 func TestAccGithubRepositoryDeployKey_basic(t *testing.T) {
+	rs := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	repositoryName := fmt.Sprintf("acctest-%s", rs)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDeployKeyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccGithubRepositoryDeployKeyConfig,
+			{
+				Config: testAccGithubRepositoryDeployKeyConfig(repositoryName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubRepositoryDeployKeyExists("github_repository_deploy_key.test_repo_deploy_key"),
 					resource.TestCheckResourceAttr("github_repository_deploy_key.test_repo_deploy_key", "read_only", "false"),
-					resource.TestCheckResourceAttr("github_repository_deploy_key.test_repo_deploy_key", "repository", testRepo),
+					resource.TestCheckResourceAttr("github_repository_deploy_key.test_repo_deploy_key", "repository", repositoryName),
 					resource.TestCheckResourceAttr("github_repository_deploy_key.test_repo_deploy_key", "key", testAccGithubRepositoryDeployKeytestDeployKey),
 					resource.TestCheckResourceAttr("github_repository_deploy_key.test_repo_deploy_key", "title", "title"),
 				),
@@ -33,15 +34,17 @@ func TestAccGithubRepositoryDeployKey_basic(t *testing.T) {
 }
 
 func TestAccGithubRepositoryDeployKey_importBasic(t *testing.T) {
+	rs := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	repositoryName := fmt.Sprintf("acctest-%s", rs)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDeployKeyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccGithubRepositoryDeployKeyConfig,
+			{
+				Config: testAccGithubRepositoryDeployKeyConfig(repositoryName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "github_repository_deploy_key.test_repo_deploy_key",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -106,7 +109,8 @@ func testAccCheckGithubRepositoryDeployKeyExists(n string) resource.TestCheckFun
 
 const testAccGithubRepositoryDeployKeytestDeployKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDnDk1liOxXwE27fjOVVHl6RNVgQznGqGIfhsoa5QNfLOcoWJR3EIv44dSUx1GSvxQ7uR9qBY/i/SEdAbKdupo3Ru5sykc0GqaMRVys+Cin/Lgnl6+ntmTZOudNjIbz10Vfu/dKmexSzqlD3XWzPGXRI5WyKWzvc2XKjRdfnOOzogJpqJ5kh/CN0ZhCzBPTu/b4mJl2ionTEzEeLK2g4Re4IuU/dGoyf0LGLidjmqhSY7dQtL+mfte9m3x/BQTrDf0+AW3kGWXR8EL0EyIJ2HRtHW67YnoOcTAFK0hDCuKgvt78rqdUQ2bVjcsIhNqnvQMPf3ZeZ5bP2JqB9zKaFl8uaRJv+TdxEeFTkgnbYb85M+aBggBYr6xxeb24g7WlU0iPxJ8GmjvCizxe2I1DOJDRDozn1sinKjapNRdJy00iuo46TJC5Wgmid0vnMJ7SMZtubz+btxhoFLt4F4U2JnILaYG4/buJg4H/GkqmkE8G3hr4b4mgsFXBtBFgK6uCTFQSvvV7TyyWkZxHL6DRCxL/Dp0bSj+EM8Tw1K304EvkBEO3rMyvPs4nXL7pepyKWalmUI8U4Qp2xMXSq7fmfZY55osb03MUAtKl0wJ/ykyKOwYWeLbubSVcc6VPx5bXZmnM5bTcZdYW9+vNt86X2F2b0h/sIkGNEPpqQQBzElY+fQ=="
 
-var testAccGithubRepositoryDeployKeyConfig = fmt.Sprintf(`
+func testAccGithubRepositoryDeployKeyConfig(name string) string {
+	return fmt.Sprintf(`
   resource "github_repository" "test_repo" {
 		name = "%s"
 	}
@@ -117,4 +121,5 @@ var testAccGithubRepositoryDeployKeyConfig = fmt.Sprintf(`
     repository = "${github_repository.test_repo.name}"
     title = "title"
   }
-`, testRepo, testAccGithubRepositoryDeployKeytestDeployKey)
+`, name, testAccGithubRepositoryDeployKeytestDeployKey)
+}

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -74,7 +74,7 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						AllowRebaseMerge: false,
 						HasDownloads:     true,
 						DefaultBranch:    "master",
-						Archived: false,
+						Archived:         false,
 					}),
 				),
 			},
@@ -90,7 +90,7 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						AllowSquashMerge: true,
 						AllowRebaseMerge: true,
 						DefaultBranch:    "master",
-						Archived: false,
+						Archived:         false,
 					}),
 				),
 			},
@@ -124,7 +124,7 @@ func TestAccGithubRepository_archive(t *testing.T) {
 						AllowRebaseMerge: false,
 						HasDownloads:     true,
 						DefaultBranch:    "master",
-						Archived: true,
+						Archived:         true,
 					}),
 				),
 			},
@@ -158,7 +158,7 @@ func TestAccGithubRepository_archiveUpdate(t *testing.T) {
 						AllowRebaseMerge: false,
 						HasDownloads:     true,
 						DefaultBranch:    "master",
-						Archived: false,
+						Archived:         false,
 					}),
 				),
 			},
@@ -177,7 +177,7 @@ func TestAccGithubRepository_archiveUpdate(t *testing.T) {
 						AllowRebaseMerge: false,
 						HasDownloads:     true,
 						DefaultBranch:    "master",
-						Archived: true,
+						Archived:         true,
 					}),
 				),
 			},
@@ -232,7 +232,7 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 						AllowRebaseMerge: false,
 						HasDownloads:     true,
 						DefaultBranch:    "master",
-						Archived: false,
+						Archived:         false,
 					}),
 				),
 			},
@@ -255,7 +255,7 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 						AllowRebaseMerge: false,
 						HasDownloads:     true,
 						DefaultBranch:    "foo",
-						Archived: false,
+						Archived:         false,
 					}),
 				),
 			},
@@ -292,7 +292,7 @@ func TestAccGithubRepository_templates(t *testing.T) {
 						DefaultBranch:     "master",
 						LicenseTemplate:   "ms-pl",
 						GitignoreTemplate: "C++",
-						Archived: false,
+						Archived:          false,
 					}),
 				),
 			},
@@ -338,7 +338,7 @@ type testAccGithubRepositoryExpectedAttributes struct {
 	DefaultBranch     string
 	LicenseTemplate   string
 	GitignoreTemplate string
-	Archived bool
+	Archived          bool
 }
 
 func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testAccGithubRepositoryExpectedAttributes) resource.TestCheckFunc {

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -74,6 +74,7 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						AllowRebaseMerge: false,
 						HasDownloads:     true,
 						DefaultBranch:    "master",
+						Archived: false,
 					}),
 				),
 			},
@@ -89,6 +90,94 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						AllowSquashMerge: true,
 						AllowRebaseMerge: true,
 						DefaultBranch:    "master",
+						Archived: false,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGithubRepository_archive(t *testing.T) {
+	var repo github.Repository
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	name := fmt.Sprintf("tf-acc-test-%s", randString)
+	description := fmt.Sprintf("Terraform acceptance tests %s", randString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubRepositoryArchivedConfig(randString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubRepositoryExists("github_repository.foo", &repo),
+					testAccCheckGithubRepositoryAttributes(&repo, &testAccGithubRepositoryExpectedAttributes{
+						Name:             name,
+						Description:      description,
+						Homepage:         "http://example.com/",
+						HasIssues:        true,
+						HasWiki:          true,
+						AllowMergeCommit: true,
+						AllowSquashMerge: false,
+						AllowRebaseMerge: false,
+						HasDownloads:     true,
+						DefaultBranch:    "master",
+						Archived: true,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGithubRepository_archiveUpdate(t *testing.T) {
+	var repo github.Repository
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	name := fmt.Sprintf("tf-acc-test-%s", randString)
+	description := fmt.Sprintf("Terraform acceptance tests %s", randString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubRepositoryConfig(randString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubRepositoryExists("github_repository.foo", &repo),
+					testAccCheckGithubRepositoryAttributes(&repo, &testAccGithubRepositoryExpectedAttributes{
+						Name:             name,
+						Description:      description,
+						Homepage:         "http://example.com/",
+						HasIssues:        true,
+						HasWiki:          true,
+						AllowMergeCommit: true,
+						AllowSquashMerge: false,
+						AllowRebaseMerge: false,
+						HasDownloads:     true,
+						DefaultBranch:    "master",
+						Archived: false,
+					}),
+				),
+			},
+			{
+				Config: testAccGithubRepositoryArchivedConfig(randString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubRepositoryExists("github_repository.foo", &repo),
+					testAccCheckGithubRepositoryAttributes(&repo, &testAccGithubRepositoryExpectedAttributes{
+						Name:             name,
+						Description:      description,
+						Homepage:         "http://example.com/",
+						HasIssues:        true,
+						HasWiki:          true,
+						AllowMergeCommit: true,
+						AllowSquashMerge: false,
+						AllowRebaseMerge: false,
+						HasDownloads:     true,
+						DefaultBranch:    "master",
+						Archived: true,
 					}),
 				),
 			},
@@ -143,6 +232,7 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 						AllowRebaseMerge: false,
 						HasDownloads:     true,
 						DefaultBranch:    "master",
+						Archived: false,
 					}),
 				),
 			},
@@ -165,6 +255,7 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 						AllowRebaseMerge: false,
 						HasDownloads:     true,
 						DefaultBranch:    "foo",
+						Archived: false,
 					}),
 				),
 			},
@@ -201,6 +292,7 @@ func TestAccGithubRepository_templates(t *testing.T) {
 						DefaultBranch:     "master",
 						LicenseTemplate:   "ms-pl",
 						GitignoreTemplate: "C++",
+						Archived: false,
 					}),
 				),
 			},
@@ -246,6 +338,7 @@ type testAccGithubRepositoryExpectedAttributes struct {
 	DefaultBranch     string
 	LicenseTemplate   string
 	GitignoreTemplate string
+	Archived bool
 }
 
 func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testAccGithubRepositoryExpectedAttributes) resource.TestCheckFunc {
@@ -435,6 +528,28 @@ resource "github_repository" "foo" {
   allow_squash_merge = true
   allow_rebase_merge = true
   has_downloads = false
+}
+`, randString, randString)
+}
+
+func testAccGithubRepositoryArchivedConfig(randString string) string {
+	return fmt.Sprintf(`
+resource "github_repository" "foo" {
+  name = "tf-acc-test-%s"
+  description = "Terraform acceptance tests %s"
+  homepage_url = "http://example.com/"
+
+  # So that acceptance tests can be run in a github organization
+  # with no billing
+  private = false
+
+  has_issues = true
+  has_wiki = true
+  allow_merge_commit = true
+  allow_squash_merge = false
+  allow_rebase_merge = false
+  has_downloads = true
+  archived = true
 }
 `, randString, randString)
 }

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -97,9 +97,9 @@ func resourceGithubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 	description := d.Get("description").(string)
 	privacy := d.Get("privacy").(string)
 	editedTeam := github.NewTeam{
-		Name: name,
+		Name:        name,
 		Description: &description,
-		Privacy: &privacy,
+		Privacy:     &privacy,
 	}
 
 	team, _, err = client.Organizations.EditTeam(context.TODO(), *team.ID, &editedTeam)

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -46,8 +46,8 @@ func resourceGithubTeamCreate(d *schema.ResourceData, meta interface{}) error {
 	n := d.Get("name").(string)
 	desc := d.Get("description").(string)
 	p := d.Get("privacy").(string)
-	githubTeam, _, err := client.Organizations.CreateTeam(context.TODO(), meta.(*Organization).name, &github.Team{
-		Name:        &n,
+	githubTeam, _, err := client.Organizations.CreateTeam(context.TODO(), meta.(*Organization).name, &github.NewTeam{
+		Name:        n,
 		Description: &desc,
 		Privacy:     &p,
 	})
@@ -96,11 +96,13 @@ func resourceGithubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
 	privacy := d.Get("privacy").(string)
-	team.Description = &description
-	team.Name = &name
-	team.Privacy = &privacy
+	editedTeam := github.NewTeam{
+		Name: name,
+		Description: &description,
+		Privacy: &privacy,
+	}
 
-	team, _, err = client.Organizations.EditTeam(context.TODO(), *team.ID, team)
+	team, _, err = client.Organizations.EditTeam(context.TODO(), *team.ID, &editedTeam)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/google/go-github/github/activity_events.go
+++ b/vendor/github.com/google/go-github/github/activity_events.go
@@ -15,7 +15,7 @@ import (
 // Event represents a GitHub event.
 type Event struct {
 	Type       *string          `json:"type,omitempty"`
-	Public     *bool            `json:"public"`
+	Public     *bool            `json:"public,omitempty"`
 	RawPayload *json.RawMessage `json:"payload,omitempty"`
 	Repo       *Repository      `json:"repo,omitempty"`
 	Actor      *User            `json:"actor,omitempty"`
@@ -56,6 +56,8 @@ func (e *Event) ParsePayload() (payload interface{}, err error) {
 		payload = &IssuesEvent{}
 	case "LabelEvent":
 		payload = &LabelEvent{}
+	case "MarketplacePurchaseEvent":
+		payload = &MarketplacePurchaseEvent{}
 	case "MemberEvent":
 		payload = &MemberEvent{}
 	case "MembershipEvent":

--- a/vendor/github.com/google/go-github/github/admin_stats.go
+++ b/vendor/github.com/google/go-github/github/admin_stats.go
@@ -1,0 +1,171 @@
+// Copyright 2017 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// AdminStats represents a variety of stats of a Github Enterprise
+// installation.
+type AdminStats struct {
+	Issues     *IssueStats     `json:"issues,omitempty"`
+	Hooks      *HookStats      `json:"hooks,omitempty"`
+	Milestones *MilestoneStats `json:"milestones,omitempty"`
+	Orgs       *OrgStats       `json:"orgs,omitempty"`
+	Comments   *CommentStats   `json:"comments,omitempty"`
+	Pages      *PageStats      `json:"pages,omitempty"`
+	Users      *UserStats      `json:"users,omitempty"`
+	Gists      *GistStats      `json:"gists,omitempty"`
+	Pulls      *PullStats      `json:"pulls,omitempty"`
+	Repos      *RepoStats      `json:"repos,omitempty"`
+}
+
+func (s AdminStats) String() string {
+	return Stringify(s)
+}
+
+// IssueStats represents the number of total, open and closed issues.
+type IssueStats struct {
+	TotalIssues  *int `json:"total_issues,omitempty"`
+	OpenIssues   *int `json:"open_issues,omitempty"`
+	ClosedIssues *int `json:"closed_issues,omitempty"`
+}
+
+func (s IssueStats) String() string {
+	return Stringify(s)
+}
+
+// HookStats represents the number of total, active and inactive hooks.
+type HookStats struct {
+	TotalHooks    *int `json:"total_hooks,omitempty"`
+	ActiveHooks   *int `json:"active_hooks,omitempty"`
+	InactiveHooks *int `json:"inactive_hooks,omitempty"`
+}
+
+func (s HookStats) String() string {
+	return Stringify(s)
+}
+
+// MilestoneStats represents the number of total, open and close milestones.
+type MilestoneStats struct {
+	TotalMilestones  *int `json:"total_milestones,omitempty"`
+	OpenMilestones   *int `json:"open_milestones,omitempty"`
+	ClosedMilestones *int `json:"closed_milestones,omitempty"`
+}
+
+func (s MilestoneStats) String() string {
+	return Stringify(s)
+}
+
+// OrgStats represents the number of total, disabled organizations and the team
+// and team member count.
+type OrgStats struct {
+	TotalOrgs        *int `json:"total_orgs,omitempty"`
+	DisabledOrgs     *int `json:"disabled_orgs,omitempty"`
+	TotalTeams       *int `json:"total_teams,omitempty"`
+	TotalTeamMembers *int `json:"total_team_members,omitempty"`
+}
+
+func (s OrgStats) String() string {
+	return Stringify(s)
+}
+
+// CommentStats represents the number of total comments on commits, gists, issues
+// and pull requests.
+type CommentStats struct {
+	TotalCommitComments      *int `json:"total_commit_comments,omitempty"`
+	TotalGistComments        *int `json:"total_gist_comments,omitempty"`
+	TotalIssueComments       *int `json:"total_issue_comments,omitempty"`
+	TotalPullRequestComments *int `json:"total_pull_request_comments,omitempty"`
+}
+
+func (s CommentStats) String() string {
+	return Stringify(s)
+}
+
+// PageStats represents the total number of github pages.
+type PageStats struct {
+	TotalPages *int `json:"total_pages,omitempty"`
+}
+
+func (s PageStats) String() string {
+	return Stringify(s)
+}
+
+// UserStats represents the number of total, admin and suspended users.
+type UserStats struct {
+	TotalUsers     *int `json:"total_users,omitempty"`
+	AdminUsers     *int `json:"admin_users,omitempty"`
+	SuspendedUsers *int `json:"suspended_users,omitempty"`
+}
+
+func (s UserStats) String() string {
+	return Stringify(s)
+}
+
+//GistStats represents the number of total, private and public gists.
+type GistStats struct {
+	TotalGists   *int `json:"total_gists,omitempty"`
+	PrivateGists *int `json:"private_gists,omitempty"`
+	PublicGists  *int `json:"public_gists,omitempty"`
+}
+
+func (s GistStats) String() string {
+	return Stringify(s)
+}
+
+// PullStats represents the number of total, merged, mergable and unmergeable
+// pull-requests.
+type PullStats struct {
+	TotalPulls      *int `json:"total_pulls,omitempty"`
+	MergedPulls     *int `json:"merged_pulls,omitempty"`
+	MergablePulls   *int `json:"mergeable_pulls,omitempty"`
+	UnmergablePulls *int `json:"unmergeable_pulls,omitempty"`
+}
+
+func (s PullStats) String() string {
+	return Stringify(s)
+}
+
+// RepoStats represents the number of total, root, fork, organization repositories
+// together with the total number of pushes and wikis.
+type RepoStats struct {
+	TotalRepos  *int `json:"total_repos,omitempty"`
+	RootRepos   *int `json:"root_repos,omitempty"`
+	ForkRepos   *int `json:"fork_repos,omitempty"`
+	OrgRepos    *int `json:"org_repos,omitempty"`
+	TotalPushes *int `json:"total_pushes,omitempty"`
+	TotalWikis  *int `json:"total_wikis,omitempty"`
+}
+
+func (s RepoStats) String() string {
+	return Stringify(s)
+}
+
+// GetAdminStats returns a variety of metrics about a Github Enterprise
+// installation.
+//
+// Please note that this is only available to site administrators,
+// otherwise it will error with a 404 not found (instead of 401 or 403).
+//
+// GitHub API docs: https://developer.github.com/v3/enterprise-admin/admin_stats/
+func (s *AdminService) GetAdminStats(ctx context.Context) (*AdminStats, *Response, error) {
+	u := fmt.Sprintf("enterprise/stats/all")
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(AdminStats)
+	resp, err := s.client.Do(ctx, req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}

--- a/vendor/github.com/google/go-github/github/apps.go
+++ b/vendor/github.com/google/go-github/github/apps.go
@@ -5,13 +5,68 @@
 
 package github
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"time"
+)
 
 // AppsService provides access to the installation related functions
 // in the GitHub API.
 //
 // GitHub API docs: https://developer.github.com/v3/apps/
 type AppsService service
+
+// App represents a GitHub App.
+type App struct {
+	ID          *int       `json:"id,omitempty"`
+	Owner       *User      `json:"owner,omitempty"`
+	Name        *string    `json:"name,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	ExternalURL *string    `json:"external_url,omitempty"`
+	HTMLURL     *string    `json:"html_url,omitempty"`
+	CreatedAt   *time.Time `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+}
+
+// InstallationToken represents an installation token.
+type InstallationToken struct {
+	Token     *string    `json:"token,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+// Get a single GitHub App. Passing the empty string will get
+// the authenticated GitHub App.
+//
+// Note: appSlug is just the URL-friendly name of your GitHub App.
+// You can find this on the settings page for your GitHub App
+// (e.g., https://github.com/settings/apps/:app_slug).
+//
+// GitHub API docs: https://developer.github.com/v3/apps/#get-a-single-github-app
+func (s *AppsService) Get(ctx context.Context, appSlug string) (*App, *Response, error) {
+	var u string
+	if appSlug != "" {
+		u = fmt.Sprintf("apps/%v", appSlug)
+	} else {
+		u = "app"
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
+	app := new(App)
+	resp, err := s.client.Do(ctx, req, app)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return app, resp, nil
+}
 
 // ListInstallations lists the installations that the current GitHub App has.
 //
@@ -37,4 +92,78 @@ func (s *AppsService) ListInstallations(ctx context.Context, opt *ListOptions) (
 	}
 
 	return i, resp, nil
+}
+
+// GetInstallation returns the specified installation.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/#get-a-single-installation
+func (s *AppsService) GetInstallation(ctx context.Context, id int) (*Installation, *Response, error) {
+	u := fmt.Sprintf("app/installations/%v", id)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
+	i := new(Installation)
+	resp, err := s.client.Do(ctx, req, i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, nil
+}
+
+// ListUserInstallations lists installations that are accessible to the authenticated user.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/#list-installations-for-user
+func (s *AppsService) ListUserInstallations(ctx context.Context, opt *ListOptions) ([]*Installation, *Response, error) {
+	u, err := addOptions("user/installations", opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
+	var i struct {
+		Installations []*Installation `json:"installations"`
+	}
+	resp, err := s.client.Do(ctx, req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i.Installations, resp, nil
+}
+
+// CreateInstallationToken creates a new installation token.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/#create-a-new-installation-token
+func (s *AppsService) CreateInstallationToken(ctx context.Context, id int) (*InstallationToken, *Response, error) {
+	u := fmt.Sprintf("installations/%v/access_tokens", id)
+
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
+	t := new(InstallationToken)
+	resp, err := s.client.Do(ctx, req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, nil
 }

--- a/vendor/github.com/google/go-github/github/apps_installation.go
+++ b/vendor/github.com/google/go-github/github/apps_installation.go
@@ -51,6 +51,36 @@ func (s *AppsService) ListRepos(ctx context.Context, opt *ListOptions) ([]*Repos
 	return r.Repositories, resp, nil
 }
 
+// ListUserRepos lists repositories that are accessible
+// to the authenticated user for an installation.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation
+func (s *AppsService) ListUserRepos(ctx context.Context, id int, opt *ListOptions) ([]*Repository, *Response, error) {
+	u := fmt.Sprintf("user/installations/%v/repositories", id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
+	var r struct {
+		Repositories []*Repository `json:"repositories"`
+	}
+	resp, err := s.client.Do(ctx, req, &r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r.Repositories, resp, nil
+}
+
 // AddRepository adds a single repository to an installation.
 //
 // GitHub API docs: https://developer.github.com/v3/apps/installations/#add-repository-to-installation

--- a/vendor/github.com/google/go-github/github/apps_marketplace.go
+++ b/vendor/github.com/google/go-github/github/apps_marketplace.go
@@ -1,0 +1,180 @@
+// Copyright 2017 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// MarketplaceService handles communication with the marketplace related
+// methods of the GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/marketplace/
+type MarketplaceService struct {
+	client *Client
+	// Stubbed controls whether endpoints that return stubbed data are used
+	// instead of production endpoints. Stubbed data is fake data that's useful
+	// for testing your GitHub Apps. Stubbed data is hard-coded and will not
+	// change based on actual subscriptions.
+	//
+	// GitHub API docs: https://developer.github.com/v3/apps/marketplace/
+	Stubbed bool
+}
+
+// MarketplacePlan represents a GitHub Apps Marketplace Listing Plan.
+type MarketplacePlan struct {
+	URL                 *string   `json:"url,omitempty"`
+	AccountsURL         *string   `json:"accounts_url,omitempty"`
+	ID                  *int      `json:"id,omitempty"`
+	Name                *string   `json:"name,omitempty"`
+	Description         *string   `json:"description,omitempty"`
+	MonthlyPriceInCents *int      `json:"monthly_price_in_cents,omitempty"`
+	YearlyPriceInCents  *int      `json:"yearly_price_in_cents,omitempty"`
+	PriceModel          *string   `json:"price_model,omitempty"`
+	UnitName            *string   `json:"unit_name,omitempty"`
+	Bullets             *[]string `json:"bullets,omitempty"`
+}
+
+// MarketplacePurchase represents a GitHub Apps Marketplace Purchase.
+type MarketplacePurchase struct {
+	BillingCycle    *string                 `json:"billing_cycle,omitempty"`
+	NextBillingDate *string                 `json:"next_billing_date,omitempty"`
+	UnitCount       *int                    `json:"unit_count,omitempty"`
+	Plan            *MarketplacePlan        `json:"plan,omitempty"`
+	Account         *MarketplacePlanAccount `json:"account,omitempty"`
+}
+
+// MarketplacePlanAccount represents a GitHub Account (user or organization) on a specific plan.
+type MarketplacePlanAccount struct {
+	URL                      *string              `json:"url,omitempty"`
+	Type                     *string              `json:"type,omitempty"`
+	ID                       *int                 `json:"id,omitempty"`
+	Login                    *string              `json:"login,omitempty"`
+	Email                    *string              `json:"email,omitempty"`
+	OrganizationBillingEmail *string              `json:"organization_billing_email,omitempty"`
+	MarketplacePurchase      *MarketplacePurchase `json:"marketplace_purchase,omitempty"`
+}
+
+// ListPlans lists all plans for your Marketplace listing.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/marketplace/#list-all-plans-for-your-marketplace-listing
+func (s *MarketplaceService) ListPlans(ctx context.Context, opt *ListOptions) ([]*MarketplacePlan, *Response, error) {
+	uri := s.marketplaceURI("plans")
+	u, err := addOptions(uri, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMarketplacePreview)
+
+	var plans []*MarketplacePlan
+	resp, err := s.client.Do(ctx, req, &plans)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return plans, resp, nil
+}
+
+// ListPlanAccountsForPlan lists all GitHub accounts (user or organization) on a specific plan.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/marketplace/#list-all-github-accounts-user-or-organization-on-a-specific-plan
+func (s *MarketplaceService) ListPlanAccountsForPlan(ctx context.Context, planID int, opt *ListOptions) ([]*MarketplacePlanAccount, *Response, error) {
+	uri := s.marketplaceURI(fmt.Sprintf("plans/%v/accounts", planID))
+	u, err := addOptions(uri, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMarketplacePreview)
+
+	var accounts []*MarketplacePlanAccount
+	resp, err := s.client.Do(ctx, req, &accounts)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return accounts, resp, nil
+}
+
+// ListPlanAccountsForAccount lists all GitHub accounts (user or organization) associated with an account.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/marketplace/#check-if-a-github-account-is-associated-with-any-marketplace-listing
+func (s *MarketplaceService) ListPlanAccountsForAccount(ctx context.Context, accountID int, opt *ListOptions) ([]*MarketplacePlanAccount, *Response, error) {
+	uri := s.marketplaceURI(fmt.Sprintf("accounts/%v", accountID))
+	u, err := addOptions(uri, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMarketplacePreview)
+
+	var accounts []*MarketplacePlanAccount
+	resp, err := s.client.Do(ctx, req, &accounts)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return accounts, resp, nil
+}
+
+// ListMarketplacePurchasesForUser lists all GitHub marketplace purchases made by a user.
+//
+// GitHub API docs: https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases
+func (s *MarketplaceService) ListMarketplacePurchasesForUser(ctx context.Context, opt *ListOptions) ([]*MarketplacePurchase, *Response, error) {
+	uri := "user/marketplace_purchases"
+	if s.Stubbed {
+		uri = "user/marketplace_purchases/stubbed"
+	}
+
+	u, err := addOptions(uri, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeMarketplacePreview)
+
+	var purchases []*MarketplacePurchase
+	resp, err := s.client.Do(ctx, req, &purchases)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return purchases, resp, nil
+}
+
+func (s *MarketplaceService) marketplaceURI(endpoint string) string {
+	url := "marketplace_listing"
+	if s.Stubbed {
+		url = "marketplace_listing/stubbed"
+	}
+	return url + "/" + endpoint
+}

--- a/vendor/github.com/google/go-github/github/event_types.go
+++ b/vendor/github.com/google/go-github/github/event_types.go
@@ -268,6 +268,24 @@ type LabelEvent struct {
 	Installation *Installation `json:"installation,omitempty"`
 }
 
+// MarketplacePurchaseEvent is triggered when a user purchases, cancels, or changes
+// their GitHub Marketplace plan.
+// Webhook event name "marketplace_purchase".
+//
+// Github API docs: https://developer.github.com/v3/activity/events/types/#marketplacepurchaseevent
+type MarketplacePurchaseEvent struct {
+	// Action is the action that was performed. Possible values are:
+	// "purchased", "cancelled", "changed".
+	Action *string `json:"action,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	EffectiveDate               *Timestamp           `json:"effective_date,omitempty"`
+	MarketplacePurchase         *MarketplacePurchase `json:"marketplace_purchase,omitempty"`
+	PreviousMarketplacePurchase *MarketplacePurchase `json:"previous_marketplace_purchase,omitempty"`
+	Sender                      *User                `json:"sender,omitempty"`
+	Installation                *Installation        `json:"installation,omitempty"`
+}
+
 // MemberEvent is triggered when a user is added as a collaborator to a repository.
 // The Webhook event name is "member".
 //
@@ -461,9 +479,10 @@ type PublicEvent struct {
 //
 // GitHub API docs: https://developer.github.com/v3/activity/events/types/#pullrequestevent
 type PullRequestEvent struct {
-	// Action is the action that was performed. Possible values are: "assigned",
-	// "unassigned", "labeled", "unlabeled", "opened", "closed", or "reopened",
-	// "synchronize", "edited". If the action is "closed" and the merged key is false,
+	// Action is the action that was performed. Possible values are:
+	// "assigned", "unassigned", "review_requested", "review_request_removed", "labeled", "unlabeled",
+	// "opened", "closed", "reopened", "synchronize", "edited".
+	// If the action is "closed" and the merged key is false,
 	// the pull request was closed with unmerged commits. If the action is "closed"
 	// and the merged key is true, the pull request was merged.
 	Action      *string      `json:"action,omitempty"`
@@ -471,10 +490,11 @@ type PullRequestEvent struct {
 	PullRequest *PullRequest `json:"pull_request,omitempty"`
 
 	// The following fields are only populated by Webhook events.
-	Changes      *EditChange   `json:"changes,omitempty"`
-	Repo         *Repository   `json:"repository,omitempty"`
-	Sender       *User         `json:"sender,omitempty"`
-	Installation *Installation `json:"installation,omitempty"`
+	Changes            *EditChange   `json:"changes,omitempty"`
+	RequestedReviewers []*User       `json:"requested_reviewers,omitempty"` // Populated in "review_requested", "review_request_removed" event deliveries.
+	Repo               *Repository   `json:"repository,omitempty"`
+	Sender             *User         `json:"sender,omitempty"`
+	Installation       *Installation `json:"installation,omitempty"`
 }
 
 // PullRequestReviewEvent is triggered when a review is submitted on a pull

--- a/vendor/github.com/google/go-github/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/github/github-accessors.go
@@ -28,12 +28,164 @@ func (a *AdminEnforcement) GetURL() string {
 	return *a.URL
 }
 
+// GetComments returns the Comments field.
+func (a *AdminStats) GetComments() *CommentStats {
+	if a == nil {
+		return nil
+	}
+	return a.Comments
+}
+
+// GetGists returns the Gists field.
+func (a *AdminStats) GetGists() *GistStats {
+	if a == nil {
+		return nil
+	}
+	return a.Gists
+}
+
+// GetHooks returns the Hooks field.
+func (a *AdminStats) GetHooks() *HookStats {
+	if a == nil {
+		return nil
+	}
+	return a.Hooks
+}
+
+// GetIssues returns the Issues field.
+func (a *AdminStats) GetIssues() *IssueStats {
+	if a == nil {
+		return nil
+	}
+	return a.Issues
+}
+
+// GetMilestones returns the Milestones field.
+func (a *AdminStats) GetMilestones() *MilestoneStats {
+	if a == nil {
+		return nil
+	}
+	return a.Milestones
+}
+
+// GetOrgs returns the Orgs field.
+func (a *AdminStats) GetOrgs() *OrgStats {
+	if a == nil {
+		return nil
+	}
+	return a.Orgs
+}
+
+// GetPages returns the Pages field.
+func (a *AdminStats) GetPages() *PageStats {
+	if a == nil {
+		return nil
+	}
+	return a.Pages
+}
+
+// GetPulls returns the Pulls field.
+func (a *AdminStats) GetPulls() *PullStats {
+	if a == nil {
+		return nil
+	}
+	return a.Pulls
+}
+
+// GetRepos returns the Repos field.
+func (a *AdminStats) GetRepos() *RepoStats {
+	if a == nil {
+		return nil
+	}
+	return a.Repos
+}
+
+// GetUsers returns the Users field.
+func (a *AdminStats) GetUsers() *UserStats {
+	if a == nil {
+		return nil
+	}
+	return a.Users
+}
+
 // GetVerifiablePasswordAuthentication returns the VerifiablePasswordAuthentication field if it's non-nil, zero value otherwise.
 func (a *APIMeta) GetVerifiablePasswordAuthentication() bool {
 	if a == nil || a.VerifiablePasswordAuthentication == nil {
 		return false
 	}
 	return *a.VerifiablePasswordAuthentication
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (a *App) GetCreatedAt() time.Time {
+	if a == nil || a.CreatedAt == nil {
+		return time.Time{}
+	}
+	return *a.CreatedAt
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (a *App) GetDescription() string {
+	if a == nil || a.Description == nil {
+		return ""
+	}
+	return *a.Description
+}
+
+// GetExternalURL returns the ExternalURL field if it's non-nil, zero value otherwise.
+func (a *App) GetExternalURL() string {
+	if a == nil || a.ExternalURL == nil {
+		return ""
+	}
+	return *a.ExternalURL
+}
+
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (a *App) GetHTMLURL() string {
+	if a == nil || a.HTMLURL == nil {
+		return ""
+	}
+	return *a.HTMLURL
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (a *App) GetID() int {
+	if a == nil || a.ID == nil {
+		return 0
+	}
+	return *a.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (a *App) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
+// GetOwner returns the Owner field.
+func (a *App) GetOwner() *User {
+	if a == nil {
+		return nil
+	}
+	return a.Owner
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (a *App) GetUpdatedAt() time.Time {
+	if a == nil || a.UpdatedAt == nil {
+		return time.Time{}
+	}
+	return *a.UpdatedAt
+}
+
+// GetApp returns the App field.
+func (a *Authorization) GetApp() *AuthorizationApp {
+	if a == nil {
+		return nil
+	}
+	return a.App
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -114,6 +266,14 @@ func (a *Authorization) GetURL() string {
 		return ""
 	}
 	return *a.URL
+}
+
+// GetUser returns the User field.
+func (a *Authorization) GetUser() *User {
+	if a == nil {
+		return nil
+	}
+	return a.User
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
@@ -244,6 +404,14 @@ func (b *Blob) GetURL() string {
 	return *b.URL
 }
 
+// GetCommit returns the Commit field.
+func (b *Branch) GetCommit() *RepositoryCommit {
+	if b == nil {
+		return nil
+	}
+	return b.Commit
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (b *Branch) GetName() string {
 	if b == nil || b.Name == nil {
@@ -314,6 +482,14 @@ func (c *CodeResult) GetPath() string {
 		return ""
 	}
 	return *c.Path
+}
+
+// GetRepository returns the Repository field.
+func (c *CodeResult) GetRepository() *Repository {
+	if c == nil {
+		return nil
+	}
+	return c.Repository
 }
 
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
@@ -388,12 +564,60 @@ func (c *CombinedStatus) GetTotalCount() int {
 	return *c.TotalCount
 }
 
+// GetTotalCommitComments returns the TotalCommitComments field if it's non-nil, zero value otherwise.
+func (c *CommentStats) GetTotalCommitComments() int {
+	if c == nil || c.TotalCommitComments == nil {
+		return 0
+	}
+	return *c.TotalCommitComments
+}
+
+// GetTotalGistComments returns the TotalGistComments field if it's non-nil, zero value otherwise.
+func (c *CommentStats) GetTotalGistComments() int {
+	if c == nil || c.TotalGistComments == nil {
+		return 0
+	}
+	return *c.TotalGistComments
+}
+
+// GetTotalIssueComments returns the TotalIssueComments field if it's non-nil, zero value otherwise.
+func (c *CommentStats) GetTotalIssueComments() int {
+	if c == nil || c.TotalIssueComments == nil {
+		return 0
+	}
+	return *c.TotalIssueComments
+}
+
+// GetTotalPullRequestComments returns the TotalPullRequestComments field if it's non-nil, zero value otherwise.
+func (c *CommentStats) GetTotalPullRequestComments() int {
+	if c == nil || c.TotalPullRequestComments == nil {
+		return 0
+	}
+	return *c.TotalPullRequestComments
+}
+
+// GetAuthor returns the Author field.
+func (c *Commit) GetAuthor() *CommitAuthor {
+	if c == nil {
+		return nil
+	}
+	return c.Author
+}
+
 // GetCommentCount returns the CommentCount field if it's non-nil, zero value otherwise.
 func (c *Commit) GetCommentCount() int {
 	if c == nil || c.CommentCount == nil {
 		return 0
 	}
 	return *c.CommentCount
+}
+
+// GetCommitter returns the Committer field.
+func (c *Commit) GetCommitter() *CommitAuthor {
+	if c == nil {
+		return nil
+	}
+	return c.Committer
 }
 
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
@@ -420,12 +644,36 @@ func (c *Commit) GetSHA() string {
 	return *c.SHA
 }
 
+// GetStats returns the Stats field.
+func (c *Commit) GetStats() *CommitStats {
+	if c == nil {
+		return nil
+	}
+	return c.Stats
+}
+
+// GetTree returns the Tree field.
+func (c *Commit) GetTree() *Tree {
+	if c == nil {
+		return nil
+	}
+	return c.Tree
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (c *Commit) GetURL() string {
 	if c == nil || c.URL == nil {
 		return ""
 	}
 	return *c.URL
+}
+
+// GetVerification returns the Verification field.
+func (c *Commit) GetVerification() *SignatureVerification {
+	if c == nil {
+		return nil
+	}
+	return c.Verification
 }
 
 // GetDate returns the Date field if it's non-nil, zero value otherwise.
@@ -466,6 +714,38 @@ func (c *CommitCommentEvent) GetAction() string {
 		return ""
 	}
 	return *c.Action
+}
+
+// GetComment returns the Comment field.
+func (c *CommitCommentEvent) GetComment() *RepositoryComment {
+	if c == nil {
+		return nil
+	}
+	return c.Comment
+}
+
+// GetInstallation returns the Installation field.
+func (c *CommitCommentEvent) GetInstallation() *Installation {
+	if c == nil {
+		return nil
+	}
+	return c.Installation
+}
+
+// GetRepo returns the Repo field.
+func (c *CommitCommentEvent) GetRepo() *Repository {
+	if c == nil {
+		return nil
+	}
+	return c.Repo
+}
+
+// GetSender returns the Sender field.
+func (c *CommitCommentEvent) GetSender() *User {
+	if c == nil {
+		return nil
+	}
+	return c.Sender
 }
 
 // GetAdditions returns the Additions field if it's non-nil, zero value otherwise.
@@ -548,6 +828,14 @@ func (c *CommitFile) GetStatus() string {
 	return *c.Status
 }
 
+// GetAuthor returns the Author field.
+func (c *CommitResult) GetAuthor() *User {
+	if c == nil {
+		return nil
+	}
+	return c.Author
+}
+
 // GetCommentsURL returns the CommentsURL field if it's non-nil, zero value otherwise.
 func (c *CommitResult) GetCommentsURL() string {
 	if c == nil || c.CommentsURL == nil {
@@ -556,12 +844,44 @@ func (c *CommitResult) GetCommentsURL() string {
 	return *c.CommentsURL
 }
 
+// GetCommit returns the Commit field.
+func (c *CommitResult) GetCommit() *Commit {
+	if c == nil {
+		return nil
+	}
+	return c.Commit
+}
+
+// GetCommitter returns the Committer field.
+func (c *CommitResult) GetCommitter() *User {
+	if c == nil {
+		return nil
+	}
+	return c.Committer
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (c *CommitResult) GetHTMLURL() string {
 	if c == nil || c.HTMLURL == nil {
 		return ""
 	}
 	return *c.HTMLURL
+}
+
+// GetRepository returns the Repository field.
+func (c *CommitResult) GetRepository() *Repository {
+	if c == nil {
+		return nil
+	}
+	return c.Repository
+}
+
+// GetScore returns the Score field.
+func (c *CommitResult) GetScore() *float64 {
+	if c == nil {
+		return nil
+	}
+	return c.Score
 }
 
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
@@ -588,6 +908,14 @@ func (c *CommitsComparison) GetAheadBy() int {
 	return *c.AheadBy
 }
 
+// GetBaseCommit returns the BaseCommit field.
+func (c *CommitsComparison) GetBaseCommit() *RepositoryCommit {
+	if c == nil {
+		return nil
+	}
+	return c.BaseCommit
+}
+
 // GetBehindBy returns the BehindBy field if it's non-nil, zero value otherwise.
 func (c *CommitsComparison) GetBehindBy() int {
 	if c == nil || c.BehindBy == nil {
@@ -610,6 +938,14 @@ func (c *CommitsComparison) GetHTMLURL() string {
 		return ""
 	}
 	return *c.HTMLURL
+}
+
+// GetMergeBaseCommit returns the MergeBaseCommit field.
+func (c *CommitsComparison) GetMergeBaseCommit() *RepositoryCommit {
+	if c == nil {
+		return nil
+	}
+	return c.MergeBaseCommit
 }
 
 // GetPatchURL returns the PatchURL field if it's non-nil, zero value otherwise.
@@ -690,6 +1026,46 @@ func (c *CommitStats) GetTotal() int {
 		return 0
 	}
 	return *c.Total
+}
+
+// GetCodeOfConduct returns the CodeOfConduct field.
+func (c *CommunityHealthFiles) GetCodeOfConduct() *Metric {
+	if c == nil {
+		return nil
+	}
+	return c.CodeOfConduct
+}
+
+// GetContributing returns the Contributing field.
+func (c *CommunityHealthFiles) GetContributing() *Metric {
+	if c == nil {
+		return nil
+	}
+	return c.Contributing
+}
+
+// GetLicense returns the License field.
+func (c *CommunityHealthFiles) GetLicense() *Metric {
+	if c == nil {
+		return nil
+	}
+	return c.License
+}
+
+// GetReadme returns the Readme field.
+func (c *CommunityHealthFiles) GetReadme() *Metric {
+	if c == nil {
+		return nil
+	}
+	return c.Readme
+}
+
+// GetFiles returns the Files field.
+func (c *CommunityHealthMetrics) GetFiles() *CommunityHealthFiles {
+	if c == nil {
+		return nil
+	}
+	return c.Files
 }
 
 // GetHealthPercentage returns the HealthPercentage field if it's non-nil, zero value otherwise.
@@ -852,6 +1228,14 @@ func (c *Contributor) GetURL() string {
 	return *c.URL
 }
 
+// GetAuthor returns the Author field.
+func (c *ContributorStats) GetAuthor() *Contributor {
+	if c == nil {
+		return nil
+	}
+	return c.Author
+}
+
 // GetTotal returns the Total field if it's non-nil, zero value otherwise.
 func (c *ContributorStats) GetTotal() int {
 	if c == nil || c.Total == nil {
@@ -860,28 +1244,20 @@ func (c *ContributorStats) GetTotal() int {
 	return *c.Total
 }
 
-// GetMessage returns the Message field if it's non-nil, zero value otherwise.
-func (c *createCommit) GetMessage() string {
-	if c == nil || c.Message == nil {
-		return ""
-	}
-	return *c.Message
-}
-
-// GetTree returns the Tree field if it's non-nil, zero value otherwise.
-func (c *createCommit) GetTree() string {
-	if c == nil || c.Tree == nil {
-		return ""
-	}
-	return *c.Tree
-}
-
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (c *CreateEvent) GetDescription() string {
 	if c == nil || c.Description == nil {
 		return ""
 	}
 	return *c.Description
+}
+
+// GetInstallation returns the Installation field.
+func (c *CreateEvent) GetInstallation() *Installation {
+	if c == nil {
+		return nil
+	}
+	return c.Installation
 }
 
 // GetMasterBranch returns the MasterBranch field if it's non-nil, zero value otherwise.
@@ -916,52 +1292,28 @@ func (c *CreateEvent) GetRefType() string {
 	return *c.RefType
 }
 
-// GetRef returns the Ref field if it's non-nil, zero value otherwise.
-func (c *createRefRequest) GetRef() string {
-	if c == nil || c.Ref == nil {
-		return ""
+// GetRepo returns the Repo field.
+func (c *CreateEvent) GetRepo() *Repository {
+	if c == nil {
+		return nil
 	}
-	return *c.Ref
+	return c.Repo
 }
 
-// GetSHA returns the SHA field if it's non-nil, zero value otherwise.
-func (c *createRefRequest) GetSHA() string {
-	if c == nil || c.SHA == nil {
-		return ""
+// GetSender returns the Sender field.
+func (c *CreateEvent) GetSender() *User {
+	if c == nil {
+		return nil
 	}
-	return *c.SHA
+	return c.Sender
 }
 
-// GetMessage returns the Message field if it's non-nil, zero value otherwise.
-func (c *createTagRequest) GetMessage() string {
-	if c == nil || c.Message == nil {
-		return ""
+// GetInstallation returns the Installation field.
+func (d *DeleteEvent) GetInstallation() *Installation {
+	if d == nil {
+		return nil
 	}
-	return *c.Message
-}
-
-// GetObject returns the Object field if it's non-nil, zero value otherwise.
-func (c *createTagRequest) GetObject() string {
-	if c == nil || c.Object == nil {
-		return ""
-	}
-	return *c.Object
-}
-
-// GetTag returns the Tag field if it's non-nil, zero value otherwise.
-func (c *createTagRequest) GetTag() string {
-	if c == nil || c.Tag == nil {
-		return ""
-	}
-	return *c.Tag
-}
-
-// GetType returns the Type field if it's non-nil, zero value otherwise.
-func (c *createTagRequest) GetType() string {
-	if c == nil || c.Type == nil {
-		return ""
-	}
-	return *c.Type
+	return d.Installation
 }
 
 // GetPusherType returns the PusherType field if it's non-nil, zero value otherwise.
@@ -988,12 +1340,36 @@ func (d *DeleteEvent) GetRefType() string {
 	return *d.RefType
 }
 
+// GetRepo returns the Repo field.
+func (d *DeleteEvent) GetRepo() *Repository {
+	if d == nil {
+		return nil
+	}
+	return d.Repo
+}
+
+// GetSender returns the Sender field.
+func (d *DeleteEvent) GetSender() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Sender
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (d *Deployment) GetCreatedAt() Timestamp {
 	if d == nil || d.CreatedAt == nil {
 		return Timestamp{}
 	}
 	return *d.CreatedAt
+}
+
+// GetCreator returns the Creator field.
+func (d *Deployment) GetCreator() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Creator
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -1076,6 +1452,38 @@ func (d *Deployment) GetURL() string {
 	return *d.URL
 }
 
+// GetDeployment returns the Deployment field.
+func (d *DeploymentEvent) GetDeployment() *Deployment {
+	if d == nil {
+		return nil
+	}
+	return d.Deployment
+}
+
+// GetInstallation returns the Installation field.
+func (d *DeploymentEvent) GetInstallation() *Installation {
+	if d == nil {
+		return nil
+	}
+	return d.Installation
+}
+
+// GetRepo returns the Repo field.
+func (d *DeploymentEvent) GetRepo() *Repository {
+	if d == nil {
+		return nil
+	}
+	return d.Repo
+}
+
+// GetSender returns the Sender field.
+func (d *DeploymentEvent) GetSender() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Sender
+}
+
 // GetAutoMerge returns the AutoMerge field if it's non-nil, zero value otherwise.
 func (d *DeploymentRequest) GetAutoMerge() bool {
 	if d == nil || d.AutoMerge == nil {
@@ -1156,6 +1564,14 @@ func (d *DeploymentStatus) GetCreatedAt() Timestamp {
 	return *d.CreatedAt
 }
 
+// GetCreator returns the Creator field.
+func (d *DeploymentStatus) GetCreator() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Creator
+}
+
 // GetDeploymentURL returns the DeploymentURL field if it's non-nil, zero value otherwise.
 func (d *DeploymentStatus) GetDeploymentURL() string {
 	if d == nil || d.DeploymentURL == nil {
@@ -1210,6 +1626,46 @@ func (d *DeploymentStatus) GetUpdatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *d.UpdatedAt
+}
+
+// GetDeployment returns the Deployment field.
+func (d *DeploymentStatusEvent) GetDeployment() *Deployment {
+	if d == nil {
+		return nil
+	}
+	return d.Deployment
+}
+
+// GetDeploymentStatus returns the DeploymentStatus field.
+func (d *DeploymentStatusEvent) GetDeploymentStatus() *DeploymentStatus {
+	if d == nil {
+		return nil
+	}
+	return d.DeploymentStatus
+}
+
+// GetInstallation returns the Installation field.
+func (d *DeploymentStatusEvent) GetInstallation() *Installation {
+	if d == nil {
+		return nil
+	}
+	return d.Installation
+}
+
+// GetRepo returns the Repo field.
+func (d *DeploymentStatusEvent) GetRepo() *Repository {
+	if d == nil {
+		return nil
+	}
+	return d.Repo
+}
+
+// GetSender returns the Sender field.
+func (d *DeploymentStatusEvent) GetSender() *User {
+	if d == nil {
+		return nil
+	}
+	return d.Sender
 }
 
 // GetAutoInactive returns the AutoInactive field if it's non-nil, zero value otherwise.
@@ -1276,6 +1732,14 @@ func (d *DraftReviewComment) GetPosition() int {
 	return *d.Position
 }
 
+// GetActor returns the Actor field.
+func (e *Event) GetActor() *User {
+	if e == nil {
+		return nil
+	}
+	return e.Actor
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (e *Event) GetCreatedAt() time.Time {
 	if e == nil || e.CreatedAt == nil {
@@ -1292,6 +1756,14 @@ func (e *Event) GetID() string {
 	return *e.ID
 }
 
+// GetOrg returns the Org field.
+func (e *Event) GetOrg() *Organization {
+	if e == nil {
+		return nil
+	}
+	return e.Org
+}
+
 // GetPublic returns the Public field if it's non-nil, zero value otherwise.
 func (e *Event) GetPublic() bool {
 	if e == nil || e.Public == nil {
@@ -1306,6 +1778,14 @@ func (e *Event) GetRawPayload() json.RawMessage {
 		return json.RawMessage{}
 	}
 	return *e.RawPayload
+}
+
+// GetRepo returns the Repo field.
+func (e *Event) GetRepo() *Repository {
+	if e == nil {
+		return nil
+	}
+	return e.Repo
 }
 
 // GetType returns the Type field if it's non-nil, zero value otherwise.
@@ -1380,6 +1860,38 @@ func (f *Feeds) GetUserURL() string {
 	return *f.UserURL
 }
 
+// GetForkee returns the Forkee field.
+func (f *ForkEvent) GetForkee() *Repository {
+	if f == nil {
+		return nil
+	}
+	return f.Forkee
+}
+
+// GetInstallation returns the Installation field.
+func (f *ForkEvent) GetInstallation() *Installation {
+	if f == nil {
+		return nil
+	}
+	return f.Installation
+}
+
+// GetRepo returns the Repo field.
+func (f *ForkEvent) GetRepo() *Repository {
+	if f == nil {
+		return nil
+	}
+	return f.Repo
+}
+
+// GetSender returns the Sender field.
+func (f *ForkEvent) GetSender() *User {
+	if f == nil {
+		return nil
+	}
+	return f.Sender
+}
+
 // GetComments returns the Comments field if it's non-nil, zero value otherwise.
 func (g *Gist) GetComments() int {
 	if g == nil || g.Comments == nil {
@@ -1436,6 +1948,14 @@ func (g *Gist) GetID() string {
 	return *g.ID
 }
 
+// GetOwner returns the Owner field.
+func (g *Gist) GetOwner() *User {
+	if g == nil {
+		return nil
+	}
+	return g.Owner
+}
+
 // GetPublic returns the Public field if it's non-nil, zero value otherwise.
 func (g *Gist) GetPublic() bool {
 	if g == nil || g.Public == nil {
@@ -1484,6 +2004,22 @@ func (g *GistComment) GetURL() string {
 	return *g.URL
 }
 
+// GetUser returns the User field.
+func (g *GistComment) GetUser() *User {
+	if g == nil {
+		return nil
+	}
+	return g.User
+}
+
+// GetChangeStatus returns the ChangeStatus field.
+func (g *GistCommit) GetChangeStatus() *CommitStats {
+	if g == nil {
+		return nil
+	}
+	return g.ChangeStatus
+}
+
 // GetCommittedAt returns the CommittedAt field if it's non-nil, zero value otherwise.
 func (g *GistCommit) GetCommittedAt() Timestamp {
 	if g == nil || g.CommittedAt == nil {
@@ -1498,6 +2034,14 @@ func (g *GistCommit) GetURL() string {
 		return ""
 	}
 	return *g.URL
+}
+
+// GetUser returns the User field.
+func (g *GistCommit) GetUser() *User {
+	if g == nil {
+		return nil
+	}
+	return g.User
 }
 
 // GetVersion returns the Version field if it's non-nil, zero value otherwise.
@@ -1588,6 +2132,38 @@ func (g *GistFork) GetURL() string {
 	return *g.URL
 }
 
+// GetUser returns the User field.
+func (g *GistFork) GetUser() *User {
+	if g == nil {
+		return nil
+	}
+	return g.User
+}
+
+// GetPrivateGists returns the PrivateGists field if it's non-nil, zero value otherwise.
+func (g *GistStats) GetPrivateGists() int {
+	if g == nil || g.PrivateGists == nil {
+		return 0
+	}
+	return *g.PrivateGists
+}
+
+// GetPublicGists returns the PublicGists field if it's non-nil, zero value otherwise.
+func (g *GistStats) GetPublicGists() int {
+	if g == nil || g.PublicGists == nil {
+		return 0
+	}
+	return *g.PublicGists
+}
+
+// GetTotalGists returns the TotalGists field if it's non-nil, zero value otherwise.
+func (g *GistStats) GetTotalGists() int {
+	if g == nil || g.TotalGists == nil {
+		return 0
+	}
+	return *g.TotalGists
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (g *Gitignore) GetName() string {
 	if g == nil || g.Name == nil {
@@ -1626,6 +2202,30 @@ func (g *GitObject) GetURL() string {
 		return ""
 	}
 	return *g.URL
+}
+
+// GetInstallation returns the Installation field.
+func (g *GollumEvent) GetInstallation() *Installation {
+	if g == nil {
+		return nil
+	}
+	return g.Installation
+}
+
+// GetRepo returns the Repo field.
+func (g *GollumEvent) GetRepo() *Repository {
+	if g == nil {
+		return nil
+	}
+	return g.Repo
+}
+
+// GetSender returns the Sender field.
+func (g *GollumEvent) GetSender() *User {
+	if g == nil {
+		return nil
+	}
+	return g.Sender
 }
 
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
@@ -1724,6 +2324,14 @@ func (g *GPGKey) GetPublicKey() string {
 	return *g.PublicKey
 }
 
+// GetApp returns the App field.
+func (g *Grant) GetApp() *AuthorizationApp {
+	if g == nil {
+		return nil
+	}
+	return g.App
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (g *Grant) GetCreatedAt() Timestamp {
 	if g == nil || g.CreatedAt == nil {
@@ -1802,6 +2410,30 @@ func (h *Hook) GetURL() string {
 		return ""
 	}
 	return *h.URL
+}
+
+// GetActiveHooks returns the ActiveHooks field if it's non-nil, zero value otherwise.
+func (h *HookStats) GetActiveHooks() int {
+	if h == nil || h.ActiveHooks == nil {
+		return 0
+	}
+	return *h.ActiveHooks
+}
+
+// GetInactiveHooks returns the InactiveHooks field if it's non-nil, zero value otherwise.
+func (h *HookStats) GetInactiveHooks() int {
+	if h == nil || h.InactiveHooks == nil {
+		return 0
+	}
+	return *h.InactiveHooks
+}
+
+// GetTotalHooks returns the TotalHooks field if it's non-nil, zero value otherwise.
+func (h *HookStats) GetTotalHooks() int {
+	if h == nil || h.TotalHooks == nil {
+		return 0
+	}
+	return *h.TotalHooks
 }
 
 // GetAuthorsCount returns the AuthorsCount field if it's non-nil, zero value otherwise.
@@ -1988,6 +2620,14 @@ func (i *Installation) GetAccessTokensURL() string {
 	return *i.AccessTokensURL
 }
 
+// GetAccount returns the Account field.
+func (i *Installation) GetAccount() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Account
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (i *Installation) GetHTMLURL() string {
 	if i == nil || i.HTMLURL == nil {
@@ -2020,6 +2660,22 @@ func (i *InstallationEvent) GetAction() string {
 	return *i.Action
 }
 
+// GetInstallation returns the Installation field.
+func (i *InstallationEvent) GetInstallation() *Installation {
+	if i == nil {
+		return nil
+	}
+	return i.Installation
+}
+
+// GetSender returns the Sender field.
+func (i *InstallationEvent) GetSender() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Sender
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (i *InstallationRepositoriesEvent) GetAction() string {
 	if i == nil || i.Action == nil {
@@ -2028,12 +2684,44 @@ func (i *InstallationRepositoriesEvent) GetAction() string {
 	return *i.Action
 }
 
+// GetInstallation returns the Installation field.
+func (i *InstallationRepositoriesEvent) GetInstallation() *Installation {
+	if i == nil {
+		return nil
+	}
+	return i.Installation
+}
+
 // GetRepositorySelection returns the RepositorySelection field if it's non-nil, zero value otherwise.
 func (i *InstallationRepositoriesEvent) GetRepositorySelection() string {
 	if i == nil || i.RepositorySelection == nil {
 		return ""
 	}
 	return *i.RepositorySelection
+}
+
+// GetSender returns the Sender field.
+func (i *InstallationRepositoriesEvent) GetSender() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Sender
+}
+
+// GetExpiresAt returns the ExpiresAt field if it's non-nil, zero value otherwise.
+func (i *InstallationToken) GetExpiresAt() time.Time {
+	if i == nil || i.ExpiresAt == nil {
+		return time.Time{}
+	}
+	return *i.ExpiresAt
+}
+
+// GetToken returns the Token field if it's non-nil, zero value otherwise.
+func (i *InstallationToken) GetToken() string {
+	if i == nil || i.Token == nil {
+		return ""
+	}
+	return *i.Token
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -2060,6 +2748,14 @@ func (i *Invitation) GetID() int {
 	return *i.ID
 }
 
+// GetInviter returns the Inviter field.
+func (i *Invitation) GetInviter() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Inviter
+}
+
 // GetLogin returns the Login field if it's non-nil, zero value otherwise.
 func (i *Invitation) GetLogin() string {
 	if i == nil || i.Login == nil {
@@ -2076,6 +2772,14 @@ func (i *Invitation) GetRole() string {
 	return *i.Role
 }
 
+// GetAssignee returns the Assignee field.
+func (i *Issue) GetAssignee() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Assignee
+}
+
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
 func (i *Issue) GetBody() string {
 	if i == nil || i.Body == nil {
@@ -2090,6 +2794,14 @@ func (i *Issue) GetClosedAt() time.Time {
 		return time.Time{}
 	}
 	return *i.ClosedAt
+}
+
+// GetClosedBy returns the ClosedBy field.
+func (i *Issue) GetClosedBy() *User {
+	if i == nil {
+		return nil
+	}
+	return i.ClosedBy
 }
 
 // GetComments returns the Comments field if it's non-nil, zero value otherwise.
@@ -2156,12 +2868,44 @@ func (i *Issue) GetLocked() bool {
 	return *i.Locked
 }
 
+// GetMilestone returns the Milestone field.
+func (i *Issue) GetMilestone() *Milestone {
+	if i == nil {
+		return nil
+	}
+	return i.Milestone
+}
+
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
 func (i *Issue) GetNumber() int {
 	if i == nil || i.Number == nil {
 		return 0
 	}
 	return *i.Number
+}
+
+// GetPullRequestLinks returns the PullRequestLinks field.
+func (i *Issue) GetPullRequestLinks() *PullRequestLinks {
+	if i == nil {
+		return nil
+	}
+	return i.PullRequestLinks
+}
+
+// GetReactions returns the Reactions field.
+func (i *Issue) GetReactions() *Reactions {
+	if i == nil {
+		return nil
+	}
+	return i.Reactions
+}
+
+// GetRepository returns the Repository field.
+func (i *Issue) GetRepository() *Repository {
+	if i == nil {
+		return nil
+	}
+	return i.Repository
 }
 
 // GetRepositoryURL returns the RepositoryURL field if it's non-nil, zero value otherwise.
@@ -2204,6 +2948,14 @@ func (i *Issue) GetURL() string {
 	return *i.URL
 }
 
+// GetUser returns the User field.
+func (i *Issue) GetUser() *User {
+	if i == nil {
+		return nil
+	}
+	return i.User
+}
+
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
 func (i *IssueComment) GetBody() string {
 	if i == nil || i.Body == nil {
@@ -2244,6 +2996,14 @@ func (i *IssueComment) GetIssueURL() string {
 	return *i.IssueURL
 }
 
+// GetReactions returns the Reactions field.
+func (i *IssueComment) GetReactions() *Reactions {
+	if i == nil {
+		return nil
+	}
+	return i.Reactions
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (i *IssueComment) GetUpdatedAt() time.Time {
 	if i == nil || i.UpdatedAt == nil {
@@ -2260,12 +3020,92 @@ func (i *IssueComment) GetURL() string {
 	return *i.URL
 }
 
+// GetUser returns the User field.
+func (i *IssueComment) GetUser() *User {
+	if i == nil {
+		return nil
+	}
+	return i.User
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (i *IssueCommentEvent) GetAction() string {
 	if i == nil || i.Action == nil {
 		return ""
 	}
 	return *i.Action
+}
+
+// GetChanges returns the Changes field.
+func (i *IssueCommentEvent) GetChanges() *EditChange {
+	if i == nil {
+		return nil
+	}
+	return i.Changes
+}
+
+// GetComment returns the Comment field.
+func (i *IssueCommentEvent) GetComment() *IssueComment {
+	if i == nil {
+		return nil
+	}
+	return i.Comment
+}
+
+// GetInstallation returns the Installation field.
+func (i *IssueCommentEvent) GetInstallation() *Installation {
+	if i == nil {
+		return nil
+	}
+	return i.Installation
+}
+
+// GetIssue returns the Issue field.
+func (i *IssueCommentEvent) GetIssue() *Issue {
+	if i == nil {
+		return nil
+	}
+	return i.Issue
+}
+
+// GetRepo returns the Repo field.
+func (i *IssueCommentEvent) GetRepo() *Repository {
+	if i == nil {
+		return nil
+	}
+	return i.Repo
+}
+
+// GetSender returns the Sender field.
+func (i *IssueCommentEvent) GetSender() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Sender
+}
+
+// GetActor returns the Actor field.
+func (i *IssueEvent) GetActor() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Actor
+}
+
+// GetAssignee returns the Assignee field.
+func (i *IssueEvent) GetAssignee() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Assignee
+}
+
+// GetAssigner returns the Assigner field.
+func (i *IssueEvent) GetAssigner() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Assigner
 }
 
 // GetCommitID returns the CommitID field if it's non-nil, zero value otherwise.
@@ -2298,6 +3138,38 @@ func (i *IssueEvent) GetID() int {
 		return 0
 	}
 	return *i.ID
+}
+
+// GetIssue returns the Issue field.
+func (i *IssueEvent) GetIssue() *Issue {
+	if i == nil {
+		return nil
+	}
+	return i.Issue
+}
+
+// GetLabel returns the Label field.
+func (i *IssueEvent) GetLabel() *Label {
+	if i == nil {
+		return nil
+	}
+	return i.Label
+}
+
+// GetMilestone returns the Milestone field.
+func (i *IssueEvent) GetMilestone() *Milestone {
+	if i == nil {
+		return nil
+	}
+	return i.Milestone
+}
+
+// GetRename returns the Rename field.
+func (i *IssueEvent) GetRename() *Rename {
+	if i == nil {
+		return nil
+	}
+	return i.Rename
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -2372,6 +3244,62 @@ func (i *IssuesEvent) GetAction() string {
 	return *i.Action
 }
 
+// GetAssignee returns the Assignee field.
+func (i *IssuesEvent) GetAssignee() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Assignee
+}
+
+// GetChanges returns the Changes field.
+func (i *IssuesEvent) GetChanges() *EditChange {
+	if i == nil {
+		return nil
+	}
+	return i.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (i *IssuesEvent) GetInstallation() *Installation {
+	if i == nil {
+		return nil
+	}
+	return i.Installation
+}
+
+// GetIssue returns the Issue field.
+func (i *IssuesEvent) GetIssue() *Issue {
+	if i == nil {
+		return nil
+	}
+	return i.Issue
+}
+
+// GetLabel returns the Label field.
+func (i *IssuesEvent) GetLabel() *Label {
+	if i == nil {
+		return nil
+	}
+	return i.Label
+}
+
+// GetRepo returns the Repo field.
+func (i *IssuesEvent) GetRepo() *Repository {
+	if i == nil {
+		return nil
+	}
+	return i.Repo
+}
+
+// GetSender returns the Sender field.
+func (i *IssuesEvent) GetSender() *User {
+	if i == nil {
+		return nil
+	}
+	return i.Sender
+}
+
 // GetIncompleteResults returns the IncompleteResults field if it's non-nil, zero value otherwise.
 func (i *IssuesSearchResult) GetIncompleteResults() bool {
 	if i == nil || i.IncompleteResults == nil {
@@ -2386,6 +3314,30 @@ func (i *IssuesSearchResult) GetTotal() int {
 		return 0
 	}
 	return *i.Total
+}
+
+// GetClosedIssues returns the ClosedIssues field if it's non-nil, zero value otherwise.
+func (i *IssueStats) GetClosedIssues() int {
+	if i == nil || i.ClosedIssues == nil {
+		return 0
+	}
+	return *i.ClosedIssues
+}
+
+// GetOpenIssues returns the OpenIssues field if it's non-nil, zero value otherwise.
+func (i *IssueStats) GetOpenIssues() int {
+	if i == nil || i.OpenIssues == nil {
+		return 0
+	}
+	return *i.OpenIssues
+}
+
+// GetTotalIssues returns the TotalIssues field if it's non-nil, zero value otherwise.
+func (i *IssueStats) GetTotalIssues() int {
+	if i == nil || i.TotalIssues == nil {
+		return 0
+	}
+	return *i.TotalIssues
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
@@ -2466,6 +3418,46 @@ func (l *LabelEvent) GetAction() string {
 		return ""
 	}
 	return *l.Action
+}
+
+// GetChanges returns the Changes field.
+func (l *LabelEvent) GetChanges() *EditChange {
+	if l == nil {
+		return nil
+	}
+	return l.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (l *LabelEvent) GetInstallation() *Installation {
+	if l == nil {
+		return nil
+	}
+	return l.Installation
+}
+
+// GetLabel returns the Label field.
+func (l *LabelEvent) GetLabel() *Label {
+	if l == nil {
+		return nil
+	}
+	return l.Label
+}
+
+// GetOrg returns the Org field.
+func (l *LabelEvent) GetOrg() *Organization {
+	if l == nil {
+		return nil
+	}
+	return l.Org
+}
+
+// GetRepo returns the Repo field.
+func (l *LabelEvent) GetRepo() *Repository {
+	if l == nil {
+		return nil
+	}
+	return l.Repo
 }
 
 // GetOID returns the OID field if it's non-nil, zero value otherwise.
@@ -2596,28 +3588,228 @@ func (l *License) GetURL() string {
 	return *l.URL
 }
 
-// GetContext returns the Context field if it's non-nil, zero value otherwise.
-func (m *markdownRequest) GetContext() string {
-	if m == nil || m.Context == nil {
+// GetAccountsURL returns the AccountsURL field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetAccountsURL() string {
+	if m == nil || m.AccountsURL == nil {
 		return ""
 	}
-	return *m.Context
+	return *m.AccountsURL
 }
 
-// GetMode returns the Mode field if it's non-nil, zero value otherwise.
-func (m *markdownRequest) GetMode() string {
-	if m == nil || m.Mode == nil {
-		return ""
+// GetBullets returns the Bullets field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetBullets() []string {
+	if m == nil || m.Bullets == nil {
+		return nil
 	}
-	return *m.Mode
+	return *m.Bullets
 }
 
-// GetText returns the Text field if it's non-nil, zero value otherwise.
-func (m *markdownRequest) GetText() string {
-	if m == nil || m.Text == nil {
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetDescription() string {
+	if m == nil || m.Description == nil {
 		return ""
 	}
-	return *m.Text
+	return *m.Description
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetID() int {
+	if m == nil || m.ID == nil {
+		return 0
+	}
+	return *m.ID
+}
+
+// GetMonthlyPriceInCents returns the MonthlyPriceInCents field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetMonthlyPriceInCents() int {
+	if m == nil || m.MonthlyPriceInCents == nil {
+		return 0
+	}
+	return *m.MonthlyPriceInCents
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetName() string {
+	if m == nil || m.Name == nil {
+		return ""
+	}
+	return *m.Name
+}
+
+// GetPriceModel returns the PriceModel field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetPriceModel() string {
+	if m == nil || m.PriceModel == nil {
+		return ""
+	}
+	return *m.PriceModel
+}
+
+// GetUnitName returns the UnitName field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetUnitName() string {
+	if m == nil || m.UnitName == nil {
+		return ""
+	}
+	return *m.UnitName
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetURL() string {
+	if m == nil || m.URL == nil {
+		return ""
+	}
+	return *m.URL
+}
+
+// GetYearlyPriceInCents returns the YearlyPriceInCents field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlan) GetYearlyPriceInCents() int {
+	if m == nil || m.YearlyPriceInCents == nil {
+		return 0
+	}
+	return *m.YearlyPriceInCents
+}
+
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlanAccount) GetEmail() string {
+	if m == nil || m.Email == nil {
+		return ""
+	}
+	return *m.Email
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlanAccount) GetID() int {
+	if m == nil || m.ID == nil {
+		return 0
+	}
+	return *m.ID
+}
+
+// GetLogin returns the Login field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlanAccount) GetLogin() string {
+	if m == nil || m.Login == nil {
+		return ""
+	}
+	return *m.Login
+}
+
+// GetMarketplacePurchase returns the MarketplacePurchase field.
+func (m *MarketplacePlanAccount) GetMarketplacePurchase() *MarketplacePurchase {
+	if m == nil {
+		return nil
+	}
+	return m.MarketplacePurchase
+}
+
+// GetOrganizationBillingEmail returns the OrganizationBillingEmail field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlanAccount) GetOrganizationBillingEmail() string {
+	if m == nil || m.OrganizationBillingEmail == nil {
+		return ""
+	}
+	return *m.OrganizationBillingEmail
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlanAccount) GetType() string {
+	if m == nil || m.Type == nil {
+		return ""
+	}
+	return *m.Type
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (m *MarketplacePlanAccount) GetURL() string {
+	if m == nil || m.URL == nil {
+		return ""
+	}
+	return *m.URL
+}
+
+// GetAccount returns the Account field.
+func (m *MarketplacePurchase) GetAccount() *MarketplacePlanAccount {
+	if m == nil {
+		return nil
+	}
+	return m.Account
+}
+
+// GetBillingCycle returns the BillingCycle field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchase) GetBillingCycle() string {
+	if m == nil || m.BillingCycle == nil {
+		return ""
+	}
+	return *m.BillingCycle
+}
+
+// GetNextBillingDate returns the NextBillingDate field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchase) GetNextBillingDate() string {
+	if m == nil || m.NextBillingDate == nil {
+		return ""
+	}
+	return *m.NextBillingDate
+}
+
+// GetPlan returns the Plan field.
+func (m *MarketplacePurchase) GetPlan() *MarketplacePlan {
+	if m == nil {
+		return nil
+	}
+	return m.Plan
+}
+
+// GetUnitCount returns the UnitCount field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchase) GetUnitCount() int {
+	if m == nil || m.UnitCount == nil {
+		return 0
+	}
+	return *m.UnitCount
+}
+
+// GetAction returns the Action field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchaseEvent) GetAction() string {
+	if m == nil || m.Action == nil {
+		return ""
+	}
+	return *m.Action
+}
+
+// GetEffectiveDate returns the EffectiveDate field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchaseEvent) GetEffectiveDate() Timestamp {
+	if m == nil || m.EffectiveDate == nil {
+		return Timestamp{}
+	}
+	return *m.EffectiveDate
+}
+
+// GetInstallation returns the Installation field.
+func (m *MarketplacePurchaseEvent) GetInstallation() *Installation {
+	if m == nil {
+		return nil
+	}
+	return m.Installation
+}
+
+// GetMarketplacePurchase returns the MarketplacePurchase field.
+func (m *MarketplacePurchaseEvent) GetMarketplacePurchase() *MarketplacePurchase {
+	if m == nil {
+		return nil
+	}
+	return m.MarketplacePurchase
+}
+
+// GetPreviousMarketplacePurchase returns the PreviousMarketplacePurchase field.
+func (m *MarketplacePurchaseEvent) GetPreviousMarketplacePurchase() *MarketplacePurchase {
+	if m == nil {
+		return nil
+	}
+	return m.PreviousMarketplacePurchase
+}
+
+// GetSender returns the Sender field.
+func (m *MarketplacePurchaseEvent) GetSender() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Sender
 }
 
 // GetText returns the Text field if it's non-nil, zero value otherwise.
@@ -2634,6 +3826,46 @@ func (m *MemberEvent) GetAction() string {
 		return ""
 	}
 	return *m.Action
+}
+
+// GetInstallation returns the Installation field.
+func (m *MemberEvent) GetInstallation() *Installation {
+	if m == nil {
+		return nil
+	}
+	return m.Installation
+}
+
+// GetMember returns the Member field.
+func (m *MemberEvent) GetMember() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Member
+}
+
+// GetRepo returns the Repo field.
+func (m *MemberEvent) GetRepo() *Repository {
+	if m == nil {
+		return nil
+	}
+	return m.Repo
+}
+
+// GetSender returns the Sender field.
+func (m *MemberEvent) GetSender() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Sender
+}
+
+// GetOrganization returns the Organization field.
+func (m *Membership) GetOrganization() *Organization {
+	if m == nil {
+		return nil
+	}
+	return m.Organization
 }
 
 // GetOrganizationURL returns the OrganizationURL field if it's non-nil, zero value otherwise.
@@ -2668,6 +3900,14 @@ func (m *Membership) GetURL() string {
 	return *m.URL
 }
 
+// GetUser returns the User field.
+func (m *Membership) GetUser() *User {
+	if m == nil {
+		return nil
+	}
+	return m.User
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (m *MembershipEvent) GetAction() string {
 	if m == nil || m.Action == nil {
@@ -2676,12 +3916,52 @@ func (m *MembershipEvent) GetAction() string {
 	return *m.Action
 }
 
+// GetInstallation returns the Installation field.
+func (m *MembershipEvent) GetInstallation() *Installation {
+	if m == nil {
+		return nil
+	}
+	return m.Installation
+}
+
+// GetMember returns the Member field.
+func (m *MembershipEvent) GetMember() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Member
+}
+
+// GetOrg returns the Org field.
+func (m *MembershipEvent) GetOrg() *Organization {
+	if m == nil {
+		return nil
+	}
+	return m.Org
+}
+
 // GetScope returns the Scope field if it's non-nil, zero value otherwise.
 func (m *MembershipEvent) GetScope() string {
 	if m == nil || m.Scope == nil {
 		return ""
 	}
 	return *m.Scope
+}
+
+// GetSender returns the Sender field.
+func (m *MembershipEvent) GetSender() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Sender
+}
+
+// GetTeam returns the Team field.
+func (m *MembershipEvent) GetTeam() *Team {
+	if m == nil {
+		return nil
+	}
+	return m.Team
 }
 
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
@@ -2804,6 +4084,14 @@ func (m *Milestone) GetCreatedAt() time.Time {
 	return *m.CreatedAt
 }
 
+// GetCreator returns the Creator field.
+func (m *Milestone) GetCreator() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Creator
+}
+
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
 func (m *Milestone) GetDescription() string {
 	if m == nil || m.Description == nil {
@@ -2900,6 +4188,78 @@ func (m *MilestoneEvent) GetAction() string {
 	return *m.Action
 }
 
+// GetChanges returns the Changes field.
+func (m *MilestoneEvent) GetChanges() *EditChange {
+	if m == nil {
+		return nil
+	}
+	return m.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (m *MilestoneEvent) GetInstallation() *Installation {
+	if m == nil {
+		return nil
+	}
+	return m.Installation
+}
+
+// GetMilestone returns the Milestone field.
+func (m *MilestoneEvent) GetMilestone() *Milestone {
+	if m == nil {
+		return nil
+	}
+	return m.Milestone
+}
+
+// GetOrg returns the Org field.
+func (m *MilestoneEvent) GetOrg() *Organization {
+	if m == nil {
+		return nil
+	}
+	return m.Org
+}
+
+// GetRepo returns the Repo field.
+func (m *MilestoneEvent) GetRepo() *Repository {
+	if m == nil {
+		return nil
+	}
+	return m.Repo
+}
+
+// GetSender returns the Sender field.
+func (m *MilestoneEvent) GetSender() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Sender
+}
+
+// GetClosedMilestones returns the ClosedMilestones field if it's non-nil, zero value otherwise.
+func (m *MilestoneStats) GetClosedMilestones() int {
+	if m == nil || m.ClosedMilestones == nil {
+		return 0
+	}
+	return *m.ClosedMilestones
+}
+
+// GetOpenMilestones returns the OpenMilestones field if it's non-nil, zero value otherwise.
+func (m *MilestoneStats) GetOpenMilestones() int {
+	if m == nil || m.OpenMilestones == nil {
+		return 0
+	}
+	return *m.OpenMilestones
+}
+
+// GetTotalMilestones returns the TotalMilestones field if it's non-nil, zero value otherwise.
+func (m *MilestoneStats) GetTotalMilestones() int {
+	if m == nil || m.TotalMilestones == nil {
+		return 0
+	}
+	return *m.TotalMilestones
+}
+
 // GetBase returns the Base field if it's non-nil, zero value otherwise.
 func (n *NewPullRequest) GetBase() string {
 	if n == nil || n.Base == nil {
@@ -2948,6 +4308,46 @@ func (n *NewPullRequest) GetTitle() string {
 	return *n.Title
 }
 
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetDescription() string {
+	if n == nil || n.Description == nil {
+		return ""
+	}
+	return *n.Description
+}
+
+// GetLDAPDN returns the LDAPDN field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetLDAPDN() string {
+	if n == nil || n.LDAPDN == nil {
+		return ""
+	}
+	return *n.LDAPDN
+}
+
+// GetParentTeamID returns the ParentTeamID field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetParentTeamID() int {
+	if n == nil || n.ParentTeamID == nil {
+		return 0
+	}
+	return *n.ParentTeamID
+}
+
+// GetPermission returns the Permission field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetPermission() string {
+	if n == nil || n.Permission == nil {
+		return ""
+	}
+	return *n.Permission
+}
+
+// GetPrivacy returns the Privacy field if it's non-nil, zero value otherwise.
+func (n *NewTeam) GetPrivacy() string {
+	if n == nil || n.Privacy == nil {
+		return ""
+	}
+	return *n.Privacy
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (n *Notification) GetID() string {
 	if n == nil || n.ID == nil {
@@ -2970,6 +4370,22 @@ func (n *Notification) GetReason() string {
 		return ""
 	}
 	return *n.Reason
+}
+
+// GetRepository returns the Repository field.
+func (n *Notification) GetRepository() *Repository {
+	if n == nil {
+		return nil
+	}
+	return n.Repository
+}
+
+// GetSubject returns the Subject field.
+func (n *Notification) GetSubject() *NotificationSubject {
+	if n == nil {
+		return nil
+	}
+	return n.Subject
 }
 
 // GetUnread returns the Unread field if it's non-nil, zero value otherwise.
@@ -3196,6 +4612,14 @@ func (o *Organization) GetOwnedPrivateRepos() int {
 	return *o.OwnedPrivateRepos
 }
 
+// GetPlan returns the Plan field.
+func (o *Organization) GetPlan() *Plan {
+	if o == nil {
+		return nil
+	}
+	return o.Plan
+}
+
 // GetPrivateGists returns the PrivateGists field if it's non-nil, zero value otherwise.
 func (o *Organization) GetPrivateGists() int {
 	if o == nil || o.PrivateGists == nil {
@@ -3276,12 +4700,116 @@ func (o *OrganizationEvent) GetAction() string {
 	return *o.Action
 }
 
+// GetInstallation returns the Installation field.
+func (o *OrganizationEvent) GetInstallation() *Installation {
+	if o == nil {
+		return nil
+	}
+	return o.Installation
+}
+
+// GetInvitation returns the Invitation field.
+func (o *OrganizationEvent) GetInvitation() *Invitation {
+	if o == nil {
+		return nil
+	}
+	return o.Invitation
+}
+
+// GetMembership returns the Membership field.
+func (o *OrganizationEvent) GetMembership() *Membership {
+	if o == nil {
+		return nil
+	}
+	return o.Membership
+}
+
+// GetOrganization returns the Organization field.
+func (o *OrganizationEvent) GetOrganization() *Organization {
+	if o == nil {
+		return nil
+	}
+	return o.Organization
+}
+
+// GetSender returns the Sender field.
+func (o *OrganizationEvent) GetSender() *User {
+	if o == nil {
+		return nil
+	}
+	return o.Sender
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (o *OrgBlockEvent) GetAction() string {
 	if o == nil || o.Action == nil {
 		return ""
 	}
 	return *o.Action
+}
+
+// GetBlockedUser returns the BlockedUser field.
+func (o *OrgBlockEvent) GetBlockedUser() *User {
+	if o == nil {
+		return nil
+	}
+	return o.BlockedUser
+}
+
+// GetInstallation returns the Installation field.
+func (o *OrgBlockEvent) GetInstallation() *Installation {
+	if o == nil {
+		return nil
+	}
+	return o.Installation
+}
+
+// GetOrganization returns the Organization field.
+func (o *OrgBlockEvent) GetOrganization() *Organization {
+	if o == nil {
+		return nil
+	}
+	return o.Organization
+}
+
+// GetSender returns the Sender field.
+func (o *OrgBlockEvent) GetSender() *User {
+	if o == nil {
+		return nil
+	}
+	return o.Sender
+}
+
+// GetDisabledOrgs returns the DisabledOrgs field if it's non-nil, zero value otherwise.
+func (o *OrgStats) GetDisabledOrgs() int {
+	if o == nil || o.DisabledOrgs == nil {
+		return 0
+	}
+	return *o.DisabledOrgs
+}
+
+// GetTotalOrgs returns the TotalOrgs field if it's non-nil, zero value otherwise.
+func (o *OrgStats) GetTotalOrgs() int {
+	if o == nil || o.TotalOrgs == nil {
+		return 0
+	}
+	return *o.TotalOrgs
+}
+
+// GetTotalTeamMembers returns the TotalTeamMembers field if it's non-nil, zero value otherwise.
+func (o *OrgStats) GetTotalTeamMembers() int {
+	if o == nil || o.TotalTeamMembers == nil {
+		return 0
+	}
+	return *o.TotalTeamMembers
+}
+
+// GetTotalTeams returns the TotalTeams field if it's non-nil, zero value otherwise.
+func (o *OrgStats) GetTotalTeams() int {
+	if o == nil || o.TotalTeams == nil {
+		return 0
+	}
+	return *o.TotalTeams
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
@@ -3332,12 +4860,44 @@ func (p *Page) GetTitle() string {
 	return *p.Title
 }
 
+// GetBuild returns the Build field.
+func (p *PageBuildEvent) GetBuild() *PagesBuild {
+	if p == nil {
+		return nil
+	}
+	return p.Build
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (p *PageBuildEvent) GetID() int {
 	if p == nil || p.ID == nil {
 		return 0
 	}
 	return *p.ID
+}
+
+// GetInstallation returns the Installation field.
+func (p *PageBuildEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetRepo returns the Repo field.
+func (p *PageBuildEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PageBuildEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetCNAME returns the CNAME field if it's non-nil, zero value otherwise.
@@ -3404,6 +4964,22 @@ func (p *PagesBuild) GetDuration() int {
 	return *p.Duration
 }
 
+// GetError returns the Error field.
+func (p *PagesBuild) GetError() *PagesError {
+	if p == nil {
+		return nil
+	}
+	return p.Error
+}
+
+// GetPusher returns the Pusher field.
+func (p *PagesBuild) GetPusher() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Pusher
+}
+
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (p *PagesBuild) GetStatus() string {
 	if p == nil || p.Status == nil {
@@ -3436,12 +5012,36 @@ func (p *PagesError) GetMessage() string {
 	return *p.Message
 }
 
+// GetTotalPages returns the TotalPages field if it's non-nil, zero value otherwise.
+func (p *PageStats) GetTotalPages() int {
+	if p == nil || p.TotalPages == nil {
+		return 0
+	}
+	return *p.TotalPages
+}
+
+// GetHook returns the Hook field.
+func (p *PingEvent) GetHook() *Hook {
+	if p == nil {
+		return nil
+	}
+	return p.Hook
+}
+
 // GetHookID returns the HookID field if it's non-nil, zero value otherwise.
 func (p *PingEvent) GetHookID() int {
 	if p == nil || p.HookID == nil {
 		return 0
 	}
 	return *p.HookID
+}
+
+// GetInstallation returns the Installation field.
+func (p *PingEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
 }
 
 // GetZen returns the Zen field if it's non-nil, zero value otherwise.
@@ -3498,6 +5098,14 @@ func (p *Project) GetCreatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *p.CreatedAt
+}
+
+// GetCreator returns the Creator field.
+func (p *Project) GetCreator() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Creator
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
@@ -3580,6 +5188,14 @@ func (p *ProjectCard) GetCreatedAt() Timestamp {
 	return *p.CreatedAt
 }
 
+// GetCreator returns the Creator field.
+func (p *ProjectCard) GetCreator() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Creator
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (p *ProjectCard) GetID() int {
 	if p == nil || p.ID == nil {
@@ -3626,6 +5242,54 @@ func (p *ProjectCardEvent) GetAfterID() int {
 		return 0
 	}
 	return *p.AfterID
+}
+
+// GetChanges returns the Changes field.
+func (p *ProjectCardEvent) GetChanges() *ProjectCardChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (p *ProjectCardEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetOrg returns the Org field.
+func (p *ProjectCardEvent) GetOrg() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Org
+}
+
+// GetProjectCard returns the ProjectCard field.
+func (p *ProjectCardEvent) GetProjectCard() *ProjectCard {
+	if p == nil {
+		return nil
+	}
+	return p.ProjectCard
+}
+
+// GetRepo returns the Repo field.
+func (p *ProjectCardEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *ProjectCardEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -3684,6 +5348,54 @@ func (p *ProjectColumnEvent) GetAfterID() int {
 	return *p.AfterID
 }
 
+// GetChanges returns the Changes field.
+func (p *ProjectColumnEvent) GetChanges() *ProjectColumnChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (p *ProjectColumnEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetOrg returns the Org field.
+func (p *ProjectColumnEvent) GetOrg() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Org
+}
+
+// GetProjectColumn returns the ProjectColumn field.
+func (p *ProjectColumnEvent) GetProjectColumn() *ProjectColumn {
+	if p == nil {
+		return nil
+	}
+	return p.ProjectColumn
+}
+
+// GetRepo returns the Repo field.
+func (p *ProjectColumnEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *ProjectColumnEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *ProjectEvent) GetAction() string {
 	if p == nil || p.Action == nil {
@@ -3692,12 +5404,164 @@ func (p *ProjectEvent) GetAction() string {
 	return *p.Action
 }
 
+// GetChanges returns the Changes field.
+func (p *ProjectEvent) GetChanges() *ProjectChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (p *ProjectEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetOrg returns the Org field.
+func (p *ProjectEvent) GetOrg() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Org
+}
+
+// GetProject returns the Project field.
+func (p *ProjectEvent) GetProject() *Project {
+	if p == nil {
+		return nil
+	}
+	return p.Project
+}
+
+// GetRepo returns the Repo field.
+func (p *ProjectEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *ProjectEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
+}
+
+// GetEnforceAdmins returns the EnforceAdmins field.
+func (p *Protection) GetEnforceAdmins() *AdminEnforcement {
+	if p == nil {
+		return nil
+	}
+	return p.EnforceAdmins
+}
+
+// GetRequiredPullRequestReviews returns the RequiredPullRequestReviews field.
+func (p *Protection) GetRequiredPullRequestReviews() *PullRequestReviewsEnforcement {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredPullRequestReviews
+}
+
+// GetRequiredStatusChecks returns the RequiredStatusChecks field.
+func (p *Protection) GetRequiredStatusChecks() *RequiredStatusChecks {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredStatusChecks
+}
+
+// GetRestrictions returns the Restrictions field.
+func (p *Protection) GetRestrictions() *BranchRestrictions {
+	if p == nil {
+		return nil
+	}
+	return p.Restrictions
+}
+
+// GetRequiredPullRequestReviews returns the RequiredPullRequestReviews field.
+func (p *ProtectionRequest) GetRequiredPullRequestReviews() *PullRequestReviewsEnforcementRequest {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredPullRequestReviews
+}
+
+// GetRequiredStatusChecks returns the RequiredStatusChecks field.
+func (p *ProtectionRequest) GetRequiredStatusChecks() *RequiredStatusChecks {
+	if p == nil {
+		return nil
+	}
+	return p.RequiredStatusChecks
+}
+
+// GetRestrictions returns the Restrictions field.
+func (p *ProtectionRequest) GetRestrictions() *BranchRestrictionsRequest {
+	if p == nil {
+		return nil
+	}
+	return p.Restrictions
+}
+
+// GetInstallation returns the Installation field.
+func (p *PublicEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetRepo returns the Repo field.
+func (p *PublicEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PublicEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
+}
+
 // GetAdditions returns the Additions field if it's non-nil, zero value otherwise.
 func (p *PullRequest) GetAdditions() int {
 	if p == nil || p.Additions == nil {
 		return 0
 	}
 	return *p.Additions
+}
+
+// GetAssignee returns the Assignee field.
+func (p *PullRequest) GetAssignee() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Assignee
+}
+
+// GetAuthorAssociation returns the AuthorAssociation field if it's non-nil, zero value otherwise.
+func (p *PullRequest) GetAuthorAssociation() string {
+	if p == nil || p.AuthorAssociation == nil {
+		return ""
+	}
+	return *p.AuthorAssociation
+}
+
+// GetBase returns the Base field.
+func (p *PullRequest) GetBase() *PullRequestBranch {
+	if p == nil {
+		return nil
+	}
+	return p.Base
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -3764,6 +5628,14 @@ func (p *PullRequest) GetDiffURL() string {
 	return *p.DiffURL
 }
 
+// GetHead returns the Head field.
+func (p *PullRequest) GetHead() *PullRequestBranch {
+	if p == nil {
+		return nil
+	}
+	return p.Head
+}
+
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
 func (p *PullRequest) GetHTMLURL() string {
 	if p == nil || p.HTMLURL == nil {
@@ -3826,6 +5698,22 @@ func (p *PullRequest) GetMergedAt() time.Time {
 		return time.Time{}
 	}
 	return *p.MergedAt
+}
+
+// GetMergedBy returns the MergedBy field.
+func (p *PullRequest) GetMergedBy() *User {
+	if p == nil {
+		return nil
+	}
+	return p.MergedBy
+}
+
+// GetMilestone returns the Milestone field.
+func (p *PullRequest) GetMilestone() *Milestone {
+	if p == nil {
+		return nil
+	}
+	return p.Milestone
 }
 
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
@@ -3900,6 +5788,14 @@ func (p *PullRequest) GetURL() string {
 	return *p.URL
 }
 
+// GetUser returns the User field.
+func (p *PullRequest) GetUser() *User {
+	if p == nil {
+		return nil
+	}
+	return p.User
+}
+
 // GetLabel returns the Label field if it's non-nil, zero value otherwise.
 func (p *PullRequestBranch) GetLabel() string {
 	if p == nil || p.Label == nil {
@@ -3916,12 +5812,28 @@ func (p *PullRequestBranch) GetRef() string {
 	return *p.Ref
 }
 
+// GetRepo returns the Repo field.
+func (p *PullRequestBranch) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
 func (p *PullRequestBranch) GetSHA() string {
 	if p == nil || p.SHA == nil {
 		return ""
 	}
 	return *p.SHA
+}
+
+// GetUser returns the User field.
+func (p *PullRequestBranch) GetUser() *User {
+	if p == nil {
+		return nil
+	}
+	return p.User
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -4020,6 +5932,14 @@ func (p *PullRequestComment) GetPullRequestURL() string {
 	return *p.PullRequestURL
 }
 
+// GetReactions returns the Reactions field.
+func (p *PullRequestComment) GetReactions() *Reactions {
+	if p == nil {
+		return nil
+	}
+	return p.Reactions
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (p *PullRequestComment) GetUpdatedAt() time.Time {
 	if p == nil || p.UpdatedAt == nil {
@@ -4036,6 +5956,14 @@ func (p *PullRequestComment) GetURL() string {
 	return *p.URL
 }
 
+// GetUser returns the User field.
+func (p *PullRequestComment) GetUser() *User {
+	if p == nil {
+		return nil
+	}
+	return p.User
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *PullRequestEvent) GetAction() string {
 	if p == nil || p.Action == nil {
@@ -4044,12 +5972,52 @@ func (p *PullRequestEvent) GetAction() string {
 	return *p.Action
 }
 
+// GetChanges returns the Changes field.
+func (p *PullRequestEvent) GetChanges() *EditChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (p *PullRequestEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
 // GetNumber returns the Number field if it's non-nil, zero value otherwise.
 func (p *PullRequestEvent) GetNumber() int {
 	if p == nil || p.Number == nil {
 		return 0
 	}
 	return *p.Number
+}
+
+// GetPullRequest returns the PullRequest field.
+func (p *PullRequestEvent) GetPullRequest() *PullRequest {
+	if p == nil {
+		return nil
+	}
+	return p.PullRequest
+}
+
+// GetRepo returns the Repo field.
+func (p *PullRequestEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PullRequestEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetDiffURL returns the DiffURL field if it's non-nil, zero value otherwise.
@@ -4164,12 +6132,68 @@ func (p *PullRequestReview) GetSubmittedAt() time.Time {
 	return *p.SubmittedAt
 }
 
+// GetUser returns the User field.
+func (p *PullRequestReview) GetUser() *User {
+	if p == nil {
+		return nil
+	}
+	return p.User
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (p *PullRequestReviewCommentEvent) GetAction() string {
 	if p == nil || p.Action == nil {
 		return ""
 	}
 	return *p.Action
+}
+
+// GetChanges returns the Changes field.
+func (p *PullRequestReviewCommentEvent) GetChanges() *EditChange {
+	if p == nil {
+		return nil
+	}
+	return p.Changes
+}
+
+// GetComment returns the Comment field.
+func (p *PullRequestReviewCommentEvent) GetComment() *PullRequestComment {
+	if p == nil {
+		return nil
+	}
+	return p.Comment
+}
+
+// GetInstallation returns the Installation field.
+func (p *PullRequestReviewCommentEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetPullRequest returns the PullRequest field.
+func (p *PullRequestReviewCommentEvent) GetPullRequest() *PullRequest {
+	if p == nil {
+		return nil
+	}
+	return p.PullRequest
+}
+
+// GetRepo returns the Repo field.
+func (p *PullRequestReviewCommentEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PullRequestReviewCommentEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetMessage returns the Message field if it's non-nil, zero value otherwise.
@@ -4186,6 +6210,54 @@ func (p *PullRequestReviewEvent) GetAction() string {
 		return ""
 	}
 	return *p.Action
+}
+
+// GetInstallation returns the Installation field.
+func (p *PullRequestReviewEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetOrganization returns the Organization field.
+func (p *PullRequestReviewEvent) GetOrganization() *Organization {
+	if p == nil {
+		return nil
+	}
+	return p.Organization
+}
+
+// GetPullRequest returns the PullRequest field.
+func (p *PullRequestReviewEvent) GetPullRequest() *PullRequest {
+	if p == nil {
+		return nil
+	}
+	return p.PullRequest
+}
+
+// GetRepo returns the Repo field.
+func (p *PullRequestReviewEvent) GetRepo() *Repository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetReview returns the Review field.
+func (p *PullRequestReviewEvent) GetReview() *PullRequestReview {
+	if p == nil {
+		return nil
+	}
+	return p.Review
+}
+
+// GetSender returns the Sender field.
+func (p *PullRequestReviewEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -4212,6 +6284,22 @@ func (p *PullRequestReviewRequest) GetEvent() string {
 	return *p.Event
 }
 
+// GetDismissalRestrictionsRequest returns the DismissalRestrictionsRequest field.
+func (p *PullRequestReviewsEnforcementRequest) GetDismissalRestrictionsRequest() *DismissalRestrictionsRequest {
+	if p == nil {
+		return nil
+	}
+	return p.DismissalRestrictionsRequest
+}
+
+// GetDismissalRestrictionsRequest returns the DismissalRestrictionsRequest field.
+func (p *PullRequestReviewsEnforcementUpdate) GetDismissalRestrictionsRequest() *DismissalRestrictionsRequest {
+	if p == nil {
+		return nil
+	}
+	return p.DismissalRestrictionsRequest
+}
+
 // GetDismissStaleReviews returns the DismissStaleReviews field if it's non-nil, zero value otherwise.
 func (p *PullRequestReviewsEnforcementUpdate) GetDismissStaleReviews() bool {
 	if p == nil || p.DismissStaleReviews == nil {
@@ -4220,44 +6308,36 @@ func (p *PullRequestReviewsEnforcementUpdate) GetDismissStaleReviews() bool {
 	return *p.DismissStaleReviews
 }
 
-// GetBase returns the Base field if it's non-nil, zero value otherwise.
-func (p *pullRequestUpdate) GetBase() string {
-	if p == nil || p.Base == nil {
-		return ""
+// GetMergablePulls returns the MergablePulls field if it's non-nil, zero value otherwise.
+func (p *PullStats) GetMergablePulls() int {
+	if p == nil || p.MergablePulls == nil {
+		return 0
 	}
-	return *p.Base
+	return *p.MergablePulls
 }
 
-// GetBody returns the Body field if it's non-nil, zero value otherwise.
-func (p *pullRequestUpdate) GetBody() string {
-	if p == nil || p.Body == nil {
-		return ""
+// GetMergedPulls returns the MergedPulls field if it's non-nil, zero value otherwise.
+func (p *PullStats) GetMergedPulls() int {
+	if p == nil || p.MergedPulls == nil {
+		return 0
 	}
-	return *p.Body
+	return *p.MergedPulls
 }
 
-// GetMaintainerCanModify returns the MaintainerCanModify field if it's non-nil, zero value otherwise.
-func (p *pullRequestUpdate) GetMaintainerCanModify() bool {
-	if p == nil || p.MaintainerCanModify == nil {
-		return false
+// GetTotalPulls returns the TotalPulls field if it's non-nil, zero value otherwise.
+func (p *PullStats) GetTotalPulls() int {
+	if p == nil || p.TotalPulls == nil {
+		return 0
 	}
-	return *p.MaintainerCanModify
+	return *p.TotalPulls
 }
 
-// GetState returns the State field if it's non-nil, zero value otherwise.
-func (p *pullRequestUpdate) GetState() string {
-	if p == nil || p.State == nil {
-		return ""
+// GetUnmergablePulls returns the UnmergablePulls field if it's non-nil, zero value otherwise.
+func (p *PullStats) GetUnmergablePulls() int {
+	if p == nil || p.UnmergablePulls == nil {
+		return 0
 	}
-	return *p.State
-}
-
-// GetTitle returns the Title field if it's non-nil, zero value otherwise.
-func (p *pullRequestUpdate) GetTitle() string {
-	if p == nil || p.Title == nil {
-		return ""
-	}
-	return *p.Title
+	return *p.UnmergablePulls
 }
 
 // GetCommits returns the Commits field if it's non-nil, zero value otherwise.
@@ -4356,6 +6436,30 @@ func (p *PushEvent) GetHead() string {
 	return *p.Head
 }
 
+// GetHeadCommit returns the HeadCommit field.
+func (p *PushEvent) GetHeadCommit() *PushEventCommit {
+	if p == nil {
+		return nil
+	}
+	return p.HeadCommit
+}
+
+// GetInstallation returns the Installation field.
+func (p *PushEvent) GetInstallation() *Installation {
+	if p == nil {
+		return nil
+	}
+	return p.Installation
+}
+
+// GetPusher returns the Pusher field.
+func (p *PushEvent) GetPusher() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Pusher
+}
+
 // GetPushID returns the PushID field if it's non-nil, zero value otherwise.
 func (p *PushEvent) GetPushID() int {
 	if p == nil || p.PushID == nil {
@@ -4372,12 +6476,44 @@ func (p *PushEvent) GetRef() string {
 	return *p.Ref
 }
 
+// GetRepo returns the Repo field.
+func (p *PushEvent) GetRepo() *PushEventRepository {
+	if p == nil {
+		return nil
+	}
+	return p.Repo
+}
+
+// GetSender returns the Sender field.
+func (p *PushEvent) GetSender() *User {
+	if p == nil {
+		return nil
+	}
+	return p.Sender
+}
+
 // GetSize returns the Size field if it's non-nil, zero value otherwise.
 func (p *PushEvent) GetSize() int {
 	if p == nil || p.Size == nil {
 		return 0
 	}
 	return *p.Size
+}
+
+// GetAuthor returns the Author field.
+func (p *PushEventCommit) GetAuthor() *CommitAuthor {
+	if p == nil {
+		return nil
+	}
+	return p.Author
+}
+
+// GetCommitter returns the Committer field.
+func (p *PushEventCommit) GetCommitter() *CommitAuthor {
+	if p == nil {
+		return nil
+	}
+	return p.Committer
 }
 
 // GetDistinct returns the Distinct field if it's non-nil, zero value otherwise.
@@ -4620,6 +6756,14 @@ func (p *PushEventRepository) GetOrganization() string {
 	return *p.Organization
 }
 
+// GetOwner returns the Owner field.
+func (p *PushEventRepository) GetOwner() *PushEventRepoOwner {
+	if p == nil {
+		return nil
+	}
+	return p.Owner
+}
+
 // GetPrivate returns the Private field if it's non-nil, zero value otherwise.
 func (p *PushEventRepository) GetPrivate() bool {
 	if p == nil || p.Private == nil {
@@ -4700,6 +6844,22 @@ func (p *PushEventRepository) GetWatchersCount() int {
 	return *p.WatchersCount
 }
 
+// GetCore returns the Core field.
+func (r *RateLimits) GetCore() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.Core
+}
+
+// GetSearch returns the Search field.
+func (r *RateLimits) GetSearch() *Rate {
+	if r == nil {
+		return nil
+	}
+	return r.Search
+}
+
 // GetContent returns the Content field if it's non-nil, zero value otherwise.
 func (r *Reaction) GetContent() string {
 	if r == nil || r.Content == nil {
@@ -4714,6 +6874,14 @@ func (r *Reaction) GetID() int {
 		return 0
 	}
 	return *r.ID
+}
+
+// GetUser returns the User field.
+func (r *Reaction) GetUser() *User {
+	if r == nil {
+		return nil
+	}
+	return r.User
 }
 
 // GetConfused returns the Confused field if it's non-nil, zero value otherwise.
@@ -4778,6 +6946,14 @@ func (r *Reactions) GetURL() string {
 		return ""
 	}
 	return *r.URL
+}
+
+// GetObject returns the Object field.
+func (r *Reference) GetObject() *GitObject {
+	if r == nil {
+		return nil
+	}
+	return r.Object
 }
 
 // GetRef returns the Ref field if it's non-nil, zero value otherwise.
@@ -4876,6 +7052,14 @@ func (r *ReleaseAsset) GetUpdatedAt() Timestamp {
 	return *r.UpdatedAt
 }
 
+// GetUploader returns the Uploader field.
+func (r *ReleaseAsset) GetUploader() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Uploader
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (r *ReleaseAsset) GetURL() string {
 	if r == nil || r.URL == nil {
@@ -4890,6 +7074,38 @@ func (r *ReleaseEvent) GetAction() string {
 		return ""
 	}
 	return *r.Action
+}
+
+// GetInstallation returns the Installation field.
+func (r *ReleaseEvent) GetInstallation() *Installation {
+	if r == nil {
+		return nil
+	}
+	return r.Installation
+}
+
+// GetRelease returns the Release field.
+func (r *ReleaseEvent) GetRelease() *RepositoryRelease {
+	if r == nil {
+		return nil
+	}
+	return r.Release
+}
+
+// GetRepo returns the Repo field.
+func (r *ReleaseEvent) GetRepo() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Repo
+}
+
+// GetSender returns the Sender field.
+func (r *ReleaseEvent) GetSender() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Sender
 }
 
 // GetFrom returns the From field if it's non-nil, zero value otherwise.
@@ -4948,6 +7164,14 @@ func (r *Repository) GetAllowSquashMerge() bool {
 	return *r.AllowSquashMerge
 }
 
+// GetArchived returns the Archived field if it's non-nil, zero value otherwise.
+func (r *Repository) GetArchived() bool {
+	if r == nil || r.Archived == nil {
+		return false
+	}
+	return *r.Archived
+}
+
 // GetArchiveURL returns the ArchiveURL field if it's non-nil, zero value otherwise.
 func (r *Repository) GetArchiveURL() string {
 	if r == nil || r.ArchiveURL == nil {
@@ -4994,6 +7218,14 @@ func (r *Repository) GetCloneURL() string {
 		return ""
 	}
 	return *r.CloneURL
+}
+
+// GetCodeOfConduct returns the CodeOfConduct field.
+func (r *Repository) GetCodeOfConduct() *CodeOfConduct {
+	if r == nil {
+		return nil
+	}
+	return r.CodeOfConduct
 }
 
 // GetCollaboratorsURL returns the CollaboratorsURL field if it's non-nil, zero value otherwise.
@@ -5188,6 +7420,14 @@ func (r *Repository) GetHasPages() bool {
 	return *r.HasPages
 }
 
+// GetHasProjects returns the HasProjects field if it's non-nil, zero value otherwise.
+func (r *Repository) GetHasProjects() bool {
+	if r == nil || r.HasProjects == nil {
+		return false
+	}
+	return *r.HasProjects
+}
+
 // GetHasWiki returns the HasWiki field if it's non-nil, zero value otherwise.
 func (r *Repository) GetHasWiki() bool {
 	if r == nil || r.HasWiki == nil {
@@ -5284,6 +7524,14 @@ func (r *Repository) GetLanguagesURL() string {
 	return *r.LanguagesURL
 }
 
+// GetLicense returns the License field.
+func (r *Repository) GetLicense() *License {
+	if r == nil {
+		return nil
+	}
+	return r.License
+}
+
 // GetLicenseTemplate returns the LicenseTemplate field if it's non-nil, zero value otherwise.
 func (r *Repository) GetLicenseTemplate() string {
 	if r == nil || r.LicenseTemplate == nil {
@@ -5356,6 +7604,30 @@ func (r *Repository) GetOpenIssuesCount() int {
 	return *r.OpenIssuesCount
 }
 
+// GetOrganization returns the Organization field.
+func (r *Repository) GetOrganization() *Organization {
+	if r == nil {
+		return nil
+	}
+	return r.Organization
+}
+
+// GetOwner returns the Owner field.
+func (r *Repository) GetOwner() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Owner
+}
+
+// GetParent returns the Parent field.
+func (r *Repository) GetParent() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Parent
+}
+
 // GetPermissions returns the Permissions field if it's non-nil, zero value otherwise.
 func (r *Repository) GetPermissions() map[string]bool {
 	if r == nil || r.Permissions == nil {
@@ -5402,6 +7674,14 @@ func (r *Repository) GetSize() int {
 		return 0
 	}
 	return *r.Size
+}
+
+// GetSource returns the Source field.
+func (r *Repository) GetSource() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Source
 }
 
 // GetSSHURL returns the SSHURL field if it's non-nil, zero value otherwise.
@@ -5580,6 +7860,14 @@ func (r *RepositoryComment) GetPosition() int {
 	return *r.Position
 }
 
+// GetReactions returns the Reactions field.
+func (r *RepositoryComment) GetReactions() *Reactions {
+	if r == nil {
+		return nil
+	}
+	return r.Reactions
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (r *RepositoryComment) GetUpdatedAt() time.Time {
 	if r == nil || r.UpdatedAt == nil {
@@ -5596,12 +7884,44 @@ func (r *RepositoryComment) GetURL() string {
 	return *r.URL
 }
 
+// GetUser returns the User field.
+func (r *RepositoryComment) GetUser() *User {
+	if r == nil {
+		return nil
+	}
+	return r.User
+}
+
+// GetAuthor returns the Author field.
+func (r *RepositoryCommit) GetAuthor() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Author
+}
+
 // GetCommentsURL returns the CommentsURL field if it's non-nil, zero value otherwise.
 func (r *RepositoryCommit) GetCommentsURL() string {
 	if r == nil || r.CommentsURL == nil {
 		return ""
 	}
 	return *r.CommentsURL
+}
+
+// GetCommit returns the Commit field.
+func (r *RepositoryCommit) GetCommit() *Commit {
+	if r == nil {
+		return nil
+	}
+	return r.Commit
+}
+
+// GetCommitter returns the Committer field.
+func (r *RepositoryCommit) GetCommitter() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Committer
 }
 
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
@@ -5618,6 +7938,14 @@ func (r *RepositoryCommit) GetSHA() string {
 		return ""
 	}
 	return *r.SHA
+}
+
+// GetStats returns the Stats field.
+func (r *RepositoryCommit) GetStats() *CommitStats {
+	if r == nil {
+		return nil
+	}
+	return r.Stats
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -5708,12 +8036,28 @@ func (r *RepositoryContent) GetURL() string {
 	return *r.URL
 }
 
+// GetAuthor returns the Author field.
+func (r *RepositoryContentFileOptions) GetAuthor() *CommitAuthor {
+	if r == nil {
+		return nil
+	}
+	return r.Author
+}
+
 // GetBranch returns the Branch field if it's non-nil, zero value otherwise.
 func (r *RepositoryContentFileOptions) GetBranch() string {
 	if r == nil || r.Branch == nil {
 		return ""
 	}
 	return *r.Branch
+}
+
+// GetCommitter returns the Committer field.
+func (r *RepositoryContentFileOptions) GetCommitter() *CommitAuthor {
+	if r == nil {
+		return nil
+	}
+	return r.Committer
 }
 
 // GetMessage returns the Message field if it's non-nil, zero value otherwise.
@@ -5732,12 +8076,52 @@ func (r *RepositoryContentFileOptions) GetSHA() string {
 	return *r.SHA
 }
 
+// GetContent returns the Content field.
+func (r *RepositoryContentResponse) GetContent() *RepositoryContent {
+	if r == nil {
+		return nil
+	}
+	return r.Content
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (r *RepositoryEvent) GetAction() string {
 	if r == nil || r.Action == nil {
 		return ""
 	}
 	return *r.Action
+}
+
+// GetInstallation returns the Installation field.
+func (r *RepositoryEvent) GetInstallation() *Installation {
+	if r == nil {
+		return nil
+	}
+	return r.Installation
+}
+
+// GetOrg returns the Org field.
+func (r *RepositoryEvent) GetOrg() *Organization {
+	if r == nil {
+		return nil
+	}
+	return r.Org
+}
+
+// GetRepo returns the Repo field.
+func (r *RepositoryEvent) GetRepo() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Repo
+}
+
+// GetSender returns the Sender field.
+func (r *RepositoryEvent) GetSender() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Sender
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
@@ -5764,12 +8148,36 @@ func (r *RepositoryInvitation) GetID() int {
 	return *r.ID
 }
 
+// GetInvitee returns the Invitee field.
+func (r *RepositoryInvitation) GetInvitee() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Invitee
+}
+
+// GetInviter returns the Inviter field.
+func (r *RepositoryInvitation) GetInviter() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Inviter
+}
+
 // GetPermissions returns the Permissions field if it's non-nil, zero value otherwise.
 func (r *RepositoryInvitation) GetPermissions() string {
 	if r == nil || r.Permissions == nil {
 		return ""
 	}
 	return *r.Permissions
+}
+
+// GetRepo returns the Repo field.
+func (r *RepositoryInvitation) GetRepo() *Repository {
+	if r == nil {
+		return nil
+	}
+	return r.Repo
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -5818,6 +8226,14 @@ func (r *RepositoryLicense) GetHTMLURL() string {
 		return ""
 	}
 	return *r.HTMLURL
+}
+
+// GetLicense returns the License field.
+func (r *RepositoryLicense) GetLicense() *License {
+	if r == nil {
+		return nil
+	}
+	return r.License
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.
@@ -5900,12 +8316,28 @@ func (r *RepositoryPermissionLevel) GetPermission() string {
 	return *r.Permission
 }
 
+// GetUser returns the User field.
+func (r *RepositoryPermissionLevel) GetUser() *User {
+	if r == nil {
+		return nil
+	}
+	return r.User
+}
+
 // GetAssetsURL returns the AssetsURL field if it's non-nil, zero value otherwise.
 func (r *RepositoryRelease) GetAssetsURL() string {
 	if r == nil || r.AssetsURL == nil {
 		return ""
 	}
 	return *r.AssetsURL
+}
+
+// GetAuthor returns the Author field.
+func (r *RepositoryRelease) GetAuthor() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Author
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -6020,6 +8452,14 @@ func (r *RepositoryRelease) GetZipballURL() string {
 	return *r.ZipballURL
 }
 
+// GetCommit returns the Commit field.
+func (r *RepositoryTag) GetCommit() *Commit {
+	if r == nil {
+		return nil
+	}
+	return r.Commit
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (r *RepositoryTag) GetName() string {
 	if r == nil || r.Name == nil {
@@ -6044,6 +8484,54 @@ func (r *RepositoryTag) GetZipballURL() string {
 	return *r.ZipballURL
 }
 
+// GetForkRepos returns the ForkRepos field if it's non-nil, zero value otherwise.
+func (r *RepoStats) GetForkRepos() int {
+	if r == nil || r.ForkRepos == nil {
+		return 0
+	}
+	return *r.ForkRepos
+}
+
+// GetOrgRepos returns the OrgRepos field if it's non-nil, zero value otherwise.
+func (r *RepoStats) GetOrgRepos() int {
+	if r == nil || r.OrgRepos == nil {
+		return 0
+	}
+	return *r.OrgRepos
+}
+
+// GetRootRepos returns the RootRepos field if it's non-nil, zero value otherwise.
+func (r *RepoStats) GetRootRepos() int {
+	if r == nil || r.RootRepos == nil {
+		return 0
+	}
+	return *r.RootRepos
+}
+
+// GetTotalPushes returns the TotalPushes field if it's non-nil, zero value otherwise.
+func (r *RepoStats) GetTotalPushes() int {
+	if r == nil || r.TotalPushes == nil {
+		return 0
+	}
+	return *r.TotalPushes
+}
+
+// GetTotalRepos returns the TotalRepos field if it's non-nil, zero value otherwise.
+func (r *RepoStats) GetTotalRepos() int {
+	if r == nil || r.TotalRepos == nil {
+		return 0
+	}
+	return *r.TotalRepos
+}
+
+// GetTotalWikis returns the TotalWikis field if it's non-nil, zero value otherwise.
+func (r *RepoStats) GetTotalWikis() int {
+	if r == nil || r.TotalWikis == nil {
+		return 0
+	}
+	return *r.TotalWikis
+}
+
 // GetContext returns the Context field if it's non-nil, zero value otherwise.
 func (r *RepoStatus) GetContext() string {
 	if r == nil || r.Context == nil {
@@ -6058,6 +8546,14 @@ func (r *RepoStatus) GetCreatedAt() time.Time {
 		return time.Time{}
 	}
 	return *r.CreatedAt
+}
+
+// GetCreator returns the Creator field.
+func (r *RepoStatus) GetCreator() *User {
+	if r == nil {
+		return nil
+	}
+	return r.Creator
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -6148,6 +8644,14 @@ func (s *SignatureVerification) GetVerified() bool {
 	return *s.Verified
 }
 
+// GetActor returns the Actor field.
+func (s *Source) GetActor() *User {
+	if s == nil {
+		return nil
+	}
+	return s.Actor
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (s *Source) GetID() int {
 	if s == nil || s.ID == nil {
@@ -6228,6 +8732,22 @@ func (s *Stargazer) GetStarredAt() Timestamp {
 	return *s.StarredAt
 }
 
+// GetUser returns the User field.
+func (s *Stargazer) GetUser() *User {
+	if s == nil {
+		return nil
+	}
+	return s.User
+}
+
+// GetRepository returns the Repository field.
+func (s *StarredRepository) GetRepository() *Repository {
+	if s == nil {
+		return nil
+	}
+	return s.Repository
+}
+
 // GetStarredAt returns the StarredAt field if it's non-nil, zero value otherwise.
 func (s *StarredRepository) GetStarredAt() Timestamp {
 	if s == nil || s.StarredAt == nil {
@@ -6236,20 +8756,12 @@ func (s *StarredRepository) GetStarredAt() Timestamp {
 	return *s.StarredAt
 }
 
-// GetExcludeAttachments returns the ExcludeAttachments field if it's non-nil, zero value otherwise.
-func (s *startMigration) GetExcludeAttachments() bool {
-	if s == nil || s.ExcludeAttachments == nil {
-		return false
+// GetCommit returns the Commit field.
+func (s *StatusEvent) GetCommit() *RepositoryCommit {
+	if s == nil {
+		return nil
 	}
-	return *s.ExcludeAttachments
-}
-
-// GetLockRepositories returns the LockRepositories field if it's non-nil, zero value otherwise.
-func (s *startMigration) GetLockRepositories() bool {
-	if s == nil || s.LockRepositories == nil {
-		return false
-	}
-	return *s.LockRepositories
+	return s.Commit
 }
 
 // GetContext returns the Context field if it's non-nil, zero value otherwise.
@@ -6284,12 +8796,36 @@ func (s *StatusEvent) GetID() int {
 	return *s.ID
 }
 
+// GetInstallation returns the Installation field.
+func (s *StatusEvent) GetInstallation() *Installation {
+	if s == nil {
+		return nil
+	}
+	return s.Installation
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (s *StatusEvent) GetName() string {
 	if s == nil || s.Name == nil {
 		return ""
 	}
 	return *s.Name
+}
+
+// GetRepo returns the Repo field.
+func (s *StatusEvent) GetRepo() *Repository {
+	if s == nil {
+		return nil
+	}
+	return s.Repo
+}
+
+// GetSender returns the Sender field.
+func (s *StatusEvent) GetSender() *User {
+	if s == nil {
+		return nil
+	}
+	return s.Sender
 }
 
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
@@ -6388,6 +8924,14 @@ func (t *Tag) GetMessage() string {
 	return *t.Message
 }
 
+// GetObject returns the Object field.
+func (t *Tag) GetObject() *GitObject {
+	if t == nil {
+		return nil
+	}
+	return t.Object
+}
+
 // GetSHA returns the SHA field if it's non-nil, zero value otherwise.
 func (t *Tag) GetSHA() string {
 	if t == nil || t.SHA == nil {
@@ -6404,12 +8948,28 @@ func (t *Tag) GetTag() string {
 	return *t.Tag
 }
 
+// GetTagger returns the Tagger field.
+func (t *Tag) GetTagger() *CommitAuthor {
+	if t == nil {
+		return nil
+	}
+	return t.Tagger
+}
+
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
 func (t *Tag) GetURL() string {
 	if t == nil || t.URL == nil {
 		return ""
 	}
 	return *t.URL
+}
+
+// GetVerification returns the Verification field.
+func (t *Tag) GetVerification() *SignatureVerification {
+	if t == nil {
+		return nil
+	}
+	return t.Verification
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -6460,6 +9020,22 @@ func (t *Team) GetName() string {
 	return *t.Name
 }
 
+// GetOrganization returns the Organization field.
+func (t *Team) GetOrganization() *Organization {
+	if t == nil {
+		return nil
+	}
+	return t.Organization
+}
+
+// GetParent returns the Parent field.
+func (t *Team) GetParent() *Team {
+	if t == nil {
+		return nil
+	}
+	return t.Parent
+}
+
 // GetPermission returns the Permission field if it's non-nil, zero value otherwise.
 func (t *Team) GetPermission() string {
 	if t == nil || t.Permission == nil {
@@ -6508,12 +9084,100 @@ func (t *Team) GetURL() string {
 	return *t.URL
 }
 
+// GetInstallation returns the Installation field.
+func (t *TeamAddEvent) GetInstallation() *Installation {
+	if t == nil {
+		return nil
+	}
+	return t.Installation
+}
+
+// GetOrg returns the Org field.
+func (t *TeamAddEvent) GetOrg() *Organization {
+	if t == nil {
+		return nil
+	}
+	return t.Org
+}
+
+// GetRepo returns the Repo field.
+func (t *TeamAddEvent) GetRepo() *Repository {
+	if t == nil {
+		return nil
+	}
+	return t.Repo
+}
+
+// GetSender returns the Sender field.
+func (t *TeamAddEvent) GetSender() *User {
+	if t == nil {
+		return nil
+	}
+	return t.Sender
+}
+
+// GetTeam returns the Team field.
+func (t *TeamAddEvent) GetTeam() *Team {
+	if t == nil {
+		return nil
+	}
+	return t.Team
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (t *TeamEvent) GetAction() string {
 	if t == nil || t.Action == nil {
 		return ""
 	}
 	return *t.Action
+}
+
+// GetChanges returns the Changes field.
+func (t *TeamEvent) GetChanges() *TeamChange {
+	if t == nil {
+		return nil
+	}
+	return t.Changes
+}
+
+// GetInstallation returns the Installation field.
+func (t *TeamEvent) GetInstallation() *Installation {
+	if t == nil {
+		return nil
+	}
+	return t.Installation
+}
+
+// GetOrg returns the Org field.
+func (t *TeamEvent) GetOrg() *Organization {
+	if t == nil {
+		return nil
+	}
+	return t.Org
+}
+
+// GetRepo returns the Repo field.
+func (t *TeamEvent) GetRepo() *Repository {
+	if t == nil {
+		return nil
+	}
+	return t.Repo
+}
+
+// GetSender returns the Sender field.
+func (t *TeamEvent) GetSender() *User {
+	if t == nil {
+		return nil
+	}
+	return t.Sender
+}
+
+// GetTeam returns the Team field.
+func (t *TeamEvent) GetTeam() *Team {
+	if t == nil {
+		return nil
+	}
+	return t.Team
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -6628,6 +9292,22 @@ func (t *TextMatch) GetProperty() string {
 	return *t.Property
 }
 
+// GetActor returns the Actor field.
+func (t *Timeline) GetActor() *User {
+	if t == nil {
+		return nil
+	}
+	return t.Actor
+}
+
+// GetAssignee returns the Assignee field.
+func (t *Timeline) GetAssignee() *User {
+	if t == nil {
+		return nil
+	}
+	return t.Assignee
+}
+
 // GetCommitID returns the CommitID field if it's non-nil, zero value otherwise.
 func (t *Timeline) GetCommitID() string {
 	if t == nil || t.CommitID == nil {
@@ -6666,6 +9346,38 @@ func (t *Timeline) GetID() int {
 		return 0
 	}
 	return *t.ID
+}
+
+// GetLabel returns the Label field.
+func (t *Timeline) GetLabel() *Label {
+	if t == nil {
+		return nil
+	}
+	return t.Label
+}
+
+// GetMilestone returns the Milestone field.
+func (t *Timeline) GetMilestone() *Milestone {
+	if t == nil {
+		return nil
+	}
+	return t.Milestone
+}
+
+// GetRename returns the Rename field.
+func (t *Timeline) GetRename() *Rename {
+	if t == nil {
+		return nil
+	}
+	return t.Rename
+}
+
+// GetSource returns the Source field.
+func (t *Timeline) GetSource() *Source {
+	if t == nil {
+		return nil
+	}
+	return t.Source
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.
@@ -6850,22 +9562,6 @@ func (t *TreeEntry) GetURL() string {
 		return ""
 	}
 	return *t.URL
-}
-
-// GetForce returns the Force field if it's non-nil, zero value otherwise.
-func (u *updateRefRequest) GetForce() bool {
-	if u == nil || u.Force == nil {
-		return false
-	}
-	return *u.Force
-}
-
-// GetSHA returns the SHA field if it's non-nil, zero value otherwise.
-func (u *updateRefRequest) GetSHA() string {
-	if u == nil || u.SHA == nil {
-		return ""
-	}
-	return *u.SHA
 }
 
 // GetAvatarURL returns the AvatarURL field if it's non-nil, zero value otherwise.
@@ -7058,6 +9754,14 @@ func (u *User) GetPermissions() map[string]bool {
 		return map[string]bool{}
 	}
 	return *u.Permissions
+}
+
+// GetPlan returns the Plan field.
+func (u *User) GetPlan() *Plan {
+	if u == nil {
+		return nil
+	}
+	return u.Plan
 }
 
 // GetPrivateGists returns the PrivateGists field if it's non-nil, zero value otherwise.
@@ -7340,12 +10044,60 @@ func (u *UsersSearchResult) GetTotal() int {
 	return *u.Total
 }
 
+// GetAdminUsers returns the AdminUsers field if it's non-nil, zero value otherwise.
+func (u *UserStats) GetAdminUsers() int {
+	if u == nil || u.AdminUsers == nil {
+		return 0
+	}
+	return *u.AdminUsers
+}
+
+// GetSuspendedUsers returns the SuspendedUsers field if it's non-nil, zero value otherwise.
+func (u *UserStats) GetSuspendedUsers() int {
+	if u == nil || u.SuspendedUsers == nil {
+		return 0
+	}
+	return *u.SuspendedUsers
+}
+
+// GetTotalUsers returns the TotalUsers field if it's non-nil, zero value otherwise.
+func (u *UserStats) GetTotalUsers() int {
+	if u == nil || u.TotalUsers == nil {
+		return 0
+	}
+	return *u.TotalUsers
+}
+
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
 func (w *WatchEvent) GetAction() string {
 	if w == nil || w.Action == nil {
 		return ""
 	}
 	return *w.Action
+}
+
+// GetInstallation returns the Installation field.
+func (w *WatchEvent) GetInstallation() *Installation {
+	if w == nil {
+		return nil
+	}
+	return w.Installation
+}
+
+// GetRepo returns the Repo field.
+func (w *WatchEvent) GetRepo() *Repository {
+	if w == nil {
+		return nil
+	}
+	return w.Repo
+}
+
+// GetSender returns the Sender field.
+func (w *WatchEvent) GetSender() *User {
+	if w == nil {
+		return nil
+	}
+	return w.Sender
 }
 
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
@@ -7370,6 +10122,22 @@ func (w *WebHookAuthor) GetUsername() string {
 		return ""
 	}
 	return *w.Username
+}
+
+// GetAuthor returns the Author field.
+func (w *WebHookCommit) GetAuthor() *WebHookAuthor {
+	if w == nil {
+		return nil
+	}
+	return w.Author
+}
+
+// GetCommitter returns the Committer field.
+func (w *WebHookCommit) GetCommitter() *WebHookAuthor {
+	if w == nil {
+		return nil
+	}
+	return w.Committer
 }
 
 // GetDistinct returns the Distinct field if it's non-nil, zero value otherwise.
@@ -7452,12 +10220,44 @@ func (w *WebHookPayload) GetForced() bool {
 	return *w.Forced
 }
 
+// GetHeadCommit returns the HeadCommit field.
+func (w *WebHookPayload) GetHeadCommit() *WebHookCommit {
+	if w == nil {
+		return nil
+	}
+	return w.HeadCommit
+}
+
+// GetPusher returns the Pusher field.
+func (w *WebHookPayload) GetPusher() *User {
+	if w == nil {
+		return nil
+	}
+	return w.Pusher
+}
+
 // GetRef returns the Ref field if it's non-nil, zero value otherwise.
 func (w *WebHookPayload) GetRef() string {
 	if w == nil || w.Ref == nil {
 		return ""
 	}
 	return *w.Ref
+}
+
+// GetRepo returns the Repo field.
+func (w *WebHookPayload) GetRepo() *Repository {
+	if w == nil {
+		return nil
+	}
+	return w.Repo
+}
+
+// GetSender returns the Sender field.
+func (w *WebHookPayload) GetSender() *User {
+	if w == nil {
+		return nil
+	}
+	return w.Sender
 }
 
 // GetTotal returns the Total field if it's non-nil, zero value otherwise.

--- a/vendor/github.com/google/go-github/github/github.go
+++ b/vendor/github.com/google/go-github/github/github.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	libraryVersion = "13"
+	libraryVersion = "14"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
 	userAgent      = "go-github/" + libraryVersion
@@ -102,6 +102,15 @@ const (
 
 	// https://developer.github.com/changes/2017-07-26-team-review-request-thor-preview/
 	mediaTypeTeamReviewPreview = "application/vnd.github.thor-preview+json"
+
+	// https://developer.github.com/v3/apps/marketplace/
+	mediaTypeMarketplacePreview = "application/vnd.github.valkyrie-preview+json"
+
+	// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
+	mediaTypeNestedTeamsPreview = "application/vnd.github.hellcat-preview+json"
+
+	// https://developer.github.com/changes/2017-11-09-repository-transfer-api-preview/
+	mediaTypeRepositoryTransferPreview = "application/vnd.github.nightshade-preview+json"
 )
 
 // A Client manages communication with the GitHub API.
@@ -134,15 +143,16 @@ type Client struct {
 	Git            *GitService
 	Gitignores     *GitignoresService
 	Issues         *IssuesService
+	Licenses       *LicensesService
+	Marketplace    *MarketplaceService
+	Migrations     *MigrationService
 	Organizations  *OrganizationsService
 	Projects       *ProjectsService
 	PullRequests   *PullRequestsService
+	Reactions      *ReactionsService
 	Repositories   *RepositoriesService
 	Search         *SearchService
 	Users          *UsersService
-	Licenses       *LicensesService
-	Migrations     *MigrationService
-	Reactions      *ReactionsService
 }
 
 type service struct {
@@ -224,6 +234,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Gitignores = (*GitignoresService)(&c.common)
 	c.Issues = (*IssuesService)(&c.common)
 	c.Licenses = (*LicensesService)(&c.common)
+	c.Marketplace = &MarketplaceService{client: c}
 	c.Migrations = (*MigrationService)(&c.common)
 	c.Organizations = (*OrganizationsService)(&c.common)
 	c.Projects = (*ProjectsService)(&c.common)
@@ -233,6 +244,37 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Search = (*SearchService)(&c.common)
 	c.Users = (*UsersService)(&c.common)
 	return c
+}
+
+// NewEnterpriseClient returns a new GitHub API client with provided
+// base URL and upload URL (often the same URL).
+// If either URL does not have a trailing slash, one is added automatically.
+// If a nil httpClient is provided, http.DefaultClient will be used.
+//
+// Note that NewEnterpriseClient is a convenience helper only;
+// its behavior is equivalent to using NewClient, followed by setting
+// the BaseURL and UploadURL fields.
+func NewEnterpriseClient(baseURL, uploadURL string, httpClient *http.Client) (*Client, error) {
+	baseEndpoint, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasSuffix(baseEndpoint.Path, "/") {
+		baseEndpoint.Path += "/"
+	}
+
+	uploadEndpoint, err := url.Parse(uploadURL)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasSuffix(uploadEndpoint.Path, "/") {
+		uploadEndpoint.Path += "/"
+	}
+
+	c := NewClient(httpClient)
+	c.BaseURL = baseEndpoint
+	c.UploadURL = uploadEndpoint
+	return c, nil
 }
 
 // NewRequest creates an API request. A relative URL can be provided in urlStr,
@@ -252,7 +294,9 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	var buf io.ReadWriter
 	if body != nil {
 		buf = new(bytes.Buffer)
-		err := json.NewEncoder(buf).Encode(body)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(body)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/google/go-github/github/messages.go
+++ b/vendor/github.com/google/go-github/github/messages.go
@@ -53,6 +53,7 @@ var (
 		"issue_comment":               "IssueCommentEvent",
 		"issues":                      "IssuesEvent",
 		"label":                       "LabelEvent",
+		"marketplace_purchase":        "MarketplacePurchaseEvent",
 		"member":                      "MemberEvent",
 		"membership":                  "MembershipEvent",
 		"milestone":                   "MilestoneEvent",

--- a/vendor/github.com/google/go-github/github/pulls.go
+++ b/vendor/github.com/google/go-github/github/pulls.go
@@ -51,6 +51,7 @@ type PullRequest struct {
 	Assignees           []*User    `json:"assignees,omitempty"`
 	Milestone           *Milestone `json:"milestone,omitempty"`
 	MaintainerCanModify *bool      `json:"maintainer_can_modify,omitempty"`
+	AuthorAssociation   *string    `json:"author_association,omitempty"`
 
 	Head *PullRequestBranch `json:"head,omitempty"`
 	Base *PullRequestBranch `json:"base,omitempty"`
@@ -138,7 +139,7 @@ func (s *PullRequestsService) Get(ctx context.Context, owner string, repo string
 	return pull, resp, nil
 }
 
-// GetRaw gets raw (diff or patch) format of a pull request.
+// GetRaw gets a single pull request in raw (diff or patch) format.
 func (s *PullRequestsService) GetRaw(ctx context.Context, owner string, repo string, number int, opt RawOptions) (string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/pulls/%d", owner, repo, number)
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -155,13 +156,13 @@ func (s *PullRequestsService) GetRaw(ctx context.Context, owner string, repo str
 		return "", nil, fmt.Errorf("unsupported raw type %d", opt.Type)
 	}
 
-	ret := new(bytes.Buffer)
-	resp, err := s.client.Do(ctx, req, ret)
+	var buf bytes.Buffer
+	resp, err := s.client.Do(ctx, req, &buf)
 	if err != nil {
 		return "", resp, err
 	}
 
-	return ret.String(), resp, nil
+	return buf.String(), resp, nil
 }
 
 // NewPullRequest represents a new pull request to be created.

--- a/vendor/github.com/google/go-github/github/pulls_reviewers.go
+++ b/vendor/github.com/google/go-github/github/pulls_reviewers.go
@@ -84,5 +84,5 @@ func (s *PullRequestsService) RemoveReviewers(ctx context.Context, owner, repo s
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeTeamReviewPreview)
 
-	return s.client.Do(ctx, req, reviewers)
+	return s.client.Do(ctx, req, nil)
 }

--- a/vendor/github.com/google/go-github/github/repos.go
+++ b/vendor/github.com/google/go-github/github/repos.go
@@ -39,7 +39,7 @@ type Repository struct {
 	SSHURL           *string          `json:"ssh_url,omitempty"`
 	SVNURL           *string          `json:"svn_url,omitempty"`
 	Language         *string          `json:"language,omitempty"`
-	Fork             *bool            `json:"fork"`
+	Fork             *bool            `json:"fork,omitempty"`
 	ForksCount       *int             `json:"forks_count,omitempty"`
 	NetworkCount     *int             `json:"network_count,omitempty"`
 	OpenIssuesCount  *int             `json:"open_issues_count,omitempty"`
@@ -61,16 +61,18 @@ type Repository struct {
 	License *License `json:"license,omitempty"`
 
 	// Additional mutable fields when creating and editing a repository
-	Private           *bool   `json:"private"`
-	HasIssues         *bool   `json:"has_issues"`
-	HasWiki           *bool   `json:"has_wiki"`
-	HasPages          *bool   `json:"has_pages"`
-	HasDownloads      *bool   `json:"has_downloads"`
+	Private           *bool   `json:"private,omitempty"`
+	HasIssues         *bool   `json:"has_issues,omitempty"`
+	HasWiki           *bool   `json:"has_wiki,omitempty"`
+	HasPages          *bool   `json:"has_pages,omitempty"`
+	HasProjects       *bool   `json:"has_projects,omitempty"`
+	HasDownloads      *bool   `json:"has_downloads,omitempty"`
 	LicenseTemplate   *string `json:"license_template,omitempty"`
 	GitignoreTemplate *string `json:"gitignore_template,omitempty"`
+	Archived          *bool   `json:"archived,omitempty"`
 
 	// Creating an organization repository. Required for non-owners.
-	TeamID *int `json:"team_id"`
+	TeamID *int `json:"team_id,omitempty"`
 
 	// API URLs
 	URL              *string `json:"url,omitempty"`
@@ -403,7 +405,7 @@ type Contributor struct {
 	EventsURL         *string `json:"events_url,omitempty"`
 	ReceivedEventsURL *string `json:"received_events_url,omitempty"`
 	Type              *string `json:"type,omitempty"`
-	SiteAdmin         *bool   `json:"site_admin"`
+	SiteAdmin         *bool   `json:"site_admin,omitempty"`
 	Contributions     *int    `json:"contributions,omitempty"`
 }
 
@@ -480,6 +482,8 @@ func (s *RepositoriesService) ListTeams(ctx context.Context, owner string, repo 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
 
 	var teams []*Team
 	resp, err := s.client.Do(ctx, req, &teams)
@@ -981,15 +985,15 @@ func (s *RepositoriesService) RemoveAdminEnforcement(ctx context.Context, owner,
 	return s.client.Do(ctx, req, nil)
 }
 
-// Topics represents a collection of repository topics.
-type Topics struct {
-	Names []string `json:"names,omitempty"`
+// repositoryTopics represents a collection of repository topics.
+type repositoryTopics struct {
+	Names []string `json:"names"`
 }
 
 // ListAllTopics lists topics for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/#list-all-topics-for-a-repository
-func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo string) (*Topics, *Response, error) {
+func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo string) ([]string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/topics", owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -999,21 +1003,27 @@ func (s *RepositoriesService) ListAllTopics(ctx context.Context, owner, repo str
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
-	topics := new(Topics)
+	topics := new(repositoryTopics)
 	resp, err := s.client.Do(ctx, req, topics)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return topics, resp, nil
+	return topics.Names, resp, nil
 }
 
 // ReplaceAllTopics replaces topics for a repository.
 //
 // GitHub API docs: https://developer.github.com/v3/repos/#replace-all-topics-for-a-repository
-func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo string, topics *Topics) (*Topics, *Response, error) {
+func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo string, topics []string) ([]string, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/topics", owner, repo)
-	req, err := s.client.NewRequest("PUT", u, topics)
+	t := &repositoryTopics{
+		Names: topics,
+	}
+	if t.Names == nil {
+		t.Names = []string{}
+	}
+	req, err := s.client.NewRequest("PUT", u, t)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1021,11 +1031,46 @@ func (s *RepositoriesService) ReplaceAllTopics(ctx context.Context, owner, repo 
 	// TODO: remove custom Accept header when this API fully launches.
 	req.Header.Set("Accept", mediaTypeTopicsPreview)
 
-	t := new(Topics)
+	t = new(repositoryTopics)
 	resp, err := s.client.Do(ctx, req, t)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return t, resp, nil
+	return t.Names, resp, nil
+}
+
+// TransferRequest represents a request to transfer a repository.
+type TransferRequest struct {
+	NewOwner string `json:"new_owner"`
+	TeamID   []int  `json:"team_id,omitempty"`
+}
+
+// Transfer transfers a repository from one account or organization to another.
+//
+// This method might return an *AcceptedError and a status code of
+// 202. This is because this is the status that GitHub returns to signify that
+// it has now scheduled the transfer of the repository in a background task.
+// A follow up request, after a delay of a second or so, should result
+// in a successful request.
+//
+// GitHub API docs: https://developer.github.com/v3/repos/#transfer-a-repository
+func (s *RepositoriesService) Transfer(ctx context.Context, owner, repo string, transfer TransferRequest) (*Repository, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/transfer", owner, repo)
+
+	req, err := s.client.NewRequest("POST", u, &transfer)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeRepositoryTransferPreview)
+
+	r := new(Repository)
+	resp, err := s.client.Do(ctx, req, r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, nil
 }

--- a/vendor/github.com/google/go-github/github/repos_collaborators.go
+++ b/vendor/github.com/google/go-github/github/repos_collaborators.go
@@ -41,6 +41,8 @@ func (s *RepositoriesService) ListCollaborators(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 
+	req.Header.Set("Accept", mediaTypeNestedTeamsPreview)
+
 	var users []*User
 	resp, err := s.client.Do(ctx, req, &users)
 	if err != nil {

--- a/vendor/github.com/google/go-github/github/repos_commits.go
+++ b/vendor/github.com/google/go-github/github/repos_commits.go
@@ -140,10 +140,9 @@ func (s *RepositoriesService) ListCommits(ctx context.Context, owner, repo strin
 }
 
 // GetCommit fetches the specified commit, including all details about it.
-// todo: support media formats - https://github.com/google/go-github/issues/6
 //
 // GitHub API docs: https://developer.github.com/v3/repos/commits/#get-a-single-commit
-// See also: https://developer.github.com//v3/git/commits/#get-a-single-commit provides the same functionality
+// See also: https://developer.github.com/v3/git/commits/#get-a-single-commit provides the same functionality
 func (s *RepositoriesService) GetCommit(ctx context.Context, owner, repo, sha string) (*RepositoryCommit, *Response, error) {
 	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, sha)
 
@@ -162,6 +161,32 @@ func (s *RepositoriesService) GetCommit(ctx context.Context, owner, repo, sha st
 	}
 
 	return commit, resp, nil
+}
+
+// GetCommitRaw fetches the specified commit in raw (diff or patch) format.
+func (s *RepositoriesService) GetCommitRaw(ctx context.Context, owner string, repo string, sha string, opt RawOptions) (string, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, sha)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return "", nil, err
+	}
+
+	switch opt.Type {
+	case Diff:
+		req.Header.Set("Accept", mediaTypeV3Diff)
+	case Patch:
+		req.Header.Set("Accept", mediaTypeV3Patch)
+	default:
+		return "", nil, fmt.Errorf("unsupported raw type %d", opt.Type)
+	}
+
+	var buf bytes.Buffer
+	resp, err := s.client.Do(ctx, req, &buf)
+	if err != nil {
+		return "", resp, err
+	}
+
+	return buf.String(), resp, nil
 }
 
 // GetCommitSHA1 gets the SHA-1 of a commit reference. If a last-known SHA1 is

--- a/vendor/github.com/google/go-github/github/repos_stats.go
+++ b/vendor/github.com/google/go-github/github/repos_stats.go
@@ -182,7 +182,7 @@ func (s *RepositoriesService) ListParticipation(ctx context.Context, owner, repo
 }
 
 // PunchCard represents the number of commits made during a given hour of a
-// day of thew eek.
+// day of the week.
 type PunchCard struct {
 	Day     *int // Day of the week (0-6: =Sunday - Saturday).
 	Hour    *int // Hour of day (0-23).

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -247,10 +247,10 @@
 			"revisionTime": "2017-01-17T13:00:17Z"
 		},
 		{
-			"checksumSHA1": "zY+zzNE0kGOJ0P70fLRfIg5iZCo=",
+			"checksumSHA1": "ABGxrDDpHegthAxO2DqHfbUy+BQ=",
 			"path": "github.com/google/go-github/github",
-			"revision": "a021c14a5f1960591b0e1773a4a2ef8257ec93b8",
-			"revisionTime": "2017-10-14T14:39:26Z",
+			"revision": "fbfee053c26dab3772adfc7799d995eed379133e",
+			"revisionTime": "2017-12-02T20:04:27Z",
 			"version": "master",
 			"versionExact": "master"
 		},

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -64,6 +64,8 @@ The following arguments are supported:
 and after a correct reference has been created for the target branch inside the repository. This means a user will have to omit this parameter from the
 initial repository creation and create the target branch inside of the repository prior to setting this attribute.
 
+* `archived` - (Optional) Specifies if the repository should be archived. Defaults to `false`.
+
 ## Attributes Reference
 
 The following additional attributes are exported:

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -66,6 +66,8 @@ initial repository creation and create the target branch inside of the repositor
 
 * `archived` - (Optional) Specifies if the repository should be archived. Defaults to `false`.
 
+~> **NOTE** Currently, the API does not support unarchiving.
+
 ## Attributes Reference
 
 The following additional attributes are exported:


### PR DESCRIPTION
- Adds support for archiving repositories
- Updates the SDK to the latest commit
- Fixing the failing deployment tests (by giving them unique names)

After some additional testing with this it appears repositories can only be archived through the API and not unarchived (whereas this is possible through the UI) - so this could do with some 🤔