### PR TITLE
resource/github_issue_label: Add support for description

### DIFF
--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -32,6 +32,10 @@ func resourceGithubIssueLabel() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -66,6 +70,9 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interfa
 	existing, _, _ := client.Issues.GetLabel(context.TODO(), o, r, n)
 
 	if existing != nil {
+		description := d.Get("description").(string)
+		label.Description = &description
+
 		log.Printf("[DEBUG] Updating label: %s/%s (%s: %s)", o, r, n, c)
 
 		// Pull out the original name. If we already have a resource, this is the
@@ -86,6 +93,11 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interfa
 			return err
 		}
 	} else {
+		if v, ok := d.GetOk("description"); ok {
+			description := v.(string)
+			label.Description = &description
+		}
+
 		log.Printf("[DEBUG] Creating label: %s/%s (%s: %s)", o, r, n, c)
 		_, resp, err := client.Issues.CreateLabel(context.TODO(), o, r, label)
 		if resp != nil {
@@ -118,6 +130,7 @@ func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("repository", r)
 	d.Set("name", n)
 	d.Set("color", githubLabel.Color)
+	d.Set("description", githubLabel.Description)
 	d.Set("url", githubLabel.URL)
 
 	return nil

--- a/website/docs/r/issue_label.html.markdown
+++ b/website/docs/r/issue_label.html.markdown
@@ -42,6 +42,8 @@ The following arguments are supported:
 
 * `color` - (Required) A 6 character hex code, **without the leading #**, identifying the color of the label.
 
+* `description` - (Optional) A short description of the label.
+
 * `url` - (Computed) The URL to the issue label
 
 ## Import


### PR DESCRIPTION
Closes #76

```
make testacc TEST=./github TESTARGS='-run=TestAccGithubIssueLabel_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./github -v -run=TestAccGithubIssueLabel_ -timeout 120m
=== RUN   TestAccGithubIssueLabel_basic
--- PASS: TestAccGithubIssueLabel_basic (6.18s)
=== RUN   TestAccGithubIssueLabel_existingLabel
--- PASS: TestAccGithubIssueLabel_existingLabel (4.30s)
=== RUN   TestAccGithubIssueLabel_importBasic
--- PASS: TestAccGithubIssueLabel_importBasic (3.99s)
=== RUN   TestAccGithubIssueLabel_description
--- PASS: TestAccGithubIssueLabel_description (13.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	27.857s
```