### PR TITLE
r/membership: Fix import crash on incorrect ID

### DIFF
--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -15,7 +15,7 @@ func resourceGithubMembership() *schema.Resource {
 		Update: resourceGithubMembershipUpdate,
 		Delete: resourceGithubMembershipDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceGithubMembershipImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -88,4 +88,15 @@ func resourceGithubMembershipDelete(d *schema.ResourceData, meta interface{}) er
 	_, err := client.Organizations.RemoveOrgMembership(context.TODO(), n, meta.(*Organization).name)
 
 	return err
+}
+
+func resourceGithubMembershipImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// All we do here is validate that the import string is in a correct enough
+	// format to be parsed.  parseTwoPartID will panic if it's missing elements,
+	// and is used otherwise in places where that should never happen, so we want
+	// to keep it that way.
+	if err := validateTwoPartID(d.Id()); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
 }

--- a/github/util.go
+++ b/github/util.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -44,6 +45,19 @@ func validateValueFunc(values []string) schema.SchemaValidateFunc {
 func parseTwoPartID(id string) (string, string) {
 	parts := strings.SplitN(id, ":", 2)
 	return parts[0], parts[1]
+}
+
+// validateTwoPartID performs a quick validation of a two-part ID, designed for
+// use when validation has not been previously possible, such as importing.
+func validateTwoPartID(id string) error {
+	if id == "" {
+		return errors.New("no ID supplied. Please supply an ID format matching organization:username")
+	}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		return fmt.Errorf("incorrectly formatted ID %q. Please supply an ID format matching organization:username", id)
+	}
+	return nil
 }
 
 // format the strings into an id `a:b`

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -53,3 +53,44 @@ func TestAccGithubUtilTwoPartID(t *testing.T) {
 		t.Fatalf("Expected parsed part two bar, actual: %s", parsedPartTwo)
 	}
 }
+
+func TestAccValidateTwoPartID(t *testing.T) {
+	cases := []struct {
+		name        string
+		id          string
+		expectedErr string
+	}{
+		{
+			name: "valid",
+			id:   "foo:bar",
+		},
+		{
+			name:        "blank ID",
+			id:          "",
+			expectedErr: "no ID supplied. Please supply an ID format matching organization:username",
+		},
+		{
+			name:        "not enough parts",
+			id:          "foo",
+			expectedErr: "incorrectly formatted ID \"foo\". Please supply an ID format matching organization:username",
+		},
+		{
+			name:        "too many parts",
+			id:          "foo:bar:baz",
+			expectedErr: "incorrectly formatted ID \"foo:bar:baz\". Please supply an ID format matching organization:username",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTwoPartID(tc.id)
+			switch {
+			case err != nil && tc.expectedErr == "":
+				t.Fatalf("expected no error, got %q", err)
+			case err != nil && tc.expectedErr != "":
+				if err.Error() != tc.expectedErr {
+					t.Fatalf("expected error to be %q, got %q", tc.expectedErr, err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
An incorrect two-part ID supplied to `github_membership` during import
results in a crash - this is because the import functionality is passing
this directly to the `Read` function of the resource, for which IDs are
programatically controlled and a panic there would be more telling of a
much more serious error worthy of panicking over.

This adds an internal validation function for two-part IDs, and wraps
the resource's import functionality to use it to validate incoming IDs
before passing them to `Read`.