### PR TITLE
Refactoring & naming cleanup

### DIFF
--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -90,7 +90,10 @@ func resourceGithubOrganizationWebhookCreate(d *schema.ResourceData, meta interf
 
 func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Organization).client
-	hookID, _ := strconv.ParseInt(d.Id(), 10, 64)
+	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return unconvertibleIdErr(d.Id(), err)
+	}
 
 	hook, resp, err := client.Organizations.GetHook(context.TODO(), meta.(*Organization).name, hookID)
 	if err != nil {
@@ -114,7 +117,7 @@ func resourceGithubOrganizationWebhookUpdate(d *schema.ResourceData, meta interf
 	hk := resourceGithubOrganizationWebhookObject(d)
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return err
+		return unconvertibleIdErr(d.Id(), err)
 	}
 
 	_, _, err = client.Organizations.EditHook(context.TODO(), meta.(*Organization).name, hookID, hk)
@@ -129,7 +132,7 @@ func resourceGithubOrganizationWebhookDelete(d *schema.ResourceData, meta interf
 	client := meta.(*Organization).client
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return err
+		return unconvertibleIdErr(d.Id(), err)
 	}
 
 	_, err = client.Organizations.DeleteHook(context.TODO(), meta.(*Organization).name, hookID)

--- a/github/resource_github_organization_webhook_test.go
+++ b/github/resource_github_organization_webhook_test.go
@@ -64,7 +64,10 @@ func testAccCheckGithubOrganizationWebhookExists(n string, hook *github.Hook) re
 			return fmt.Errorf("Not Found: %s", n)
 		}
 
-		hookID, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		hookID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return unconvertibleIdErr(rs.Primary.ID, err)
+		}
 		if hookID == 0 {
 			return fmt.Errorf("No repository name is set")
 		}
@@ -121,7 +124,7 @@ func testAccCheckGithubOrganizationWebhookDestroy(s *terraform.State) error {
 
 		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
 		if err != nil {
-			return err
+			return unconvertibleIdErr(rs.Primary.ID, err)
 		}
 
 		gotHook, resp, err := conn.Organizations.GetHook(context.TODO(), orgName, id)

--- a/github/resource_github_repository_deploy_key_test.go
+++ b/github/resource_github_repository_deploy_key_test.go
@@ -61,18 +61,18 @@ func testAccCheckGithubRepositoryDeployKeyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		o := testAccProvider.Meta().(*Organization).name
-		r, i, err := parseTwoPartID(rs.Primary.ID)
+		orgName := testAccProvider.Meta().(*Organization).name
+		repoName, idString, err := parseTwoPartID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		id, err := strconv.ParseInt(i, 10, 64)
+		id, err := strconv.ParseInt(idString, 10, 64)
 		if err != nil {
-			return err
+			return unconvertibleIdErr(idString, err)
 		}
 
-		_, resp, err := conn.Repositories.GetKey(context.TODO(), o, r, id)
+		_, resp, err := conn.Repositories.GetKey(context.TODO(), orgName, repoName, id)
 
 		if err != nil && resp.Response.StatusCode != 404 {
 			return err
@@ -95,18 +95,18 @@ func testAccCheckGithubRepositoryDeployKeyExists(n string) resource.TestCheckFun
 		}
 
 		conn := testAccProvider.Meta().(*Organization).client
-		o := testAccProvider.Meta().(*Organization).name
-		r, i, err := parseTwoPartID(rs.Primary.ID)
+		orgName := testAccProvider.Meta().(*Organization).name
+		repoName, idString, err := parseTwoPartID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		id, err := strconv.ParseInt(i, 10, 64)
+		id, err := strconv.ParseInt(idString, 10, 64)
 		if err != nil {
-			return err
+			return unconvertibleIdErr(idString, err)
 		}
 
-		_, _, err = conn.Repositories.GetKey(context.TODO(), o, r, id)
+		_, _, err = conn.Repositories.GetKey(context.TODO(), orgName, repoName, id)
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -100,7 +100,7 @@ func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{
 	client := meta.(*Organization).client
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return err
+		return unconvertibleIdErr(d.Id(), err)
 	}
 
 	hook, resp, err := client.Repositories.GetHook(context.TODO(), meta.(*Organization).name, d.Get("repository").(string), hookID)
@@ -125,7 +125,7 @@ func resourceGithubRepositoryWebhookUpdate(d *schema.ResourceData, meta interfac
 	hk := resourceGithubRepositoryWebhookObject(d)
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return err
+		return unconvertibleIdErr(d.Id(), err)
 	}
 
 	_, _, err = client.Repositories.EditHook(context.TODO(), meta.(*Organization).name, d.Get("repository").(string), hookID, hk)
@@ -140,7 +140,7 @@ func resourceGithubRepositoryWebhookDelete(d *schema.ResourceData, meta interfac
 	client := meta.(*Organization).client
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return err
+		return unconvertibleIdErr(d.Id(), err)
 	}
 
 	_, err = client.Repositories.DeleteHook(context.TODO(), meta.(*Organization).name, d.Get("repository").(string), hookID)

--- a/github/resource_github_repository_webhook_test.go
+++ b/github/resource_github_repository_webhook_test.go
@@ -87,7 +87,10 @@ func testAccCheckGithubRepositoryWebhookExists(n string, repoName string, hook *
 			return fmt.Errorf("Not Found: %s", n)
 		}
 
-		hookID, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		hookID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return unconvertibleIdErr(rs.Primary.ID, err)
+		}
 		if hookID == 0 {
 			return fmt.Errorf("No repository name is set")
 		}
@@ -144,7 +147,7 @@ func testAccCheckGithubRepositoryWebhookDestroy(s *terraform.State) error {
 
 		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
 		if err != nil {
-			return err
+			return unconvertibleIdErr(rs.Primary.ID, err)
 		}
 
 		gotHook, resp, err := conn.Repositories.GetHook(context.TODO(), orgName, rs.Primary.Attributes["repository"], id)

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-github/github"
@@ -84,12 +85,18 @@ func testAccCheckGithubTeamMembershipDestroy(s *terraform.State) error {
 			continue
 		}
 
-		t, u, err := parseTwoPartID(rs.Primary.ID)
+		teamIdString, username, err := parseTwoPartID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		membership, resp, err := conn.Organizations.GetTeamMembership(context.TODO(), toGithubID(t), u)
+		teamId, err := strconv.ParseInt(teamIdString, 10, 64)
+		if err != nil {
+			return unconvertibleIdErr(teamIdString, err)
+		}
+
+		membership, resp, err := conn.Organizations.GetTeamMembership(context.TODO(),
+			teamId, username)
 		if err == nil {
 			if membership != nil {
 				return fmt.Errorf("Team membership still exists")
@@ -115,12 +122,17 @@ func testAccCheckGithubTeamMembershipExists(n string, membership *github.Members
 		}
 
 		conn := testAccProvider.Meta().(*Organization).client
-		t, u, err := parseTwoPartID(rs.Primary.ID)
+		teamIdString, username, err := parseTwoPartID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		teamMembership, _, err := conn.Organizations.GetTeamMembership(context.TODO(), toGithubID(t), u)
+		teamId, err := strconv.ParseInt(teamIdString, 10, 64)
+		if err != nil {
+			return unconvertibleIdErr(teamIdString, err)
+		}
+
+		teamMembership, _, err := conn.Organizations.GetTeamMembership(context.TODO(), teamId, username)
 
 		if err != nil {
 			return err
@@ -142,12 +154,17 @@ func testAccCheckGithubTeamMembershipRoleState(n, expected string, membership *g
 		}
 
 		conn := testAccProvider.Meta().(*Organization).client
-		t, u, err := parseTwoPartID(rs.Primary.ID)
+		teamIdString, username, err := parseTwoPartID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
+		teamId, err := strconv.ParseInt(teamIdString, 10, 64)
+		if err != nil {
+			return unconvertibleIdErr(teamIdString, err)
+		}
 
-		teamMembership, _, err := conn.Organizations.GetTeamMembership(context.TODO(), toGithubID(t), u)
+		teamMembership, _, err := conn.Organizations.GetTeamMembership(context.TODO(),
+			teamId, username)
 		if err != nil {
 			return err
 		}

--- a/github/util.go
+++ b/github/util.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -12,15 +11,6 @@ const (
 	// https://developer.github.com/guides/traversing-with-pagination/#basics-of-pagination
 	maxPerPage = 100
 )
-
-func toGithubID(id string) int64 {
-	githubID, _ := strconv.ParseInt(id, 10, 64)
-	return githubID
-}
-
-func fromGithubID(id *int64) string {
-	return strconv.FormatInt(*id, 10)
-}
 
 func validateValueFunc(values []string) schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (we []string, errors []error) {
@@ -72,4 +62,18 @@ func flattenStringList(v []string) []interface{} {
 		c = append(c, s)
 	}
 	return c
+}
+
+func unconvertibleIdErr(id string, err error) *unconvertibleIdError {
+	return &unconvertibleIdError{OriginalId: id, OriginalError: err}
+}
+
+type unconvertibleIdError struct {
+	OriginalId    string
+	OriginalError error
+}
+
+func (e *unconvertibleIdError) Error() string {
+	return fmt.Sprintf("Unexpected ID format (%q), expected numerical ID. %s",
+		e.OriginalId, e.OriginalError.Error())
 }


### PR DESCRIPTION
Some may argue that removing the `toGithubID` helper function is a step back, but I think it's hiding the intention.

`toGithubID` poses a lot of questions to me - _What ID?_, _Why is it different from the one we're passing in?_ and error (which in theory should never occur, but I'm not a huge fan of hiding errors).

So downsides IMO overweigh the benefits (few saved LOC via abstraction), hence I made the type conversion more explicit.
