### PR TITLE
resource/github_team_membership: Make role updatable

### DIFF
--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -11,9 +11,9 @@ import (
 func resourceGithubMembership() *schema.Resource {
 
 	return &schema.Resource{
-		Create: resourceGithubMembershipCreate,
+		Create: resourceGithubMembershipCreateOrUpdate,
 		Read:   resourceGithubMembershipRead,
-		Update: resourceGithubMembershipUpdate,
+		Update: resourceGithubMembershipCreateOrUpdate,
 		Delete: resourceGithubMembershipDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -35,7 +35,7 @@ func resourceGithubMembership() *schema.Resource {
 	}
 }
 
-func resourceGithubMembershipCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceGithubMembershipCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Organization).client
 
 	membership, _, err := client.Organizations.EditOrgMembership(context.TODO(),
@@ -71,24 +71,6 @@ func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) erro
 
 	d.Set("username", membership.User.Login)
 	d.Set("role", membership.Role)
-	return nil
-}
-
-func resourceGithubMembershipUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
-
-	membership, _, err := client.Organizations.EditOrgMembership(context.TODO(),
-		d.Get("username").(string),
-		meta.(*Organization).name,
-		&github.Membership{
-			Role: github.String(d.Get("role").(string)),
-		},
-	)
-	if err != nil {
-		return err
-	}
-	d.SetId(buildTwoPartID(membership.Organization.Login, membership.User.Login))
-
 	return nil
 }
 

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -12,14 +12,14 @@ import (
 func resourceGithubTeamMembership() *schema.Resource {
 
 	return &schema.Resource{
-		Create: resourceGithubTeamMembershipCreate,
+		Create: resourceGithubTeamMembershipCreateOrUpdate,
 		Read:   resourceGithubTeamMembershipRead,
+		Update: resourceGithubTeamMembershipCreateOrUpdate,
 		Delete: resourceGithubTeamMembershipDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 
-		// editing team memberships are not supported by github api so forcing new on any changes
 		Schema: map[string]*schema.Schema{
 			"team_id": {
 				Type:     schema.TypeString,
@@ -34,7 +34,6 @@ func resourceGithubTeamMembership() *schema.Resource {
 			"role": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Default:      "member",
 				ValidateFunc: validateValueFunc([]string{"member", "maintainer"}),
 			},
@@ -42,7 +41,7 @@ func resourceGithubTeamMembership() *schema.Resource {
 	}
 }
 
-func resourceGithubTeamMembershipCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceGithubTeamMembershipCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Organization).client
 
 	teamIdString := d.Get("team_id").(string)


### PR DESCRIPTION
Fixes #85

```
TF_ACC=1 go test ./github -v -run=TestAccGithubTeamMembership_ -timeout 120m
=== RUN   TestAccGithubTeamMembership_basic
--- PASS: TestAccGithubTeamMembership_basic (4.67s)
=== RUN   TestAccGithubTeamMembership_importBasic
--- PASS: TestAccGithubTeamMembership_importBasic (2.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	6.838s
```
```
TF_ACC=1 go test ./github -v -run=TestAccGithubMembership -timeout 120m
=== RUN   TestAccGithubMembership_basic
--- PASS: TestAccGithubMembership_basic (2.58s)
=== RUN   TestAccGithubMembership_importBasic
--- PASS: TestAccGithubMembership_importBasic (1.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	3.984s
```