### PR TITLE
New Resource: github_project_column and github_project_column_positions

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -43,6 +43,7 @@ func Provider() terraform.ResourceProvider {
 			"github_membership":              resourceGithubMembership(),
 			"github_organization_project":    resourceGithubOrganizationProject(),
 			"github_organization_webhook":    resourceGithubOrganizationWebhook(),
+			"github_project_column":          resourceGithubProjectColumn(),
 			"github_repository":              resourceGithubRepository(),
 			"github_repository_collaborator": resourceGithubRepositoryCollaborator(),
 			"github_repository_deploy_key":   resourceGithubRepositoryDeployKey(),

--- a/github/resource_github_project_column.go
+++ b/github/resource_github_project_column.go
@@ -1,0 +1,126 @@
+package github
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceGithubProjectColumn() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubProjectColumnCreate,
+		Read:   resourceGithubProjectColumnRead,
+		Update: resourceGithubProjectColumnUpdate,
+		Delete: resourceGithubProjectColumnDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceGithubProjectColumnCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Organization).client
+
+	options := github.ProjectColumnOptions{
+		Name: d.Get("name").(string),
+	}
+
+	projectIDStr := d.Get("project_id").(string)
+	projectID, err := strconv.ParseInt(projectIDStr, 10, 64)
+	if err != nil {
+		return unconvertibleIdErr(projectIDStr, err)
+	}
+
+	orgName := meta.(*Organization).name
+	log.Printf("[DEBUG] Creating project column (%s) in project %d (%s)", options.Name, projectID, orgName)
+	column, _, err := client.Projects.CreateProjectColumn(context.TODO(),
+		projectID,
+		&options,
+	)
+	if err != nil {
+		return err
+	}
+	d.SetId(strconv.FormatInt(*column.ID, 10))
+
+	return resourceGithubProjectColumnRead(d, meta)
+}
+
+func resourceGithubProjectColumnRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Organization).client
+
+	columnID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return unconvertibleIdErr(d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] Reading project column: %s", d.Id())
+	column, _, err := client.Projects.GetProjectColumn(context.TODO(), columnID)
+	if err != nil {
+		if err, ok := err.(*github.ErrorResponse); ok {
+			if err.Response.StatusCode == http.StatusNotFound {
+				log.Printf("[WARN] Removing project column %s from state because it no longer exists in GitHub", d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	projectURL := column.GetProjectURL()
+	projectID := strings.TrimPrefix(projectURL, client.BaseURL.String()+`projects/`)
+
+	d.Set("name", column.GetName())
+	d.Set("project_id", projectID)
+	return nil
+}
+
+func resourceGithubProjectColumnUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Organization).client
+
+	options := github.ProjectColumnOptions{
+		Name: d.Get("name").(string),
+	}
+
+	columnID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return unconvertibleIdErr(d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] Updating project column: %s", d.Id())
+	_, _, err = client.Projects.UpdateProjectColumn(context.TODO(), columnID, &options)
+	if err != nil {
+		return err
+	}
+
+	return resourceGithubProjectColumnRead(d, meta)
+}
+
+func resourceGithubProjectColumnDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Organization).client
+
+	columnID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return unconvertibleIdErr(d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] Deleting project column: %s", d.Id())
+	_, err = client.Projects.DeleteProjectColumn(context.TODO(), columnID)
+	return err
+}

--- a/github/resource_github_project_column_test.go
+++ b/github/resource_github_project_column_test.go
@@ -1,0 +1,138 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-github/github"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccGithubProjectColumn_basic(t *testing.T) {
+	var column github.ProjectColumn
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGithubProjectColumnDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubProjectColumnConfig("new column name"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubProjectColumnExists("github_project_column.column", &column),
+					testAccCheckGithubProjectColumnAttributes(&column, &testAccGithubProjectColumnExpectedAttributes{
+						Name: "new column name",
+					}),
+				),
+			},
+			{
+				Config: testAccGithubProjectColumnConfig("updated column name"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubProjectColumnExists("github_project_column.column", &column),
+					testAccCheckGithubProjectColumnAttributes(&column, &testAccGithubProjectColumnExpectedAttributes{
+						Name: "updated column name",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGithubProjectColumn_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGithubProjectColumnDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubProjectColumnConfig("a column"),
+			},
+			{
+				ResourceName:      "github_project_column.column",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccGithubProjectColumnDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*Organization).client
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "github_project_column" {
+			continue
+		}
+
+		columnID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		column, res, err := conn.Projects.GetProjectColumn(context.TODO(), columnID)
+		if err == nil {
+			if column != nil &&
+				column.GetID() == columnID {
+				return fmt.Errorf("Project column still exists")
+			}
+		}
+		if res.StatusCode != 404 {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckGithubProjectColumnExists(n string, project *github.ProjectColumn) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		columnID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*Organization).client
+		gotColumn, _, err := conn.Projects.GetProjectColumn(context.TODO(), columnID)
+		if err != nil {
+			return err
+		}
+		*project = *gotColumn
+		return nil
+	}
+}
+
+type testAccGithubProjectColumnExpectedAttributes struct {
+	Name string
+}
+
+func testAccCheckGithubProjectColumnAttributes(column *github.ProjectColumn, want *testAccGithubProjectColumnExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if *column.Name != want.Name {
+			return fmt.Errorf("got project column %q; want %q", *column.Name, want.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccGithubProjectColumnConfig(columnName string) string {
+	return fmt.Sprintf(`
+resource "github_organization_project" "test" {
+  name = "test-project"
+  body = "this is a test project"
+}
+
+resource "github_project_column" "column" {
+  project_id = "${github_organization_project.test.id}"
+  name       = "%s"
+}
+`, columnName)
+}

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "github"
-page_title: "Github: github_ip_ranges"
+page_title: "GitHub: github_ip_ranges"
 sidebar_current: "docs-github-datasource-ip-ranges"
 description: |-
   Get information on a GitHub's IP addresses.

--- a/website/docs/r/organization_project.html.markdown
+++ b/website/docs/r/organization_project.html.markdown
@@ -3,12 +3,12 @@ layout: "github"
 page_title: "GitHub: github_organization_project"
 sidebar_current: "docs-github-resource-organization-project"
 description: |-
-  Creates and manages projects for Github organizations
+  Creates and manages projects for GitHub organizations
 ---
 
 # github_organization_project
 
-This resource allows you to create and manage projects for Github organization.
+This resource allows you to create and manage projects for GitHub organization.
 
 ## Example Usage
 

--- a/website/docs/r/project_column.html.markdown
+++ b/website/docs/r/project_column.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "github"
+page_title: "GitHub: github_project_column"
+sidebar_current: "docs-github-resource-project-column"
+description: |-
+  Creates and manages project columns for GitHub projects
+---
+
+# github_repository_project
+
+This resource allows you to create and manage columns for GitHub projects.
+
+## Example Usage
+
+```hcl
+resource "github_organization_project" "project" {
+  name = "A Organization Project"
+  body = "This is a organization project."
+}
+
+resource "github_project_column" "column" {
+  project_id = "${github_organization_project.project.id}"
+  name       = "a column"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The id of an existing project that the column will be created in.
+
+* `name` - (Required) The name of the column.

--- a/website/docs/r/repository_project.html.markdown
+++ b/website/docs/r/repository_project.html.markdown
@@ -3,12 +3,12 @@ layout: "github"
 page_title: "GitHub: github_repository_project"
 sidebar_current: "docs-github-resource-repository-project"
 description: |-
-  Creates and manages projects for Github repositories
+  Creates and manages projects for GitHub repositories
 ---
 
 # github_repository_project
 
-This resource allows you to create and manage projects for Github repository.
+This resource allows you to create and manage projects for GitHub repository.
 
 ## Example Usage
 

--- a/website/github.erb
+++ b/website/github.erb
@@ -49,6 +49,9 @@
           <li<%= sidebar_current("docs-github-resource-organization-webhook") %>>
             <a href="/docs/providers/github/r/organization_webhook.html">github_organization_webhook</a>
           </li>
+          <li<%= sidebar_current("docs-github-resource-project-column") %>>
+              <a href="/docs/providers/github/r/project_column.html">github_project_column</a>
+          </li>
           <li<%= sidebar_current("docs-github-resource-repository-x") %>>
             <a href="/docs/providers/github/r/repository.html">github_repository</a>
           </li>


### PR DESCRIPTION
Hi, this PR adds the abilities to
1. manage the projects' columns: `github_project_column`
1. maintain the ordering of the columns' positions: `github_project_column_positions`
into this provider. 

It uses the APIs described in https://developer.github.com/v3/projects/columns/.

I have to admit that `github_project_column_positions` is a bit odd as it does not really create/destroy any resources on GitHub but only maintains the positions of the columns. I am not sure if this violates the philosophy of Terraform.

Would love to hear what you think about this. Thank you.
