### PR TITLE
Correct the intercapping of "GitHub"

### DIFF
--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -3,12 +3,12 @@ layout: "github"
 page_title: "Github: github_ip_ranges"
 sidebar_current: "docs-github-datasource-ip-ranges"
 description: |-
-  Get information on a Github's IP addresses.
+  Get information on a GitHub's IP addresses.
 ---
 
 # github_ip_ranges
 
-Use this data source to retrieve information about a Github's IP addresses.
+Use this data source to retrieve information about a GitHub's IP addresses.
 ## Example Usage
 
 ```

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "github"
-page_title: "Github: github_team"
+page_title: "GitHub: github_team"
 sidebar_current: "docs-github-datasource-team"
 description: |-
-  Get information on a Github team.
+  Get information on a GitHub team.
 ---
 
 # github\_team
 
-Use this data source to retrieve information about a Github team.
+Use this data source to retrieve information about a GitHub team.
 
 ## Example Usage
 

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "github"
-page_title: "Github: github_user"
+page_title: "GitHub: github_user"
 sidebar_current: "docs-github-datasource-user"
 description: |-
-  Get information on a Github user.
+  Get information on a GitHub user.
 ---
 
 # github\_user
 
-Use this data source to retrieve information about a Github user.
+Use this data source to retrieve information about a GitHub user.
 
 ## Example Usage
 
@@ -27,7 +27,7 @@ data "github_user" "example" {
  * `login` - the user's login.
  * `avatar_url` - the user's avatar URL.
  * `gravatar_id` - the user's gravatar ID.
- * `site_admin` - whether the user is a Github admin.
+ * `site_admin` - whether the user is a GitHub admin.
  * `name` - the user's full name.
  * `company` - the user's company name.
  * `blog` - the user's blog location.

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 ## Import
 
-Github Branch Protection can be imported using an id made up of `repository:branch`, e.g.
+GitHub Branch Protection can be imported using an id made up of `repository:branch`, e.g.
 
 ```
 $ terraform import github_branch_protection.terraform terraform:master

--- a/website/docs/r/issue_label.html.markdown
+++ b/website/docs/r/issue_label.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides a GitHub issue label resource.
 
 This resource allows you to create and manage issue labels within your
-Github organization.
+GitHub organization.
 
 Issue labels are keyed off of their "name", so pre-existing issue labels result
 in a 422 HTTP error if they exist outside of Terraform. Normally this would not
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 ## Import
 
-Github Issue Labels can be imported using an id made up of `repository:name`, e.g.
+GitHub Issue Labels can be imported using an id made up of `repository:name`, e.g.
 
 ```
 $ terraform import github_issue_label.panic_label terraform:panic

--- a/website/docs/r/membership.html.markdown
+++ b/website/docs/r/membership.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 ## Import
 
-Github Membership can be imported using an id made up of `organization:username`, e.g.
+GitHub Membership can be imported using an id made up of `organization:username`, e.g.
 
 ```
 $ terraform import github_membership.member hashicorp:someuser

--- a/website/docs/r/organization_webhook.html.markdown
+++ b/website/docs/r/organization_webhook.html.markdown
@@ -3,12 +3,12 @@ layout: "github"
 page_title: "GitHub: github_organization_webhook"
 sidebar_current: "docs-github-resource-organization-webhook"
 description: |-
-  Creates and manages webhooks for Github organizations
+  Creates and manages webhooks for GitHub organizations
 ---
 
 # github_organization_webhook
 
-This resource allows you to create and manage webhooks for Github organization.
+This resource allows you to create and manage webhooks for GitHub organization.
 
 ## Example Usage
 

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -3,13 +3,13 @@ layout: "github"
 page_title: "GitHub: github_repository"
 sidebar_current: "docs-github-resource-repository"
 description: |-
-  Creates and manages repositories within Github organizations
+  Creates and manages repositories within GitHub organizations
 ---
 
 # github_repository
 
 This resource allows you to create and manage repositories within your
-Github organization.
+GitHub organization.
 
 This resource cannot currently be used to manage *personal* repositories,
 outside of organizations.
@@ -38,12 +38,12 @@ The following arguments are supported:
 * `private` - (Optional) Set to `true` to create a private repository.
   Repositories are created as public (e.g. open source) by default.
 
-* `has_issues` - (Optional) Set to `true` to enable the Github Issues features
+* `has_issues` - (Optional) Set to `true` to enable the GitHub Issues features
   on the repository.
 
-* `has_projects` - (Optional) Set to `true` to enable the Github Projects features on the repository. Per the github [documentation](https://developer.github.com/v3/repos/#create) when in an organization that has disabled repository projects it will default to `false` and will otherwise default to `true`. If you specify `true` when it has been disabled it will return an error.
+* `has_projects` - (Optional) Set to `true` to enable the GitHub Projects features on the repository. Per the github [documentation](https://developer.github.com/v3/repos/#create) when in an organization that has disabled repository projects it will default to `false` and will otherwise default to `true`. If you specify `true` when it has been disabled it will return an error.
 
-* `has_wiki` - (Optional) Set to `true` to enable the Github Wiki features on
+* `has_wiki` - (Optional) Set to `true` to enable the GitHub Wiki features on
   the repository.
 
 * `allow_merge_commit` - (Optional) Set to `false` to disable merge commits on the repository.
@@ -88,7 +88,7 @@ The following additional attributes are exported:
   repository anonymously via the git protocol.
 
 * `svn_url` - URL that can be provided to `svn checkout` to check out
-  the repository via Github's Subversion protocol emulation.
+  the repository via GitHub's Subversion protocol emulation.
 
 
 ## Import

--- a/website/docs/r/repository_collaborator.html.markdown
+++ b/website/docs/r/repository_collaborator.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 ## Import
 
-Github Repository Collaborators can be imported using an id made up of `repository:username`, e.g.
+GitHub Repository Collaborators can be imported using an id made up of `repository:username`, e.g.
 
 ```
 $ terraform import github_repository_collaborator.collaborator terraform:someuser

--- a/website/docs/r/repository_deploy_key.html.markdown
+++ b/website/docs/r/repository_deploy_key.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `key` - (Required) A ssh key.
 * `read_only` - (Required) A boolean qualifying the key to be either read only or read/write.
-* `repository` - (Required) Name of the Github repository.
+* `repository` - (Required) Name of the GitHub repository.
 * `title` - (Required) A title.
 
 Changing any of the fields forces re-creating the resource.
@@ -45,7 +45,7 @@ Changing any of the fields forces re-creating the resource.
 ## Import
 
 Repository deploy keys can be imported using a colon-separated pair of repository name
-and Github's key id. The latter can be obtained by Github's SDKs and API.
+and GitHub's key id. The latter can be obtained by GitHub's SDKs and API.
 
 ```
 $ terraform import github_repository_deploy_key.foo test-repo:23824728

--- a/website/docs/r/repository_webhook.html.markdown
+++ b/website/docs/r/repository_webhook.html.markdown
@@ -3,13 +3,13 @@ layout: "github"
 page_title: "GitHub: github_repository_webhook"
 sidebar_current: "docs-github-resource-repository-webhook"
 description: |-
-  Creates and manages repository webhooks within Github organizations
+  Creates and manages repository webhooks within GitHub organizations
 ---
 
 # github_repository_webhook
 
 This resource allows you to create and manage webhooks for repositories within your
-Github organization.
+GitHub organization.
 
 This resource cannot currently be used to manage webhooks for *personal* repositories,
 outside of organizations.

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -43,7 +43,7 @@ The following attributes are exported:
 
 ## Import
 
-Github Teams can be imported using the github team Id e.g.
+GitHub Teams can be imported using the github team Id e.g.
 
 ```
 $ terraform import github_team.core 1234567

--- a/website/docs/r/team_membership.html.markdown
+++ b/website/docs/r/team_membership.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 ## Import
 
-Github Team Membership can be imported using an id made up of `teamid:username`, e.g.
+GitHub Team Membership can be imported using an id made up of `teamid:username`, e.g.
 
 ```
 $ terraform import github_team_membership.member 1234567:someuser

--- a/website/docs/r/team_repository.html.markdown
+++ b/website/docs/r/team_repository.html.markdown
@@ -9,13 +9,13 @@ description: |-
 # github_team_repository
 
 This resource manages relationships between teams and repositories
-in your Github organization.
+in your GitHub organization.
 
 Creating this resource grants a particular team permissions on a
 particular repository.
 
 The repository and the team must both belong to the same organization
-on Github. This resource does not actually *create* any repositories;
+on GitHub. This resource does not actually *create* any repositories;
 to do that, see [`github_repository`](repository.html).
 
 ## Example Usage
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 ## Import
 
-Github Team Membership can be imported using an id made up of `teamid:repository`, e.g.
+GitHub Team Membership can be imported using an id made up of `teamid:repository`, e.g.
 
 ```
 $ terraform import github_team_repository.terraform_repo 1234567:terraform


### PR DESCRIPTION
I just did the public-facing docs; correcting the internal names would be a more invasive change for questionable benefits.