### PR TITLE
resource/github_team: Expose slug (and document when to use it)

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -145,6 +145,7 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+
 	d.SetId(buildTwoPartID(&repoName, &branch))
 
 	return resourceGithubBranchProtectionRead(d, meta)

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -43,6 +43,10 @@ func resourceGithubTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"slug": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -98,6 +102,7 @@ func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("parent_team_id", "")
 	}
 	d.Set("ldap_dn", team.GetLDAPDN())
+	d.Set("slug", team.GetSlug())
 	return nil
 }
 

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -18,8 +18,8 @@ This resource allows you to configure branch protection for repositories in your
 # Protect the master branch of the foo repository. Additionally, require that
 # the "ci/travis" context to be passing and only allow the engineers team merge
 # to the branch.
-resource "github_branch_protection" "foo_master" {
-  repository = "foo"
+resource "github_branch_protection" "example" {
+  repository = "${github_repository.example.name}"
   branch = "master"
   enforce_admins = true
 
@@ -31,13 +31,23 @@ resource "github_branch_protection" "foo_master" {
   required_pull_request_reviews {
     dismiss_stale_reviews = true
     dismissal_users = ["foo-user"]
-    dismissal_teams = ["admins", "engineers"]
+    dismissal_teams = ["${github_team.example.slug}", "${github_team.second.slug}"]
   }
 
   restrictions {
     users = ["foo-user"]
-    teams = ["engineers"]
+    teams = ["${github_team.example.slug}"]
   }
+}
+
+resource "github_team" "example" {
+  name = "Example Name"
+}
+
+resource "github_team_repository" "example" {
+  team_id    = "${github_team.example.id}"
+  repository = "${github_repository.example.name}"
+  permission = "pull"
 }
 ```
 
@@ -65,7 +75,8 @@ The following arguments are supported:
 
 * `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
 * `dismissal_users`: (Optional) The list of user logins with dismissal access
-* `dismissal_teams`: (Optional) The list of team slugs with dismissal access
+* `dismissal_teams`: (Optional) The list of team slugs with dismissal access.
+  Always use `slug` of the team, **not** its name. Each team already **has** to have access to the repository.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
 
 ### Restrictions
@@ -74,6 +85,7 @@ The following arguments are supported:
 
 * `users`: (Optional) The list of user logins with push access.
 * `teams`: (Optional) The list of team slugs with push access.
+  Always use `slug` of the team, **not** its name. Each team already **has** to have access to the repository.
 
 `restrictions` is only available for organization-owned repositories.
 

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the created team.
+* `slug` - The slug of the created team, which may or may not differ from `name`,
+  depending on whether `name` contains "URL-unsafe" characters.
 
 ## Import
 

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -42,6 +42,7 @@ The following attributes are exported:
 * `id` - The ID of the created team.
 * `slug` - The slug of the created team, which may or may not differ from `name`,
   depending on whether `name` contains "URL-unsafe" characters.
+  Useful when referencing the team in [`github_branch_protection`](/docs/providers/github/r/branch_protection.html).
 
 ## Import
 


### PR DESCRIPTION
Fixes #84

I'm labelling this as enhancement, as it's technically not a _provider_ bug, but rather API bug, or undocumented behaviour.

The API silently ignores invalid team names, which can be either:

 - teams which simply don't exist
 - teams which don't have access to the repository
 - valid team names, instead of slugs

```
TF_ACC=1 go test ./github -v -run=TestAccGithubBranchProtection_ -timeout 120m
=== RUN   TestAccGithubBranchProtection_basic
--- PASS: TestAccGithubBranchProtection_basic (5.68s)
=== RUN   TestAccGithubBranchProtection_teams
--- PASS: TestAccGithubBranchProtection_teams (10.49s)
=== RUN   TestAccGithubBranchProtection_emptyItems
--- PASS: TestAccGithubBranchProtection_emptyItems (4.38s)
=== RUN   TestAccGithubBranchProtection_importBasic
--- PASS: TestAccGithubBranchProtection_importBasic (3.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	24.470s
```
```
TF_ACC=1 go test ./github -v -run=TestAccGithubTeam_ -timeout 120m
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (3.49s)
=== RUN   TestAccGithubTeam_slug
--- PASS: TestAccGithubTeam_slug (1.22s)
=== RUN   TestAccGithubTeam_hierarchical
--- PASS: TestAccGithubTeam_hierarchical (2.56s)
=== RUN   TestAccGithubTeam_importBasic
--- PASS: TestAccGithubTeam_importBasic (1.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	8.545s
```

I have sent the above feedback to GitHub via their contact page [as advised](https://developer.github.com/v3/repos/branches/#update-branch-protection) in the docs.