### PR TITLE
datasource/github_ip_ranges: implement ip datasource via the GH Meta api

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/google/go-github/github"
@@ -15,8 +16,9 @@ type Config struct {
 }
 
 type Organization struct {
-	name   string
-	client *github.Client
+	name        string
+	client      *github.Client
+	StopContext context.Context
 }
 
 // Client configures and returns a fully initialized GithubClient

--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -1,8 +1,6 @@
 package github
 
 import (
-	"context"
-
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -31,18 +29,25 @@ func dataSourceGithubIpRanges() *schema.Resource {
 }
 
 func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
-	ctx := context.Background()
+	org := meta.(*Organization)
 
-	api, _, err := client.APIMeta(ctx)
+	api, _, err := org.client.APIMeta(org.StopContext)
 	if err != nil {
 		return err
 	}
 
-	d.SetId("github-ip-ranges")
-	d.Set("hooks", api.Hooks)
-	d.Set("git", api.Git)
-	d.Set("pages", api.Pages)
+	if len(api.Hooks)+len(api.Git)+len(api.Pages) > 0 {
+		d.SetId("github-ip-ranges")
+	}
+	if len(api.Hooks) > 0 {
+		d.Set("hooks", api.Hooks)
+	}
+	if len(api.Git) > 0 {
+		d.Set("git", api.Git)
+	}
+	if len(api.Pages) > 0 {
+		d.Set("pages", api.Pages)
+	}
 
 	return nil
 }

--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -24,6 +24,8 @@ func dataSourceGithubIpRanges() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			// TODO: importer IPs coming once this is merged
+			// https://github.com/google/go-github/pull/881
 		},
 	}
 }

--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -1,0 +1,48 @@
+package github
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGithubIpRanges() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubIpRangesRead,
+
+		Schema: map[string]*schema.Schema{
+			"hooks": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"git": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"pages": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Organization).client
+	ctx := context.Background()
+
+	api, _, err := client.APIMeta(ctx)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("github-ip-ranges")
+	d.Set("hooks", api.Hooks)
+	d.Set("git", api.Git)
+	d.Set("pages", api.Pages)
+
+	return nil
+}

--- a/github/data_source_github_ip_ranges_test.go
+++ b/github/data_source_github_ip_ranges_test.go
@@ -1,0 +1,32 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccGithubIpRangesDataSource_basic(t *testing.T) {
+	slug := "non-existing"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGithubTeamDataSourceConfig(slug),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubIpRangesSetsValue(),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGithubIpRangesSetsValue() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return nil
+	}
+}

--- a/github/data_source_github_ip_ranges_test.go
+++ b/github/data_source_github_ip_ranges_test.go
@@ -4,11 +4,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccGithubIpRangesDataSource_basic(t *testing.T) {
-	slug := "non-existing"
+func TestAccGithubIpRangesDataSource_existing(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -16,17 +14,15 @@ func TestAccGithubIpRangesDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckGithubTeamDataSourceConfig(slug),
+				Config: `
+				data "github_ip_ranges" "test" {}
+				`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGithubIpRangesSetsValue(),
+					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "hooks.#"),
+					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "git.#"),
+					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages.#"),
 				),
 			},
 		},
 	})
-}
-
-func testAccCheckGithubIpRangesSetsValue() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		return nil
-	}
 }

--- a/github/provider.go
+++ b/github/provider.go
@@ -46,8 +46,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"github_user": dataSourceGithubUser(),
-			"github_team": dataSourceGithubTeam(),
+			"github_user":      dataSourceGithubUser(),
+			"github_team":      dataSourceGithubTeam(),
+			"github_ip_ranges": dataSourceGithubIpRanges(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -1,0 +1,22 @@
+---
+layout: "github"
+page_title: "Github: github_ip_ranges"
+sidebar_current: "docs-github-datasource-ip-ranges"
+description: |-
+  Get information on a Github's IP addresses.
+---
+
+# github_ip_ranges
+
+Use this data source to retrieve information about a Github's IP addresses.
+## Example Usage
+
+```
+data "github_ip_ranges" "test" {}
+```
+
+## Attributes Reference
+
+ * `hooks` - An Array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from.
+ * `git` - An Array of IP addresses in CIDR format specifying the Git servers.
+ * `pages` - An Array of IP addresses in CIDR format specifying the A records for GitHub Pages.

--- a/website/github.erb
+++ b/website/github.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-github-datasource") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+             <li<%= sidebar_current("docs-github-datasource-ip-ranges") %>>
+              <a href="/docs/providers/github/d/ip_ranges.html">github_ip_ranges</a>
+            </li>
             <li<%= sidebar_current("docs-github-datasource-user") %>>
               <a href="/docs/providers/github/d/user.html">github_user</a>
             </li>


### PR DESCRIPTION
Fix #78 

Implemented data source to pull github's ip addresses. Rigged up the StopContext to pass through to the api call (should probably be done elsewhere in the provider as well).

One of the ip sets (importer) is not yet implemented in the `go-github` library. I'll open a PR for that so we can polish off this data source in a follow up PR.

go-github PR https://github.com/google/go-github/pull/881