### PR TITLE
test/github_repository: Remove panics

### DIFF
--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -548,13 +548,13 @@ func testAccCreateRepositoryBranch(branch, repository string) error {
 
 	c, err := config.Client()
 	if err != nil {
-		panic(fmt.Sprintf("Error creating github client: %s", err))
+		return fmt.Errorf("Error creating github client: %s", err)
 	}
 	client := c.(*Organization).client
 
 	refs, _, err := client.Git.GetRefs(context.TODO(), org, repository, "heads")
 	if err != nil {
-		panic(fmt.Sprintf("Error getting reference commit: %s", err))
+		return fmt.Errorf("Error getting reference commit: %s", err)
 	}
 	ref := refs[0]
 
@@ -567,7 +567,7 @@ func testAccCreateRepositoryBranch(branch, repository string) error {
 
 	_, _, err = client.Git.CreateRef(context.TODO(), org, repository, newRef)
 	if err != nil {
-		panic(fmt.Sprintf("Error creating git reference: %s", err))
+		return fmt.Errorf("Error creating git reference: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
There is no reason for the provider to panic when we can return error and shut down gracefully.

This was discovered in one of our regular test runs:

```
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccGithubRepository_defaultBranch
--- FAIL: TestAccGithubRepository_defaultBranch (2.37s)

------- Stderr: -------
panic: Error creating git reference: POST https://api.github.com/repos/terraformtesting/tf-acc-test-go4a34ivsr/git/refs: 409 Git Repository is empty. [] [recovered]
	panic: Error creating git reference: POST https://api.github.com/repos/terraformtesting/tf-acc-test-go4a34ivsr/git/refs: 409 Git Repository is empty. []

goroutine 6 [running]:
testing.tRunner.func1(0xc42029d3b0)
	/usr/local/go/src/testing/testing.go:711 +0x2d2
panic(0xccf420, 0xc4202624f0)
	/usr/local/go/src/runtime/panic.go:491 +0x283
github.com/terraform-providers/terraform-provider-github/github.testAccCreateRepositoryBranch(0xe40200, 0x3, 0xc42021c5e0, 0x16, 0xc42038aee0, 0x0)
	/opt/teamcity-agent/work/7166d11ca1298d/src/github.com/terraform-providers/terraform-provider-github/github/resource_github_repository_test.go:570 +0x4ca
github.com/terraform-providers/terraform-provider-github/github.TestAccGithubRepository_defaultBranch.func2()
	/opt/teamcity-agent/work/7166d11ca1298d/src/github.com/terraform-providers/terraform-provider-github/github/resource_github_repository_test.go:243 +0x4f
github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/resource.testModule(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/opt/teamcity-agent/work/7166d11ca1298d/src/github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/resource/testing.go:741 +0x751
github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/resource.testStep(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/opt/teamcity-agent/work/7166d11ca1298d/src/github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go:24 +0xce
github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/resource.testStepConfig(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/opt/teamcity-agent/work/7166d11ca1298d/src/github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go:17 +0x98
github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/resource.Test(0x141d6e0, 0xc42029d3b0, 0x0, 0xc420229540, 0xc4201e4e70, 0x0, 0x0, 0xe7bfa8, 0xc4200a4f20, 0x2, ...)
	/opt/teamcity-agent/work/7166d11ca1298d/src/github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/resource/testing.go:492 +0x1439
github.com/terraform-providers/terraform-provider-github/github.TestAccGithubRepository_defaultBranch(0xc42029d3b0)
	/opt/teamcity-agent/work/7166d11ca1298d/src/github.com/terraform-providers/terraform-provider-github/github/resource_github_repository_test.go:216 +0x7dd
testing.tRunner(0xc42029d3b0, 0xe7bd78)
	/usr/local/go/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:789 +0x2de
```