### PR TITLE
data-source/github_ip_ranges: Add importer IPs

### DIFF
--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -24,8 +24,11 @@ func dataSourceGithubIpRanges() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			// TODO: importer IPs coming once this is merged
-			// https://github.com/google/go-github/pull/881
+			"importer": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -38,7 +41,7 @@ func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if len(api.Hooks)+len(api.Git)+len(api.Pages) > 0 {
+	if len(api.Hooks)+len(api.Git)+len(api.Pages)+len(api.Importer) > 0 {
 		d.SetId("github-ip-ranges")
 	}
 	if len(api.Hooks) > 0 {
@@ -49,6 +52,9 @@ func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	if len(api.Pages) > 0 {
 		d.Set("pages", api.Pages)
+	}
+	if len(api.Importer) > 0 {
+		d.Set("importer", api.Importer)
 	}
 
 	return nil

--- a/github/data_source_github_ip_ranges_test.go
+++ b/github/data_source_github_ip_ranges_test.go
@@ -21,6 +21,7 @@ func TestAccGithubIpRangesDataSource_existing(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "hooks.#"),
 					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "git.#"),
 					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages.#"),
+					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "importer.#"),
 				),
 			},
 		},

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -20,3 +20,4 @@ data "github_ip_ranges" "test" {}
  * `hooks` - An Array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from.
  * `git` - An Array of IP addresses in CIDR format specifying the Git servers.
  * `pages` - An Array of IP addresses in CIDR format specifying the A records for GitHub Pages.
+ * `importer` - An Array of IP addresses in CIDR format specifying the A records for GitHub Importer.


### PR DESCRIPTION
I'm adding the importer IP addresses since [https://github.com/google/go-github/pull/881](https://github.com/google/go-github/pull/881) was merged.