### PR TITLE
resource/github_organization_webhook: Avoid spurious diff

### DIFF
--- a/github/migrate_github_repository_webhook.go
+++ b/github/migrate_github_repository_webhook.go
@@ -8,23 +8,23 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func resourceGithubRepositoryWebhookMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceGithubWebhookMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
-		log.Println("[INFO] Found GitHub Repository Webhook State v0; migrating to v1")
-		return migrateGithubRepositoryWebhookStateV0toV1(is)
+		log.Println("[INFO] Found GitHub Webhook State v0; migrating to v1")
+		return migrateGithubWebhookStateV0toV1(is)
 	default:
 		return is, fmt.Errorf("Unexpected schema version: %d", v)
 	}
 }
 
-func migrateGithubRepositoryWebhookStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+func migrateGithubWebhookStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
 	if is.Empty() {
 		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
 		return is, nil
 	}
 
-	log.Printf("[DEBUG] GitHub Repository Webhook Attributes before migration: %#v", is.Attributes)
+	log.Printf("[DEBUG] GitHub Webhook Attributes before migration: %#v", is.Attributes)
 
 	prefix := "configuration."
 
@@ -49,7 +49,7 @@ func migrateGithubRepositoryWebhookStateV0toV1(is *terraform.InstanceState) (*te
 
 	is.Attributes[prefix+"#"] = "1"
 
-	log.Printf("[DEBUG] GitHub Repository Webhook Attributes after State Migration: %#v", is.Attributes)
+	log.Printf("[DEBUG] GitHub Webhook Attributes after State Migration: %#v", is.Attributes)
 
 	return is, nil
 }

--- a/github/migrate_github_repository_webhook_test.go
+++ b/github/migrate_github_repository_webhook_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestMigrateGithubRepositoryWebhookStateV0toV1(t *testing.T) {
+func TestMigrateGithubWebhookStateV0toV1(t *testing.T) {
 	oldAttributes := map[string]string{
 		"configuration.%":            "4",
 		"configuration.content_type": "form",
@@ -16,7 +16,7 @@ func TestMigrateGithubRepositoryWebhookStateV0toV1(t *testing.T) {
 		"configuration.url":          "https://google.co.uk/",
 	}
 
-	newState, err := migrateGithubRepositoryWebhookStateV0toV1(&terraform.InstanceState{
+	newState, err := migrateGithubWebhookStateV0toV1(&terraform.InstanceState{
 		ID:         "nonempty",
 		Attributes: oldAttributes,
 	})

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -29,7 +29,7 @@ func resourceGithubRepositoryWebhook() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		MigrateState:  resourceGithubRepositoryWebhookMigrateState,
+		MigrateState:  resourceGithubWebhookMigrateState,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -48,41 +48,7 @@ func resourceGithubRepositoryWebhook() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			"configuration": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"url": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"content_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"secret": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
-							DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
-								// Undocumented GitHub feature where API returns 8 asterisks in place of the secret
-								maskedSecret := "********"
-								if oldV == maskedSecret {
-									return true
-								}
-
-								return oldV == newV
-							},
-						},
-						"insecure_ssl": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
+			"configuration": webhookConfigurationSchema(),
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/github/schema_webhook_configuration.go
+++ b/github/schema_webhook_configuration.go
@@ -1,0 +1,43 @@
+package github
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func webhookConfigurationSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"url": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"content_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"secret": {
+					Type:      schema.TypeString,
+					Optional:  true,
+					Sensitive: true,
+					DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
+						// Undocumented GitHub feature where API returns 8 asterisks in place of the secret
+						maskedSecret := "********"
+						if oldV == maskedSecret {
+							return true
+						}
+
+						return oldV == newV
+					},
+				},
+				"insecure_ssl": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Similar to #133 the same bug appears in org webhook, which has pretty much the same schema, so I refactored some of the functionality to reuse it.

Here's a test failing prior to the patch:

```
TF_ACC=1 go test ./github -v -run=TestAccGithubOrganizationWebhook_ -timeout 120m
=== RUN   TestAccGithubOrganizationWebhook_basic
--- PASS: TestAccGithubOrganizationWebhook_basic (3.22s)
=== RUN   TestAccGithubOrganizationWebhook_secret
--- FAIL: TestAccGithubOrganizationWebhook_secret (1.38s)
	testing.go:518: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: github_organization_webhook.foo
		  configuration.secret: "********" => "VerySecret"

		STATE:

		github_organization_webhook.foo:
		  ID = 44243925
		  provider = provider.github
		  active = true
		  configuration.% = 4
		  configuration.content_type = json
		  configuration.insecure_ssl = 0
		  configuration.secret = ********
		  configuration.url = https://www.terraform.io/webhook
		  events.# = 1
		  events.2342231791 = pull_request
		  name = web
		  url = https://api.github.com/orgs/terraformtesting/hooks/44243925
FAIL
FAIL	github.com/terraform-providers/terraform-provider-github/github	4.633s
```

## After patch

```
TF_ACC=1 go test ./github -v -run=TestAccGithubOrganizationWebhook_ -timeout 120m
=== RUN   TestAccGithubOrganizationWebhook_basic
--- PASS: TestAccGithubOrganizationWebhook_basic (2.23s)
=== RUN   TestAccGithubOrganizationWebhook_secret
--- PASS: TestAccGithubOrganizationWebhook_secret (1.21s)
PASS
```