### PR TITLE
provider: Add the possibility to create repositories for non-organization accounts

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -10,12 +10,12 @@ import (
 )
 
 type Config struct {
-	Token        string
-	Organization string
-	BaseURL      string
+	Token   string
+	Owner   string
+	BaseURL string
 }
 
-type Organization struct {
+type Owner struct {
 	name        string
 	client      *github.Client
 	StopContext context.Context
@@ -23,8 +23,8 @@ type Organization struct {
 
 // Client configures and returns a fully initialized GithubClient
 func (c *Config) Client() (interface{}, error) {
-	var org Organization
-	org.name = c.Organization
+	var owner Owner
+	owner.name = c.Owner
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: c.Token},
 	)
@@ -32,14 +32,14 @@ func (c *Config) Client() (interface{}, error) {
 
 	tc.Transport = logging.NewTransport("Github", tc.Transport)
 
-	org.client = github.NewClient(tc)
+	owner.client = github.NewClient(tc)
 	if c.BaseURL != "" {
 		u, err := url.Parse(c.BaseURL)
 		if err != nil {
 			return nil, err
 		}
-		org.client.BaseURL = u
+		owner.client.BaseURL = u
 	}
 
-	return &org, nil
+	return &owner, nil
 }

--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -31,9 +31,9 @@ func dataSourceGithubIpRanges() *schema.Resource {
 }
 
 func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta interface{}) error {
-	org := meta.(*Organization)
+	owner := meta.(*Owner)
 
-	api, _, err := org.client.APIMeta(org.StopContext)
+	api, _, err := owner.client.APIMeta(owner.StopContext)
 	if err != nil {
 		return err
 	}

--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -48,10 +48,10 @@ func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	slug := d.Get("slug").(string)
 	log.Printf("[INFO] Refreshing Gitub Team: %s", slug)
 
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	ctx := context.Background()
 
-	team, err := getGithubTeamBySlug(client, meta.(*Organization).name, slug)
+	team, err := getGithubTeamBySlug(client, meta.(*Owner).name, slug)
 	if err != nil {
 		return err
 	}
@@ -76,10 +76,10 @@ func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func getGithubTeamBySlug(client *github.Client, org string, slug string) (team *github.Team, err error) {
+func getGithubTeamBySlug(client *github.Client, owner string, slug string) (team *github.Team, err error) {
 	opt := &github.ListOptions{PerPage: 10}
 	for {
-		teams, resp, err := client.Organizations.ListTeams(context.TODO(), org, opt)
+		teams, resp, err := client.Organizations.ListTeams(context.TODO(), owner, opt)
 		if err != nil {
 			return team, err
 		}

--- a/github/data_source_github_user.go
+++ b/github/data_source_github_user.go
@@ -99,7 +99,7 @@ func dataSourceGithubUserRead(d *schema.ResourceData, meta interface{}) error {
 	username := d.Get("username").(string)
 	log.Printf("[INFO] Refreshing Gitub User: %s", username)
 
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	ctx := context.Background()
 
 	user, _, err := client.Users.Get(ctx, username)

--- a/github/provider.go
+++ b/github/provider.go
@@ -19,7 +19,7 @@ func Provider() terraform.ResourceProvider {
 			},
 			"owner": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("GITHUB_OWNER", nil),
 				Description: descriptions["owner"],
 			},

--- a/github/provider.go
+++ b/github/provider.go
@@ -23,6 +23,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("GITHUB_OWNER", nil),
 				Description: descriptions["owner"],
 			},
+			"organization": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GITHUB_ORGANIZATION", nil),
+				Description: descriptions["organization"],
+			},
 			"base_url": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -65,15 +71,21 @@ func init() {
 
 		"owner": "The GitHub owner name to manage.",
 
+		"organization": "The GitHub owner name to manage.",
+
 		"base_url": "The GitHub Base API URL",
 	}
 }
 
 func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 	return func(d *schema.ResourceData) (interface{}, error) {
+		owner := d.Get("owner").(string)
+		if owner == "" {
+			owner = d.Get("organization").(string)
+		}
 		config := Config{
 			Token:   d.Get("token").(string),
-			Owner:   d.Get("owner").(string),
+			Owner:   owner,
 			BaseURL: d.Get("base_url").(string),
 		}
 

--- a/github/provider.go
+++ b/github/provider.go
@@ -17,11 +17,11 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("GITHUB_TOKEN", nil),
 				Description: descriptions["token"],
 			},
-			"organization": &schema.Schema{
+			"owner": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GITHUB_ORGANIZATION", nil),
-				Description: descriptions["organization"],
+				DefaultFunc: schema.EnvDefaultFunc("GITHUB_OWNER", nil),
+				Description: descriptions["owner"],
 			},
 			"base_url": &schema.Schema{
 				Type:        schema.TypeString,
@@ -63,7 +63,7 @@ func init() {
 	descriptions = map[string]string{
 		"token": "The OAuth token used to connect to GitHub.",
 
-		"organization": "The GitHub organization name to manage.",
+		"owner": "The GitHub owner name to manage.",
 
 		"base_url": "The GitHub Base API URL",
 	}
@@ -72,9 +72,9 @@ func init() {
 func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 	return func(d *schema.ResourceData) (interface{}, error) {
 		config := Config{
-			Token:        d.Get("token").(string),
-			Organization: d.Get("organization").(string),
-			BaseURL:      d.Get("base_url").(string),
+			Token:   d.Get("token").(string),
+			Owner:   d.Get("owner").(string),
+			BaseURL: d.Get("base_url").(string),
 		}
 
 		meta, err := config.Client()
@@ -82,7 +82,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			return nil, err
 		}
 
-		meta.(*Organization).StopContext = p.StopContext()
+		meta.(*Owner).StopContext = p.StopContext()
 
 		return meta, nil
 	}

--- a/github/provider.go
+++ b/github/provider.go
@@ -79,9 +79,9 @@ func init() {
 
 func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 	return func(d *schema.ResourceData) (interface{}, error) {
-		owner := d.Get("owner").(string)
+		owner := d.Get("organization").(string)
 		if owner == "" {
-			owner = d.Get("organization").(string)
+			owner = d.Get("owner").(string)
 		}
 		config := Config{
 			Token:   d.Get("token").(string),

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -35,8 +35,8 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("GITHUB_TOKEN"); v == "" {
 		t.Fatal("GITHUB_TOKEN must be set for acceptance tests")
 	}
-	if v := os.Getenv("GITHUB_ORGANIZATION"); v == "" {
-		t.Fatal("GITHUB_ORGANIZATION must be set for acceptance tests")
+	if v := os.Getenv("GITHUB_OWNER"); v == "" {
+		t.Fatal("GITHUB_OWNER must be set for acceptance tests")
 	}
 	if v := os.Getenv("GITHUB_TEST_USER"); v == "" {
 		t.Fatal("GITHUB_TEST_USER must be set for acceptance tests")

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -38,6 +38,9 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("GITHUB_OWNER"); v == "" {
 		t.Fatal("GITHUB_OWNER must be set for acceptance tests")
 	}
+	if v := os.Getenv("GITHUB_ORGANIZATION"); v == "" {
+		t.Fatal("GITHUB_ORGANIZATION must be set for acceptance tests")
+	}
 	if v := os.Getenv("GITHUB_TEST_USER"); v == "" {
 		t.Fatal("GITHUB_TEST_USER must be set for acceptance tests")
 	}

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -127,7 +127,7 @@ func resourceGithubBranchProtection() *schema.Resource {
 }
 
 func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	r := d.Get("repository").(string)
 	b := d.Get("branch").(string)
 
@@ -136,7 +136,7 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	_, _, err = client.Repositories.UpdateBranchProtection(context.TODO(), meta.(*Organization).name, r, b, protectionRequest)
+	_, _, err = client.Repositories.UpdateBranchProtection(context.TODO(), meta.(*Owner).name, r, b, protectionRequest)
 	if err != nil {
 		return err
 	}
@@ -146,10 +146,10 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	r, b := parseTwoPartID(d.Id())
 
-	githubProtection, _, err := client.Repositories.GetBranchProtection(context.TODO(), meta.(*Organization).name, r, b)
+	githubProtection, _, err := client.Repositories.GetBranchProtection(context.TODO(), meta.(*Owner).name, r, b)
 	if err != nil {
 		if err, ok := err.(*github.ErrorResponse); ok && err.Response.StatusCode == http.StatusNotFound {
 			d.SetId("")
@@ -179,7 +179,7 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	r, b := parseTwoPartID(d.Id())
 
 	protectionRequest, err := buildProtectionRequest(d)
@@ -187,13 +187,13 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	_, _, err = client.Repositories.UpdateBranchProtection(context.TODO(), meta.(*Organization).name, r, b, protectionRequest)
+	_, _, err = client.Repositories.UpdateBranchProtection(context.TODO(), meta.(*Owner).name, r, b, protectionRequest)
 	if err != nil {
 		return err
 	}
 
 	if protectionRequest.RequiredPullRequestReviews == nil {
-		_, err = client.Repositories.RemovePullRequestReviewEnforcement(context.TODO(), meta.(*Organization).name, r, b)
+		_, err = client.Repositories.RemovePullRequestReviewEnforcement(context.TODO(), meta.(*Owner).name, r, b)
 		if err != nil {
 			return err
 		}
@@ -205,10 +205,10 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceGithubBranchProtectionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	r, b := parseTwoPartID(d.Id())
 
-	_, err := client.Repositories.RemoveBranchProtection(context.TODO(), meta.(*Organization).name, r, b)
+	_, err := client.Repositories.RemoveBranchProtection(context.TODO(), meta.(*Owner).name, r, b)
 	return err
 }
 

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -121,8 +121,8 @@ func testAccCheckGithubProtectedBranchExists(n, id string, protection *github.Pr
 			return fmt.Errorf("Expected ID to be %v, got %v", id, rs.Primary.ID)
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
-		o := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).client
+		o := testAccProvider.Meta().(*Owner).name
 		r, b := parseTwoPartID(rs.Primary.ID)
 
 		githubProtection, _, err := conn.Repositories.GetBranchProtection(context.TODO(), o, r, b)
@@ -238,14 +238,14 @@ func testAccCheckGithubBranchProtectionNoPullRequestReviewsExist(protection *git
 }
 
 func testAccGithubBranchProtectionDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Owner).client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_branch_protection" {
 			continue
 		}
 
-		o := testAccProvider.Meta().(*Organization).name
+		o := testAccProvider.Meta().(*Owner).name
 		r, b := parseTwoPartID(rs.Primary.ID)
 		protection, res, err := conn.Repositories.GetBranchProtection(context.TODO(), o, r, b)
 

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -51,8 +51,8 @@ func resourceGithubIssueLabel() *schema.Resource {
 // same function for two schema funcs.
 
 func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
-	o := meta.(*Organization).name
+	client := meta.(*Owner).client
+	o := meta.(*Owner).name
 	r := d.Get("repository").(string)
 	n := d.Get("name").(string)
 	c := d.Get("color").(string)
@@ -98,11 +98,11 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	r, n := parseTwoPartID(d.Id())
 
 	log.Printf("[DEBUG] Reading label: %s/%s", r, n)
-	githubLabel, _, err := client.Issues.GetLabel(context.TODO(), meta.(*Organization).name, r, n)
+	githubLabel, _, err := client.Issues.GetLabel(context.TODO(), meta.(*Owner).name, r, n)
 	if err != nil {
 		d.SetId("")
 		return nil
@@ -117,11 +117,11 @@ func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceGithubIssueLabelDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	r := d.Get("repository").(string)
 	n := d.Get("name").(string)
 
 	log.Printf("[DEBUG] Deleting label: %s/%s", r, n)
-	_, err := client.Issues.DeleteLabel(context.TODO(), meta.(*Organization).name, r, n)
+	_, err := client.Issues.DeleteLabel(context.TODO(), meta.(*Owner).name, r, n)
 	return err
 }

--- a/github/resource_github_issue_label_test.go
+++ b/github/resource_github_issue_label_test.go
@@ -94,8 +94,8 @@ func testAccCheckGithubIssueLabelExists(n string, label *github.Label) resource.
 			return fmt.Errorf("No issue label ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
-		o := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).client
+		o := testAccProvider.Meta().(*Owner).name
 		r, n := parseTwoPartID(rs.Primary.ID)
 
 		githubLabel, _, err := conn.Issues.GetLabel(context.TODO(), o, r, n)
@@ -123,14 +123,14 @@ func testAccCheckGithubIssueLabelAttributes(label *github.Label, name, color str
 }
 
 func testAccGithubIssueLabelDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Owner).client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_issue_label" {
 			continue
 		}
 
-		o := testAccProvider.Meta().(*Organization).name
+		o := testAccProvider.Meta().(*Owner).name
 		r, n := parseTwoPartID(rs.Primary.ID)
 		label, res, err := conn.Issues.GetLabel(context.TODO(), o, r, n)
 

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -35,11 +35,11 @@ func resourceGithubMembership() *schema.Resource {
 }
 
 func resourceGithubMembershipCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	n := d.Get("username").(string)
 	r := d.Get("role").(string)
 
-	membership, _, err := client.Organizations.EditOrgMembership(context.TODO(), n, meta.(*Organization).name,
+	membership, _, err := client.Organizations.EditOrgMembership(context.TODO(), n, meta.(*Owner).name,
 		&github.Membership{Role: &r})
 	if err != nil {
 		return err
@@ -51,10 +51,10 @@ func resourceGithubMembershipCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	_, n := parseTwoPartID(d.Id())
 
-	membership, _, err := client.Organizations.GetOrgMembership(context.TODO(), n, meta.(*Organization).name)
+	membership, _, err := client.Organizations.GetOrgMembership(context.TODO(), n, meta.(*Owner).name)
 	if err != nil {
 		d.SetId("")
 		return nil
@@ -66,11 +66,11 @@ func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceGithubMembershipUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	n := d.Get("username").(string)
 	r := d.Get("role").(string)
 
-	membership, _, err := client.Organizations.EditOrgMembership(context.TODO(), n, meta.(*Organization).name, &github.Membership{
+	membership, _, err := client.Organizations.EditOrgMembership(context.TODO(), n, meta.(*Owner).name, &github.Membership{
 		Role: &r,
 	})
 	if err != nil {
@@ -82,10 +82,10 @@ func resourceGithubMembershipUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubMembershipDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	n := d.Get("username").(string)
 
-	_, err := client.Organizations.RemoveOrgMembership(context.TODO(), n, meta.(*Organization).name)
+	_, err := client.Organizations.RemoveOrgMembership(context.TODO(), n, meta.(*Owner).name)
 
 	return err
 }

--- a/github/resource_github_membership_test.go
+++ b/github/resource_github_membership_test.go
@@ -48,7 +48,7 @@ func TestAccGithubMembership_importBasic(t *testing.T) {
 }
 
 func testAccCheckGithubMembershipDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Owner).client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_membership" {
@@ -83,7 +83,7 @@ func testAccCheckGithubMembershipExists(n string, membership *github.Membership)
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Owner).client
 		o, u := parseTwoPartID(rs.Primary.ID)
 
 		githubMembership, _, err := conn.Organizations.GetOrgMembership(context.TODO(), u, o)
@@ -106,7 +106,7 @@ func testAccCheckGithubMembershipRoleState(n string, membership *github.Membersh
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Owner).client
 		o, u := parseTwoPartID(rs.Primary.ID)
 
 		githubMembership, _, err := conn.Organizations.GetOrgMembership(context.TODO(), u, o)

--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -76,10 +76,10 @@ func resourceGithubOrganizationWebhookObject(d *schema.ResourceData) *github.Hoo
 }
 
 func resourceGithubOrganizationWebhookCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	hk := resourceGithubOrganizationWebhookObject(d)
 
-	hook, _, err := client.Organizations.CreateHook(context.TODO(), meta.(*Organization).name, hk)
+	hook, _, err := client.Organizations.CreateHook(context.TODO(), meta.(*Owner).name, hk)
 	if err != nil {
 		return err
 	}
@@ -89,10 +89,10 @@ func resourceGithubOrganizationWebhookCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	hookID, _ := strconv.ParseInt(d.Id(), 10, 64)
 
-	hook, resp, err := client.Organizations.GetHook(context.TODO(), meta.(*Organization).name, hookID)
+	hook, resp, err := client.Organizations.GetHook(context.TODO(), meta.(*Owner).name, hookID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
@@ -110,14 +110,14 @@ func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceGithubOrganizationWebhookUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	hk := resourceGithubOrganizationWebhookObject(d)
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = client.Organizations.EditHook(context.TODO(), meta.(*Organization).name, hookID, hk)
+	_, _, err = client.Organizations.EditHook(context.TODO(), meta.(*Owner).name, hookID, hk)
 	if err != nil {
 		return err
 	}
@@ -126,12 +126,12 @@ func resourceGithubOrganizationWebhookUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceGithubOrganizationWebhookDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	_, err = client.Organizations.DeleteHook(context.TODO(), meta.(*Organization).name, hookID)
+	_, err = client.Organizations.DeleteHook(context.TODO(), meta.(*Owner).name, hookID)
 	return err
 }

--- a/github/resource_github_organization_webhook_test.go
+++ b/github/resource_github_organization_webhook_test.go
@@ -69,9 +69,9 @@ func testAccCheckGithubOrganizationWebhookExists(n string, hook *github.Hook) re
 			return fmt.Errorf("No repository name is set")
 		}
 
-		org := testAccProvider.Meta().(*Organization)
-		conn := org.client
-		getHook, _, err := conn.Organizations.GetHook(context.TODO(), org.name, hookID)
+		owner := testAccProvider.Meta().(*Owner)
+		conn := owner.client
+		getHook, _, err := conn.Organizations.GetHook(context.TODO(), owner.name, hookID)
 		if err != nil {
 			return err
 		}
@@ -111,8 +111,8 @@ func testAccCheckGithubOrganizationWebhookAttributes(hook *github.Hook, want *te
 }
 
 func testAccCheckGithubOrganizationWebhookDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
-	orgName := testAccProvider.Meta().(*Organization).name
+	conn := testAccProvider.Meta().(*Owner).client
+	ownerName := testAccProvider.Meta().(*Owner).name
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_organization_webhook" {
@@ -124,7 +124,7 @@ func testAccCheckGithubOrganizationWebhookDestroy(s *terraform.State) error {
 			return err
 		}
 
-		gotHook, resp, err := conn.Organizations.GetHook(context.TODO(), orgName, id)
+		gotHook, resp, err := conn.Organizations.GetHook(context.TODO(), ownerName, id)
 		if err == nil {
 			if gotHook != nil && *gotHook.ID == int64(id) {
 				return fmt.Errorf("Webhook still exists")

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -194,16 +194,16 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	repoName := d.Id()
 
-	log.Printf("[DEBUG] read github repository %s/%s", meta.(*Organization).name, repoName)
-	repo, resp, err := client.Repositories.Get(context.TODO(), meta.(*Organization).name, repoName)
+	log.Printf("[DEBUG] read github repository %s/%s", meta.(*Owner).name, repoName)
+	repo, resp, err := client.Repositories.Get(context.TODO(), meta.(*Owner).name, repoName)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			log.Printf(
 				"[WARN] removing %s/%s from state because it no longer exists in github",
-				meta.(*Organization).name,
+				meta.(*Owner).name,
 				repoName,
 			)
 			d.SetId("")
@@ -267,9 +267,9 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	repoName := d.Id()
-	log.Printf("[DEBUG] delete github repository %s/%s", meta.(*Organization).name, repoName)
-	_, err := client.Repositories.Delete(context.TODO(), meta.(*Organization).name, repoName)
+	log.Printf("[DEBUG] delete github repository %s/%s", meta.(*Owner).name, repoName)
+	_, err := client.Repositories.Delete(context.TODO(), meta.(*Owner).name, repoName)
 	return err
 }

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -167,16 +167,20 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 }
 
 func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	ctx := context.TODO()
+	owner := ""
+	if meta.(*Owner).IsOrganization() {
+		owner = meta.(*Owner).name
+	}
 
 	if _, ok := d.GetOk("default_branch"); ok {
 		return fmt.Errorf("Cannot set the default branch on a new repository.")
 	}
 
 	repoReq := resourceGithubRepositoryObject(d)
-	log.Printf("[DEBUG] create github repository %s/%s", meta.(*Owner).name, *repoReq.Name)
-	repo, _, err := client.Repositories.Create(context.TODO(), meta.(*Owner).name, repoReq)
+	log.Printf("[DEBUG] create github repository %s/%s", owner, *repoReq.Name)
+	repo, _, err := client.Repositories.Create(context.TODO(), owner, repoReq)
 	if err != nil {
 		return err
 	}
@@ -184,7 +188,7 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 
 	topics := repoReq.Topics
 	if len(topics) > 0 {
-		_, _, err = client.Repositories.ReplaceAllTopics(ctx, meta.(*Organization).name, *repoReq.Name, topics)
+		_, _, err = client.Repositories.ReplaceAllTopics(ctx, owner, *repoReq.Name, topics)
 		if err != nil {
 			return err
 		}
@@ -235,7 +239,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	ctx := context.TODO()
 	repoReq := resourceGithubRepositoryObject(d)
 	// Can only set `default_branch` on an already created repository with the target branches ref already in-place
@@ -248,8 +252,8 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	repoName := d.Id()
-	log.Printf("[DEBUG] update github repository %s/%s", meta.(*Organization).name, repoName)
-	repo, _, err := client.Repositories.Edit(ctx, meta.(*Organization).name, repoName, repoReq)
+	log.Printf("[DEBUG] update github repository %s/%s", meta.(*Owner).name, repoName)
+	repo, _, err := client.Repositories.Edit(ctx, meta.(*Owner).name, repoName, repoReq)
 	if err != nil {
 		return err
 	}
@@ -257,7 +261,7 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("topics") {
 		topics := repoReq.Topics
-		_, _, err = client.Repositories.ReplaceAllTopics(ctx, meta.(*Organization).name, *repo.Name, topics)
+		_, _, err = client.Repositories.ReplaceAllTopics(ctx, meta.(*Owner).name, *repo.Name, topics)
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -175,8 +175,8 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	repoReq := resourceGithubRepositoryObject(d)
-	log.Printf("[DEBUG] create github repository %s/%s", meta.(*Organization).name, *repoReq.Name)
-	repo, _, err := client.Repositories.Create(ctx, meta.(*Organization).name, repoReq)
+	log.Printf("[DEBUG] create github repository %s/%s", meta.(*Owner).name, *repoReq.Name)
+	repo, _, err := client.Repositories.Create(context.TODO(), meta.(*Owner).name, repoReq)
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -40,12 +40,12 @@ func resourceGithubRepositoryCollaborator() *schema.Resource {
 }
 
 func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	u := d.Get("username").(string)
 	r := d.Get("repository").(string)
 	p := d.Get("permission").(string)
 
-	_, err := client.Repositories.AddCollaborator(context.TODO(), meta.(*Organization).name, r, u,
+	_, err := client.Repositories.AddCollaborator(context.TODO(), meta.(*Owner).name, r, u,
 		&github.RepositoryAddCollaboratorOptions{Permission: p})
 
 	if err != nil {
@@ -58,11 +58,11 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta int
 }
 
 func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	r, u := parseTwoPartID(d.Id())
 
 	// First, check if the user has been invited but has not yet accepted
-	invitation, err := findRepoInvitation(client, meta.(*Organization).name, r, u)
+	invitation, err := findRepoInvitation(client, meta.(*Owner).name, r, u)
 	if err != nil {
 		return err
 	} else if invitation != nil {
@@ -81,7 +81,7 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 	opt := &github.ListCollaboratorsOptions{ListOptions: github.ListOptions{PerPage: maxPerPage}}
 
 	for {
-		collaborators, resp, err := client.Repositories.ListCollaborators(context.TODO(), meta.(*Organization).name, r, opt)
+		collaborators, resp, err := client.Repositories.ListCollaborators(context.TODO(), meta.(*Owner).name, r, opt)
 		if err != nil {
 			return err
 		}
@@ -112,20 +112,20 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 }
 
 func resourceGithubRepositoryCollaboratorDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	u := d.Get("username").(string)
 	r := d.Get("repository").(string)
 
 	// Delete any pending invitations
-	invitation, err := findRepoInvitation(client, meta.(*Organization).name, r, u)
+	invitation, err := findRepoInvitation(client, meta.(*Owner).name, r, u)
 	if err != nil {
 		return err
 	} else if invitation != nil {
-		_, err = client.Repositories.DeleteInvitation(context.TODO(), meta.(*Organization).name, r, *invitation.ID)
+		_, err = client.Repositories.DeleteInvitation(context.TODO(), meta.(*Owner).name, r, *invitation.ID)
 		return err
 	}
 
-	_, err = client.Repositories.RemoveCollaborator(context.TODO(), meta.(*Organization).name, r, u)
+	_, err = client.Repositories.RemoveCollaborator(context.TODO(), meta.(*Owner).name, r, u)
 	return err
 }
 

--- a/github/resource_github_repository_collaborator_test.go
+++ b/github/resource_github_repository_collaborator_test.go
@@ -52,14 +52,14 @@ func TestAccGithubRepositoryCollaborator_importBasic(t *testing.T) {
 }
 
 func testAccCheckGithubRepositoryCollaboratorDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Owner).client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository_collaborator" {
 			continue
 		}
 
-		o := testAccProvider.Meta().(*Organization).name
+		o := testAccProvider.Meta().(*Owner).name
 		r, u := parseTwoPartID(rs.Primary.ID)
 		isCollaborator, _, err := conn.Repositories.IsCollaborator(context.TODO(), o, r, u)
 
@@ -88,8 +88,8 @@ func testAccCheckGithubRepositoryCollaboratorExists(n string) resource.TestCheck
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
-		o := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).client
+		o := testAccProvider.Meta().(*Owner).name
 		r, u := parseTwoPartID(rs.Primary.ID)
 
 		invitations, _, err := conn.Repositories.ListInvitations(context.TODO(), o, r, nil)
@@ -124,8 +124,8 @@ func testAccCheckGithubRepositoryCollaboratorPermission(n string) resource.TestC
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
-		o := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).client
+		o := testAccProvider.Meta().(*Owner).name
 		r, u := parseTwoPartID(rs.Primary.ID)
 
 		invitations, _, err := conn.Repositories.ListInvitations(context.TODO(), o, r, nil)

--- a/github/resource_github_repository_deploy_key.go
+++ b/github/resource_github_repository_deploy_key.go
@@ -45,7 +45,7 @@ func resourceGithubRepositoryDeployKey() *schema.Resource {
 }
 
 func resourceGithubRepositoryDeployKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 
 	repo := d.Get("repository").(string)
 
@@ -58,7 +58,7 @@ func resourceGithubRepositoryDeployKeyCreate(d *schema.ResourceData, meta interf
 		ReadOnly: &r,
 	}
 
-	owner := meta.(*Organization).name
+	owner := meta.(*Owner).name
 	resultKey, _, err := client.Repositories.CreateKey(context.TODO(), owner, repo, key)
 
 	if err != nil {
@@ -74,9 +74,9 @@ func resourceGithubRepositoryDeployKeyCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceGithubRepositoryDeployKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 
-	owner := meta.(*Organization).name
+	owner := meta.(*Owner).name
 	repo, id := parseTwoPartID(d.Id())
 
 	i, err := strconv.ParseInt(id, 10, 64)
@@ -98,9 +98,9 @@ func resourceGithubRepositoryDeployKeyRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceGithubRepositoryDeployKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 
-	owner := meta.(*Organization).name
+	owner := meta.(*Owner).name
 	repo, id := parseTwoPartID(d.Id())
 
 	i, err := strconv.ParseInt(id, 10, 64)

--- a/github/resource_github_repository_deploy_key_test.go
+++ b/github/resource_github_repository_deploy_key_test.go
@@ -54,14 +54,14 @@ func TestAccGithubRepositoryDeployKey_importBasic(t *testing.T) {
 }
 
 func testAccCheckGithubRepositoryDeployKeyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Owner).client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository_deploy_key" {
 			continue
 		}
 
-		o := testAccProvider.Meta().(*Organization).name
+		o := testAccProvider.Meta().(*Owner).name
 		r, i := parseTwoPartID(rs.Primary.ID)
 		id, err := strconv.ParseInt(i, 10, 64)
 		if err != nil {
@@ -90,8 +90,8 @@ func testAccCheckGithubRepositoryDeployKeyExists(n string) resource.TestCheckFun
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
-		o := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).client
+		o := testAccProvider.Meta().(*Owner).name
 		r, i := parseTwoPartID(rs.Primary.ID)
 		id, err := strconv.ParseInt(i, 10, 64)
 		if err != nil {

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -28,9 +28,9 @@ func testSweepRepositories(region string) error {
 		return err
 	}
 
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 
-	repos, _, err := client.Repositories.List(context.TODO(), meta.(*Organization).name, nil)
+	repos, _, err := client.Repositories.List(context.TODO(), meta.(*Owner).name, nil)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func testSweepRepositories(region string) error {
 		if strings.HasPrefix(*r.Name, "tf-acc-") || strings.HasPrefix(*r.Name, "foo-") {
 			log.Printf("Destroying Repository %s", *r.Name)
 
-			if _, err := client.Repositories.Delete(context.TODO(), meta.(*Organization).name, *r.Name); err != nil {
+			if _, err := client.Repositories.Delete(context.TODO(), meta.(*Owner).name, *r.Name); err != nil {
 				return err
 			}
 		}
@@ -383,9 +383,9 @@ func testAccCheckGithubRepositoryExists(n string, repo *github.Repository) resou
 			return fmt.Errorf("No repository name is set")
 		}
 
-		org := testAccProvider.Meta().(*Organization)
-		conn := org.client
-		gotRepo, _, err := conn.Repositories.Get(context.TODO(), org.name, repoName)
+		owner := testAccProvider.Meta().(*Owner)
+		conn := owner.client
+		gotRepo, _, err := conn.Repositories.Get(context.TODO(), owner.name, repoName)
 		if err != nil {
 			return err
 		}
@@ -515,18 +515,18 @@ func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testA
 }
 
 func testAccCheckGithubRepositoryDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
-	orgName := testAccProvider.Meta().(*Organization).name
+	conn := testAccProvider.Meta().(*Owner).client
+	ownerName := testAccProvider.Meta().(*Owner).name
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository" {
 			continue
 		}
 
-		gotRepo, resp, err := conn.Repositories.Get(context.TODO(), orgName, rs.Primary.ID)
+		gotRepo, resp, err := conn.Repositories.Get(context.TODO(), ownerName, rs.Primary.ID)
 		if err == nil {
 			if gotRepo != nil && *gotRepo.Name == rs.Primary.ID {
-				return fmt.Errorf("Repository %s/%s still exists", orgName, *gotRepo.Name)
+				return fmt.Errorf("Repository %s/%s still exists", ownerName, *gotRepo.Name)
 			}
 		}
 		if resp.StatusCode != 404 {
@@ -538,21 +538,21 @@ func testAccCheckGithubRepositoryDestroy(s *terraform.State) error {
 }
 
 func testAccCreateRepositoryBranch(branch, repository string) error {
-	org := os.Getenv("GITHUB_ORGANIZATION")
+	owner := os.Getenv("GITHUB_OWNER")
 	token := os.Getenv("GITHUB_TOKEN")
 
 	config := Config{
-		Token:        token,
-		Organization: org,
+		Token: token,
+		Owner: owner,
 	}
 
 	c, err := config.Client()
 	if err != nil {
 		panic(fmt.Sprintf("Error creating github client: %s", err))
 	}
-	client := c.(*Organization).client
+	client := c.(*Owner).client
 
-	refs, _, err := client.Git.GetRefs(context.TODO(), org, repository, "heads")
+	refs, _, err := client.Git.GetRefs(context.TODO(), owner, repository, "heads")
 	if err != nil {
 		panic(fmt.Sprintf("Error getting reference commit: %s", err))
 	}
@@ -565,7 +565,7 @@ func testAccCreateRepositoryBranch(branch, repository string) error {
 		},
 	}
 
-	_, _, err = client.Git.CreateRef(context.TODO(), org, repository, newRef)
+	_, _, err = client.Git.CreateRef(context.TODO(), owner, repository, newRef)
 	if err != nil {
 		panic(fmt.Sprintf("Error creating git reference: %s", err))
 	}

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -84,10 +84,10 @@ func resourceGithubRepositoryWebhookObject(d *schema.ResourceData) *github.Hook 
 }
 
 func resourceGithubRepositoryWebhookCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	hk := resourceGithubRepositoryWebhookObject(d)
 
-	hook, _, err := client.Repositories.CreateHook(context.TODO(), meta.(*Organization).name, d.Get("repository").(string), hk)
+	hook, _, err := client.Repositories.CreateHook(context.TODO(), meta.(*Owner).name, d.Get("repository").(string), hk)
 	if err != nil {
 		return err
 	}
@@ -97,13 +97,13 @@ func resourceGithubRepositoryWebhookCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	hook, resp, err := client.Repositories.GetHook(context.TODO(), meta.(*Organization).name, d.Get("repository").(string), hookID)
+	hook, resp, err := client.Repositories.GetHook(context.TODO(), meta.(*Owner).name, d.Get("repository").(string), hookID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
@@ -121,14 +121,14 @@ func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceGithubRepositoryWebhookUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	hk := resourceGithubRepositoryWebhookObject(d)
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = client.Repositories.EditHook(context.TODO(), meta.(*Organization).name, d.Get("repository").(string), hookID, hk)
+	_, _, err = client.Repositories.EditHook(context.TODO(), meta.(*Owner).name, d.Get("repository").(string), hookID, hk)
 	if err != nil {
 		return err
 	}
@@ -137,12 +137,12 @@ func resourceGithubRepositoryWebhookUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceGithubRepositoryWebhookDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	_, err = client.Repositories.DeleteHook(context.TODO(), meta.(*Organization).name, d.Get("repository").(string), hookID)
+	_, err = client.Repositories.DeleteHook(context.TODO(), meta.(*Owner).name, d.Get("repository").(string), hookID)
 	return err
 }

--- a/github/resource_github_repository_webhook_test.go
+++ b/github/resource_github_repository_webhook_test.go
@@ -92,9 +92,9 @@ func testAccCheckGithubRepositoryWebhookExists(n string, repoName string, hook *
 			return fmt.Errorf("No repository name is set")
 		}
 
-		org := testAccProvider.Meta().(*Organization)
-		conn := org.client
-		getHook, _, err := conn.Repositories.GetHook(context.TODO(), org.name, repoName, hookID)
+		owner := testAccProvider.Meta().(*Owner)
+		conn := owner.client
+		getHook, _, err := conn.Repositories.GetHook(context.TODO(), owner.name, repoName, hookID)
 		if err != nil {
 			return err
 		}
@@ -134,8 +134,8 @@ func testAccCheckGithubRepositoryWebhookAttributes(hook *github.Hook, want *test
 }
 
 func testAccCheckGithubRepositoryWebhookDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
-	orgName := testAccProvider.Meta().(*Organization).name
+	conn := testAccProvider.Meta().(*Owner).client
+	ownerName := testAccProvider.Meta().(*Owner).name
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository_webhook" {
@@ -147,7 +147,7 @@ func testAccCheckGithubRepositoryWebhookDestroy(s *terraform.State) error {
 			return err
 		}
 
-		gotHook, resp, err := conn.Repositories.GetHook(context.TODO(), orgName, rs.Primary.Attributes["repository"], id)
+		gotHook, resp, err := conn.Repositories.GetHook(context.TODO(), ownerName, rs.Primary.Attributes["repository"], id)
 		if err == nil {
 			if gotHook != nil && *gotHook.ID == id {
 				return fmt.Errorf("Webhook still exists")

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -46,7 +46,7 @@ func resourceGithubTeam() *schema.Resource {
 }
 
 func resourceGithubTeamCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	n := d.Get("name").(string)
 	desc := d.Get("description").(string)
 	p := d.Get("privacy").(string)
@@ -61,7 +61,7 @@ func resourceGithubTeamCreate(d *schema.ResourceData, meta interface{}) error {
 		newTeam.ParentTeamID = &id
 	}
 
-	githubTeam, _, err := client.Organizations.CreateTeam(context.TODO(), meta.(*Organization).name, newTeam)
+	githubTeam, _, err := client.Organizations.CreateTeam(context.TODO(), meta.(*Owner).name, newTeam)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func resourceGithubTeamCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 
 	team, err := getGithubTeam(d, client)
 	if err != nil {
@@ -101,7 +101,7 @@ func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGithubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	team, err := getGithubTeam(d, client)
 
 	if err != nil {
@@ -144,7 +144,7 @@ func resourceGithubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGithubTeamDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	id := toGithubID(d.Id())
 	_, err := client.Organizations.DeleteTeam(context.TODO(), id)
 	return err

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -42,7 +42,7 @@ func resourceGithubTeamMembership() *schema.Resource {
 }
 
 func resourceGithubTeamMembershipCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	t := d.Get("team_id").(string)
 	n := d.Get("username").(string)
 	r := d.Get("role").(string)
@@ -60,7 +60,7 @@ func resourceGithubTeamMembershipCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	t, n := parseTwoPartID(d.Id())
 
 	membership, _, err := client.Organizations.GetTeamMembership(context.TODO(), toGithubID(t), n)
@@ -78,7 +78,7 @@ func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceGithubTeamMembershipDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	t := d.Get("team_id").(string)
 	n := d.Get("username").(string)
 

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -77,7 +77,7 @@ func TestAccGithubTeamMembership_importBasic(t *testing.T) {
 }
 
 func testAccCheckGithubTeamMembershipDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Owner).client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team_membership" {
@@ -110,7 +110,7 @@ func testAccCheckGithubTeamMembershipExists(n string, membership *github.Members
 			return fmt.Errorf("No team membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Owner).client
 		t, u := parseTwoPartID(rs.Primary.ID)
 
 		teamMembership, _, err := conn.Organizations.GetTeamMembership(context.TODO(), toGithubID(t), u)
@@ -134,7 +134,7 @@ func testAccCheckGithubTeamMembershipRoleState(n, expected string, membership *g
 			return fmt.Errorf("No team membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Owner).client
 		t, u := parseTwoPartID(rs.Primary.ID)
 
 		teamMembership, _, err := conn.Organizations.GetTeamMembership(context.TODO(), toGithubID(t), u)

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -39,12 +39,12 @@ func resourceGithubTeamRepository() *schema.Resource {
 }
 
 func resourceGithubTeamRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	t := d.Get("team_id").(string)
 	r := d.Get("repository").(string)
 	p := d.Get("permission").(string)
 
-	_, err := client.Organizations.AddTeamRepo(context.TODO(), toGithubID(t), meta.(*Organization).name, r,
+	_, err := client.Organizations.AddTeamRepo(context.TODO(), toGithubID(t), meta.(*Owner).name, r,
 		&github.OrganizationAddTeamRepoOptions{Permission: p})
 
 	if err != nil {
@@ -57,10 +57,10 @@ func resourceGithubTeamRepositoryCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	t, r := parseTwoPartID(d.Id())
 
-	repo, _, repoErr := client.Organizations.IsTeamRepo(context.TODO(), toGithubID(t), meta.(*Organization).name, r)
+	repo, _, repoErr := client.Organizations.IsTeamRepo(context.TODO(), toGithubID(t), meta.(*Owner).name, r)
 
 	if repoErr != nil {
 		d.SetId("")
@@ -84,13 +84,13 @@ func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceGithubTeamRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	t := d.Get("team_id").(string)
 	r := d.Get("repository").(string)
 	p := d.Get("permission").(string)
 
 	// the go-github library's AddTeamRepo method uses the add/update endpoint from Github API
-	_, err := client.Organizations.AddTeamRepo(context.TODO(), toGithubID(t), meta.(*Organization).name, r,
+	_, err := client.Organizations.AddTeamRepo(context.TODO(), toGithubID(t), meta.(*Owner).name, r,
 		&github.OrganizationAddTeamRepoOptions{Permission: p})
 
 	if err != nil {
@@ -102,11 +102,11 @@ func resourceGithubTeamRepositoryUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGithubTeamRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Owner).client
 	t := d.Get("team_id").(string)
 	r := d.Get("repository").(string)
 
-	_, err := client.Organizations.RemoveTeamRepo(context.TODO(), toGithubID(t), meta.(*Organization).name, r)
+	_, err := client.Organizations.RemoveTeamRepo(context.TODO(), toGithubID(t), meta.(*Owner).name, r)
 
 	return err
 }

--- a/github/resource_github_team_repository_test.go
+++ b/github/resource_github_team_repository_test.go
@@ -113,12 +113,12 @@ func testAccCheckGithubTeamRepositoryExists(n string, repository *github.Reposit
 			return fmt.Errorf("No team repository ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Owner).client
 		t, r := parseTwoPartID(rs.Primary.ID)
 
 		repo, _, err := conn.Organizations.IsTeamRepo(context.TODO(),
 			toGithubID(t),
-			testAccProvider.Meta().(*Organization).name, r)
+			testAccProvider.Meta().(*Owner).name, r)
 
 		if err != nil {
 			return err
@@ -129,7 +129,7 @@ func testAccCheckGithubTeamRepositoryExists(n string, repository *github.Reposit
 }
 
 func testAccCheckGithubTeamRepositoryDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Owner).client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team_repository" {
@@ -139,7 +139,7 @@ func testAccCheckGithubTeamRepositoryDestroy(s *terraform.State) error {
 
 		repo, resp, err := conn.Organizations.IsTeamRepo(context.TODO(),
 			toGithubID(t),
-			testAccProvider.Meta().(*Organization).name, r)
+			testAccProvider.Meta().(*Owner).name, r)
 
 		if err == nil {
 			if repo != nil &&

--- a/github/resource_github_team_test.go
+++ b/github/resource_github_team_test.go
@@ -95,7 +95,7 @@ func testAccCheckGithubTeamExists(n string, team *github.Team) resource.TestChec
 			return fmt.Errorf("No Team ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Owner).client
 		githubTeam, _, err := conn.Organizations.GetTeam(context.TODO(), toGithubID(rs.Primary.ID))
 		if err != nil {
 			return err
@@ -128,7 +128,7 @@ func testAccCheckGithubTeamAttributes(team *github.Team, name, description strin
 }
 
 func testAccCheckGithubTeamDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Owner).client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team" {

--- a/github/sweeper_test.go
+++ b/github/sweeper_test.go
@@ -17,14 +17,14 @@ func sharedConfigForRegion(region string) (interface{}, error) {
 		return nil, fmt.Errorf("empty GITHUB_TOKEN")
 	}
 
-	if os.Getenv("GITHUB_ORGANIZATION") == "" {
-		return nil, fmt.Errorf("empty GITHUB_ORGANIZATION")
+	if os.Getenv("GITHUB_OWNER") == "" {
+		return nil, fmt.Errorf("empty GITHUB_OWNER")
 	}
 
 	config := Config{
-		Token:        os.Getenv("GITHUB_TOKEN"),
-		Organization: os.Getenv("GITHUB_ORGANIZATION"),
-		BaseURL:      "",
+		Token:   os.Getenv("GITHUB_TOKEN"),
+		Owner:   os.Getenv("GITHUB_OWNER"),
+		BaseURL: "",
 	}
 
 	client, err := config.Client()

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,9 +37,13 @@ The following arguments are supported in the `provider` block:
 * `token` - (Required) This is the GitHub personal access token. It must be provided, but
   it can also be sourced from the `GITHUB_TOKEN` environment variable.
 
-* `owner` - (Required) This is the target GitHub organization or a user to manage. The account
+* `owner` - (Optional) This is the target GitHub organization or a user to manage. The account
   corresponding to the token will need "owner" privileges for this organization. It must be provided, but
   it can also be sourced from the `GITHUB_OWNER` environment variable.
+
+* `organization` - (DEPRICATED) This is the target GitHub organization or a user to manage. The account
+  corresponding to the token will need "organization" privileges for this organization. It must be provided, but
+  it can also be sourced from the `GITHUB_ORGANIZATION` environment variable.
 
 * `base_url` - (Optional) This is the target GitHub base API endpoint. Providing a value is a
   requirement when working with GitHub Enterprise.  It is optional to provide this value and

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -3,12 +3,12 @@ layout: "github"
 page_title: "Provider: GitHub"
 sidebar_current: "docs-github-index"
 description: |-
-  The GitHub provider is used to interact with GitHub organization resources.
+  The GitHub provider is used to interact with GitHub resources.
 ---
 
 # GitHub Provider
 
-The GitHub provider is used to interact with GitHub organization resources.
+The GitHub provider is used to interact with GitHub resources.
 
 The provider allows you to manage your GitHub organization's members and teams easily.
 It needs to be configured with the proper credentials before it can be used.
@@ -20,8 +20,8 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Configure the GitHub Provider
 provider "github" {
-  token        = "${var.github_token}"
-  organization = "${var.github_organization}"
+  token = "${var.github_token}"
+  owner = "${var.github_owner}"
 }
 
 # Add a user to the organization
@@ -34,12 +34,12 @@ resource "github_membership" "membership_for_user_x" {
 
 The following arguments are supported in the `provider` block:
 
-* `token` - (Optional) This is the GitHub personal access token. It must be provided, but
+* `token` - (Required) This is the GitHub personal access token. It must be provided, but
   it can also be sourced from the `GITHUB_TOKEN` environment variable.
 
-* `organization` - (Optional) This is the target GitHub organization to manage. The account
+* `owner` - (Required) This is the target GitHub organization or a user to manage. The account
   corresponding to the token will need "owner" privileges for this organization. It must be provided, but
-  it can also be sourced from the `GITHUB_ORGANIZATION` environment variable.
+  it can also be sourced from the `GITHUB_OWNER` environment variable.
 
 * `base_url` - (Optional) This is the target GitHub base API endpoint. Providing a value is a
   requirement when working with GitHub Enterprise.  It is optional to provide this value and


### PR DESCRIPTION
Fixed the ambiguity regarding the owner parameter name when calling the go-github api and added the possibility for the individual accounts to create repositories.

Here is the 404 error when an individual account tries to create a repository.

Github REST Api resource `/orgs/eliaszs/repos` doesn't exist for user's account.

```
$ TF_LOG=DEBUG terraform apply -target module.github -auto-approve

...

Error: Error applying plan:

1 error(s) occurred:

* module.github.github_repository.hello-stocks: 1 error(s) occurred:

* github_repository.hello-stocks: POST https://api.github.com/orgs/eliaszs/repos: 404 Not Found []
```

The PR is only breaking the compatibility with the env variable name. The `organization` structure has been renamed to `owner` together with the GITHUB_ORGANIZATION -> GITHUB_OWNER. It is now compatible with the go-github api in the most cases. 

According to the spec of this function the `org string` argument is really an owner and not the organization, as it is used in other function across go-github library.

Here is the ambiguous case for the `Create` and below is the correct one for the `Get` function in the go-github library.
```
// Create a new repository. If an organization is specified, the new
// repository will be created under that org. If the empty string is
// specified, it will be created for the authenticated user.
//
// GitHub API docs: https://developer.github.com/v3/repos/#create
func (s *RepositoriesService) Create(ctx context.Context, org string, repo *Repository) (*Repository, *Response, error) {
...
}
```

```
// Get fetches a repository.
//
// GitHub API docs: https://developer.github.com/v3/repos/#get
func (s *RepositoriesService) Get(ctx context.Context, owner, repo string) (*Repository, *Response, error) {
```

Fixes #45 