### PR TITLE
resource/github_repository_webhook: Avoid spurious diff

### DIFF
--- a/github/migrate_github_repository_webhook.go
+++ b/github/migrate_github_repository_webhook.go
@@ -1,0 +1,55 @@
+package github
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceGithubRepositoryWebhookMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found GitHub Repository Webhook State v0; migrating to v1")
+		return migrateGithubRepositoryWebhookStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateGithubRepositoryWebhookStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] GitHub Repository Webhook Attributes before migration: %#v", is.Attributes)
+
+	prefix := "configuration."
+
+	delete(is.Attributes, prefix+"%")
+
+	// Read & delete old keys
+	oldKeys := make(map[string]string, 0)
+	for k, v := range is.Attributes {
+		if strings.HasPrefix(k, prefix) {
+			oldKeys[k] = v
+
+			// Delete old keys
+			delete(is.Attributes, k)
+		}
+	}
+
+	// Write new keys
+	for k, v := range oldKeys {
+		newKey := "configuration.0." + strings.TrimPrefix(k, prefix)
+		is.Attributes[newKey] = v
+	}
+
+	is.Attributes[prefix+"#"] = "1"
+
+	log.Printf("[DEBUG] GitHub Repository Webhook Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/github/migrate_github_repository_webhook_test.go
+++ b/github/migrate_github_repository_webhook_test.go
@@ -1,0 +1,38 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestMigrateGithubRepositoryWebhookStateV0toV1(t *testing.T) {
+	oldAttributes := map[string]string{
+		"configuration.%":            "4",
+		"configuration.content_type": "form",
+		"configuration.insecure_ssl": "0",
+		"configuration.secret":       "blablah",
+		"configuration.url":          "https://google.co.uk/",
+	}
+
+	newState, err := migrateGithubRepositoryWebhookStateV0toV1(&terraform.InstanceState{
+		ID:         "nonempty",
+		Attributes: oldAttributes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedAttributes := map[string]string{
+		"configuration.#":              "1",
+		"configuration.0.content_type": "form",
+		"configuration.0.insecure_ssl": "0",
+		"configuration.0.secret":       "blablah",
+		"configuration.0.url":          "https://google.co.uk/",
+	}
+	if !reflect.DeepEqual(newState.Attributes, expectedAttributes) {
+		t.Fatalf("Expected attributes:\n%#v\n\nGiven:\n%#v\n",
+			expectedAttributes, newState.Attributes)
+	}
+}


### PR DESCRIPTION
Fixes #81

```
TF_ACC=1 go test ./github -v -run=TestAccGithubRepositoryWebhook_ -timeout 120m
=== RUN   TestAccGithubRepositoryWebhook_basic
--- PASS: TestAccGithubRepositoryWebhook_basic (6.25s)
=== RUN   TestAccGithubRepositoryWebhook_secret
--- PASS: TestAccGithubRepositoryWebhook_secret (3.80s)
=== RUN   TestAccGithubRepositoryWebhook_importBasic
--- PASS: TestAccGithubRepositoryWebhook_importBasic (4.94s)
=== RUN   TestAccGithubRepositoryWebhook_importSecret
--- PASS: TestAccGithubRepositoryWebhook_importSecret (5.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	20.069s
```