### PR TITLE
Button up adding support for require_code_owners_review

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -91,6 +91,10 @@ func resourceGithubBranchProtection() *schema.Resource {
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"require_code_owner_reviews": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -187,6 +191,11 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+
+	if protectionRequest.RequiredPullRequestReviews == nil {
+		_, err = client.Repositories.RemovePullRequestReviewEnforcement(context.TODO(), meta.(*Organization).name, r, b)
+	}
+
 	d.SetId(buildTwoPartID(&r, &b))
 
 	return resourceGithubBranchProtectionRead(d, meta)
@@ -268,9 +277,10 @@ func flattenRequiredPullRequestReviews(d *schema.ResourceData, protection *githu
 
 		if err := d.Set("required_pull_request_reviews", []interface{}{
 			map[string]interface{}{
-				"dismiss_stale_reviews": rprr.DismissStaleReviews,
-				"dismissal_users":       schema.NewSet(schema.HashString, users),
-				"dismissal_teams":       schema.NewSet(schema.HashString, teams),
+				"dismiss_stale_reviews":      rprr.DismissStaleReviews,
+				"dismissal_users":            schema.NewSet(schema.HashString, users),
+				"dismissal_teams":            schema.NewSet(schema.HashString, teams),
+				"require_code_owner_reviews": rprr.RequireCodeOwnerReviews,
 			},
 		}); err != nil {
 			return err
@@ -363,6 +373,7 @@ func expandRequiredPullRequestReviews(d *schema.ResourceData) (*github.PullReque
 
 			rprr.DismissalRestrictionsRequest = drr
 			rprr.DismissStaleReviews = m["dismiss_stale_reviews"].(bool)
+			rprr.RequireCodeOwnerReviews = m["require_code_owner_reviews"].(bool)
 		}
 
 		return rprr, nil

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -194,6 +194,9 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 
 	if protectionRequest.RequiredPullRequestReviews == nil {
 		_, err = client.Repositories.RemovePullRequestReviewEnforcement(context.TODO(), meta.(*Organization).name, r, b)
+		if err != nil {
+			return err
+		}
 	}
 
 	d.SetId(buildTwoPartID(&r, &b))

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 * `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
 * `dismissal_users`: (Optional) The list of user logins with dismissal access
 * `dismissal_teams`: (Optional) The list of team slugs with dismissal access
+* `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
 
 ### Restrictions
 


### PR DESCRIPTION
This pull request includes @denniswebb's changes from https://github.com/terraform-providers/terraform-provider-github/pull/51 with the addition of the error check that was requested in the original PR.

From the original PR:
`
This PR adds support for require_code_owner_reviews for pull request review branch protection.

Updating the github.com/google/go-github vendored library was required for this support.

Other changes:

 - Fix failing test TestAccGithubBranchProtection_basic by adding step to delete PullRequestReview settings if nil because github API does not remove when set to nil in branch protection requests.
 - Updated resource_github_repository_collaborator to use ListCollaboratorsOptions due to change in go-github library
 - Fixed failing tests TestAccGithubRepositoryDeployKey_basic
`

Could we possibly merge the original PR then this one or just this one if nobody would mind? I'm in the process of trying to open source a terraform module that relies on this functionality.