### PR TITLE
Add maintainers to resource_github_team.go

### DIFF
--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -41,6 +41,11 @@ func resourceGithubTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"maintainers": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
 		},
 	}
 }
@@ -50,11 +55,13 @@ func resourceGithubTeamCreate(d *schema.ResourceData, meta interface{}) error {
 	n := d.Get("name").(string)
 	desc := d.Get("description").(string)
 	p := d.Get("privacy").(string)
+	m := expandStringList(d.Get("maintainers").([]interface{}))
 
 	newTeam := &github.NewTeam{
 		Name:        n,
 		Description: &desc,
 		Privacy:     &p,
+		Maintainers: m,
 	}
 	if parentTeamID, ok := d.GetOk("parent_team_id"); ok {
 		id := int64(parentTeamID.(int))
@@ -112,11 +119,13 @@ func resourceGithubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
 	privacy := d.Get("privacy").(string)
+	maintainers := expandStringList(d.Get("maintainers").([]interface{}))
 
 	editedTeam := &github.NewTeam{
 		Name:        name,
 		Description: &description,
 		Privacy:     &privacy,
+		Maintainers: maintainers,
 	}
 	if parentTeamID, ok := d.GetOk("parent_team_id"); ok {
 		id := int64(parentTeamID.(int))

--- a/github/resource_github_team_test.go
+++ b/github/resource_github_team_test.go
@@ -156,6 +156,7 @@ resource "github_team" "foo" {
 	name = "tf-acc-test-%s"
 	description = "Terraform acc test group"
 	privacy = "secret"
+	maintainers = ["bar"]
 }
 `, randString)
 }

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -34,6 +34,8 @@ The following arguments are supported:
                Defaults to `secret`.
 * `parent_team_id` - (Optional) The ID of the parent team, if this is a nested team.
 * `ldap_dn` - (Optional) The LDAP Distinguished Name of the group where membership will be synchronized. Only available in GitHub Enterprise.
+* `maintainers` - (Optional) The logins of organization members to add as maintainers of the team.
+                   Defaults to `[]` (an empty list)
 
 ## Attributes Reference
 


### PR DESCRIPTION
In case not using Admin account/token, the newly created `team` resource is created with 0 members, not allowing the service account / user account to proceed and add members, sub-teams or repos.