### PR TITLE
resource/github_repository: Avoid spurious diff for topics

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -96,7 +96,7 @@ func resourceGithubRepository() *schema.Resource {
 				Default:  false,
 			},
 			"topics": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
@@ -146,7 +146,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 		LicenseTemplate:   github.String(d.Get("license_template").(string)),
 		GitignoreTemplate: github.String(d.Get("gitignore_template").(string)),
 		Archived:          github.Bool(d.Get("archived").(bool)),
-		Topics:            expandStringList(d.Get("topics").([]interface{})),
+		Topics:            expandStringList(d.Get("topics").(*schema.Set).List()),
 	}
 }
 

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
@@ -321,7 +322,7 @@ func TestAccGithubRepository_topics(t *testing.T) {
 						Name:        name,
 						Description: description,
 						Homepage:    "http://example.com/",
-						Topics:      []string{"topic1", "topic2"},
+						Topics:      []string{"topic2", "topic1"},
 
 						// non-zero defaults
 						DefaultBranch:    "master",
@@ -482,6 +483,8 @@ func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testA
 		if len(want.Topics) != len(repo.Topics) {
 			return fmt.Errorf("got topics %#v; want %#v", repo.Topics, want.Topics)
 		}
+		sort.Strings(repo.Topics)
+		sort.Strings(want.Topics)
 		for i := range want.Topics {
 			if repo.Topics[i] != want.Topics[i] {
 				return fmt.Errorf("got topics %#v; want %#v", repo.Topics, want.Topics)


### PR DESCRIPTION
Topics don't really have an order, so they should be a set, not a list.

This will avoid spurious diff when they're not in alphabetical order (which is common case when you combine two or more variables).

```
TF_ACC=1 go test ./github -v -run=TestAccGithubRepository_ -timeout 120m
=== RUN   TestAccGithubRepository_basic
--- PASS: TestAccGithubRepository_basic (5.29s)
=== RUN   TestAccGithubRepository_archive
--- PASS: TestAccGithubRepository_archive (3.27s)
=== RUN   TestAccGithubRepository_archiveUpdate
--- PASS: TestAccGithubRepository_archiveUpdate (4.93s)
=== RUN   TestAccGithubRepository_importBasic
--- PASS: TestAccGithubRepository_importBasic (2.99s)
=== RUN   TestAccGithubRepository_defaultBranch
--- PASS: TestAccGithubRepository_defaultBranch (6.54s)
=== RUN   TestAccGithubRepository_templates
--- PASS: TestAccGithubRepository_templates (3.51s)
=== RUN   TestAccGithubRepository_topics
--- PASS: TestAccGithubRepository_topics (6.62s)
=== RUN   TestAccGithubRepository_autoInitForceNew
--- PASS: TestAccGithubRepository_autoInitForceNew (6.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	39.330s
```

State migration is not required, because `Read` can just keep setting `[]string` and `Set()` will do its magic.