### PR TITLE
All resources: Use Etag to save API quota

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -35,11 +35,13 @@ func (c *Config) Client() (interface{}, error) {
 	ctx := context.Background()
 
 	if c.Insecure {
-		httpClient := insecureHttpClient()
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+		insecureClient := insecureHttpClient()
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, insecureClient)
 	}
 
 	tc := oauth2.NewClient(ctx, ts)
+
+	tc.Transport = NewEtagTransport(tc.Transport)
 
 	tc.Transport = logging.NewTransport("Github", tc.Transport)
 

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -62,7 +62,7 @@ func TestProvider_insecure(t *testing.T) {
 	certFile := filepath.Join("test-fixtures", "cert.pem")
 	keyFile := filepath.Join("test-fixtures", "key.pem")
 
-	url, closeFunc := githubApiMock(port, certFile, keyFile, t)
+	url, closeFunc := githubTLSApiMock(port, certFile, keyFile, t)
 	defer closeFunc()
 
 	oldBaseUrl := os.Getenv("GITHUB_BASE_URL")
@@ -99,7 +99,7 @@ func TestProvider_insecure(t *testing.T) {
 	})
 }
 
-func githubApiMock(port, certFile, keyFile string, t *testing.T) (string, func() error) {
+func githubTLSApiMock(port, certFile, keyFile string, t *testing.T) (string, func() error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/users/hashibot", testRespondJson(userResponseBody))
 	mux.HandleFunc("/users/hashibot/gpg_keys", testRespondJson(gpgKeysResponseBody))

--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -45,6 +45,10 @@ func resourceGithubOrganizationWebhook() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -83,11 +87,12 @@ func resourceGithubOrganizationWebhookCreate(d *schema.ResourceData, meta interf
 
 	orgName := meta.(*Organization).name
 	webhookObj := resourceGithubOrganizationWebhookObject(d)
+	ctx := context.Background()
 
 	log.Printf("[DEBUG] Creating organization webhook: %s (%s)",
 		webhookObj.GetName(), orgName)
-	hook, _, err := client.Organizations.CreateHook(context.TODO(),
-		orgName, webhookObj)
+	hook, _, err := client.Organizations.CreateHook(ctx, orgName, webhookObj)
+
 	if err != nil {
 		return err
 	}
@@ -104,12 +109,19 @@ func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return unconvertibleIdErr(d.Id(), err)
 	}
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+	if !d.IsNewResource() {
+		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
+	}
 
 	log.Printf("[DEBUG] Reading organization webhook: %s (%s)", d.Id(), orgName)
-	hook, _, err := client.Organizations.GetHook(context.TODO(), orgName, hookID)
+	hook, resp, err := client.Organizations.GetHook(ctx, orgName, hookID)
 	if err != nil {
-		if err, ok := err.(*github.ErrorResponse); ok {
-			if err.Response.StatusCode == http.StatusNotFound {
+		if ghErr, ok := err.(*github.ErrorResponse); ok {
+			if ghErr.Response.StatusCode == http.StatusNotModified {
+				return nil
+			}
+			if ghErr.Response.StatusCode == http.StatusNotFound {
 				log.Printf("[WARN] Removing organization webhook %s/%s from state because it no longer exists in GitHub",
 					orgName, d.Id())
 				d.SetId("")
@@ -119,6 +131,7 @@ func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
+	d.Set("etag", resp.Header.Get("ETag"))
 	d.Set("name", hook.Name)
 	d.Set("url", hook.URL)
 	d.Set("active", hook.Active)
@@ -137,10 +150,11 @@ func resourceGithubOrganizationWebhookUpdate(d *schema.ResourceData, meta interf
 	if err != nil {
 		return unconvertibleIdErr(d.Id(), err)
 	}
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	log.Printf("[DEBUG] Updating organization webhook: %s (%s)", d.Id(), orgName)
 
-	_, _, err = client.Organizations.EditHook(context.TODO(),
+	_, _, err = client.Organizations.EditHook(ctx,
 		orgName, hookID, webhookObj)
 	if err != nil {
 		return err
@@ -157,8 +171,9 @@ func resourceGithubOrganizationWebhookDelete(d *schema.ResourceData, meta interf
 	if err != nil {
 		return unconvertibleIdErr(d.Id(), err)
 	}
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	log.Printf("[DEBUG] Deleting organization webhook: %s (%s)", d.Id(), orgName)
-	_, err = client.Organizations.DeleteHook(context.TODO(), orgName, hookID)
+	_, err = client.Organizations.DeleteHook(ctx, orgName, hookID)
 	return err
 }

--- a/github/transport.go
+++ b/github/transport.go
@@ -1,0 +1,31 @@
+package github
+
+import (
+	"net/http"
+)
+
+const (
+	ctxEtag = "etag"
+	ctxId   = "id"
+)
+
+// etagTransport allows saving API quota by passing previously stored Etag
+// available via context to request headers
+type etagTransport struct {
+	transport http.RoundTripper
+}
+
+func (ett *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	etag := ctx.Value(ctxEtag)
+	if v, ok := etag.(string); ok {
+		req.Header.Set("If-None-Match", v)
+	}
+
+	return ett.transport.RoundTrip(req)
+}
+
+func NewEtagTransport(rt http.RoundTripper) *etagTransport {
+	return &etagTransport{transport: rt}
+}

--- a/github/transport_test.go
+++ b/github/transport_test.go
@@ -1,0 +1,120 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+func TestEtagTransport(t *testing.T) {
+	ts := githubApiMock([]*response{
+		{
+			ExpectedUri: "/repos/test/blah",
+			ExpectedHeaders: map[string]string{
+				"If-None-Match": "something",
+			},
+
+			ResponseBody: `{"id": 1234}`,
+			StatusCode:   200,
+		},
+	})
+	defer ts.Close()
+
+	httpClient := http.DefaultClient
+	httpClient.Transport = NewEtagTransport(http.DefaultTransport)
+
+	client := github.NewClient(httpClient)
+	u, _ := url.Parse(ts.URL + "/")
+	client.BaseURL = u
+
+	ctx := context.WithValue(context.Background(), ctxEtag, "something")
+	r, _, err := client.Repositories.Get(ctx, "test", "blah")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r.GetID() != 1234 {
+		t.Fatalf("Expected ID to be 1234, got: %d", r.GetID())
+	}
+}
+
+func githubApiMock(responseSequence []*response) *httptest.Server {
+	position := github.Int(0)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Server", "GitHub.com")
+
+		bodyBytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("[ERROR] %s", err)
+		}
+		log.Printf("[DEBUG] Mock server received %s request to %q; headers:\n%s\nrequest body: %q\n",
+			r.Method, r.RequestURI, r.Header, string(bodyBytes))
+
+		i := *position
+		if len(responseSequence) < i+1 {
+			w.WriteHeader(400)
+			return
+		}
+
+		tc := responseSequence[i]
+
+		headersMatch := func(h http.Header, expectedHeaders map[string]string) bool {
+			for key, value := range expectedHeaders {
+				if h.Get(key) != value {
+					return false
+				}
+			}
+			return true
+		}
+
+		if r.RequestURI != tc.ExpectedUri {
+			log.Printf("[ERROR] Expected URI: %q, given: %q", tc.ExpectedUri, r.RequestURI)
+			w.WriteHeader(400)
+			return
+		}
+		if !headersMatch(r.Header, tc.ExpectedHeaders) {
+			log.Printf("[ERROR] Expected headers: %q, given: %q", tc.ExpectedHeaders, r.Header)
+			w.WriteHeader(400)
+			return
+		}
+		if tc.ExpectedMethod != "" && r.Method != tc.ExpectedMethod {
+			log.Printf("[ERROR] Expected method: %q, given: %q", tc.ExpectedMethod, r.Method)
+			w.WriteHeader(400)
+			return
+		}
+		if len(tc.ExpectedBody) > 0 && string(bodyBytes) != string(tc.ExpectedBody) {
+			log.Printf("[ERROR] Expected body: %q, given: %q",
+				string(tc.ExpectedBody), string(bodyBytes))
+			w.WriteHeader(400)
+			return
+		}
+
+		for key, value := range tc.ResponseHeaders {
+			w.Header().Set(key, value)
+		}
+		w.WriteHeader(tc.StatusCode)
+		fmt.Fprintln(w, tc.ResponseBody)
+
+		// Treat response as disposable
+		position = github.Int(i + 1)
+	}))
+}
+
+type response struct {
+	ExpectedUri     string
+	ExpectedMethod  string
+	ExpectedHeaders map[string]string
+	ExpectedBody    []byte
+
+	StatusCode      int
+	ResponseHeaders map[string]string
+	ResponseBody    string
+}

--- a/github/transport_test.go
+++ b/github/transport_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestEtagTransport(t *testing.T) {
-	ts := githubApiMock([]*response{
+	ts := githubApiMock([]*mockResponse{
 		{
 			ExpectedUri: "/repos/test/blah",
 			ExpectedHeaders: map[string]string{
@@ -45,7 +45,7 @@ func TestEtagTransport(t *testing.T) {
 	}
 }
 
-func githubApiMock(responseSequence []*response) *httptest.Server {
+func githubApiMock(responseSequence []*mockResponse) *httptest.Server {
 	position := github.Int(0)
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -108,7 +108,7 @@ func githubApiMock(responseSequence []*response) *httptest.Server {
 	}))
 }
 
-type response struct {
+type mockResponse struct {
 	ExpectedUri     string
 	ExpectedMethod  string
 	ExpectedHeaders map[string]string


### PR DESCRIPTION
This is to address one part of https://github.com/terraform-providers/terraform-provider-github/issues/5

## 100 repositories test

### Current implementation

 - creation: 300 requests (POST -> PATCH -> GET)
 - refresh: 100 requests (GET)
 - destruction: 100 + 100 requests (GET -> DELETE)

600 requests in total.

### Etag (with patch in this PR)

 - creation: 300 requests consumed from quota
 - refresh: 0 requests consumed from quota
 - destruction: 100 requests consumed from quota

400 requests in total, i.e. **33% reduction** in quota consumption.

## Acceptance tests

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./github -v  -timeout 120m
=== RUN   TestAccGithubIpRangesDataSource_existing
--- PASS: TestAccGithubIpRangesDataSource_existing (1.32s)
=== RUN   TestAccGithubRepositoriesDataSource_basic
--- PASS: TestAccGithubRepositoriesDataSource_basic (7.39s)
=== RUN   TestAccGithubRepositoriesDataSource_noMatch
--- PASS: TestAccGithubRepositoriesDataSource_noMatch (0.85s)
=== RUN   TestAccGithubRepositoryDataSource_fullName_noMatchReturnsError
--- PASS: TestAccGithubRepositoryDataSource_fullName_noMatchReturnsError (0.16s)
=== RUN   TestAccGithubRepositoryDataSource_name_noMatchReturnsError
--- PASS: TestAccGithubRepositoryDataSource_name_noMatchReturnsError (0.16s)
=== RUN   TestAccGithubRepositoryDataSource_fullName_existing
--- PASS: TestAccGithubRepositoryDataSource_fullName_existing (0.76s)
=== RUN   TestAccGithubRepositoryDataSource_name_existing
--- PASS: TestAccGithubRepositoryDataSource_name_existing (0.78s)
=== RUN   TestAccGithubTeamDataSource_noMatchReturnsError
--- PASS: TestAccGithubTeamDataSource_noMatchReturnsError (0.14s)
=== RUN   TestAccGithubUserDataSource_noMatchReturnsError
--- PASS: TestAccGithubUserDataSource_noMatchReturnsError (0.20s)
=== RUN   TestAccGithubUserDataSource_existing
--- PASS: TestAccGithubUserDataSource_existing (2.59s)
=== RUN   TestMigrateGithubWebhookStateV0toV1
--- PASS: TestMigrateGithubWebhookStateV0toV1 (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestProvider_insecure
--- PASS: TestProvider_insecure (0.14s)
=== RUN   TestAccGithubBranchProtection_basic
--- FAIL: TestAccGithubBranchProtection_basic (3.51s)
	testing.go:518: Step 0 error: Check failed: Check 3/15 error: diff "restrictions.users": (-got +want)
		 [
		+ "terraformcollaborator",
		 ]
=== RUN   TestAccGithubBranchProtection_teams
--- PASS: TestAccGithubBranchProtection_teams (11.14s)
=== RUN   TestAccGithubBranchProtection_emptyItems
--- PASS: TestAccGithubBranchProtection_emptyItems (4.06s)
=== RUN   TestAccGithubBranchProtection_importBasic
--- FAIL: TestAccGithubBranchProtection_importBasic (3.30s)
	testing.go:518: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: github_branch_protection.master
		  required_pull_request_reviews.0.dismissal_users.#:         "0" => "1"
		  required_pull_request_reviews.0.dismissal_users.862080235: "" => "terraformcollaborator"
		  restrictions.0.users.#:                                    "0" => "1"
		  restrictions.0.users.862080235:                            "" => "terraformcollaborator"

		STATE:

		github_branch_protection.master:
		  ID = 9pfio:master
		  provider = provider.github
		  branch = master
		  enforce_admins = true
		  etag = W/"b1b78920e662f423d3989e851e9cf4ed"
		  repository = 9pfio
		  required_pull_request_reviews.# = 1
		  required_pull_request_reviews.0.dismiss_stale_reviews = true
		  required_pull_request_reviews.0.dismissal_teams.# = 0
		  required_pull_request_reviews.0.dismissal_users.# = 0
		  required_pull_request_reviews.0.include_admins = false
		  required_pull_request_reviews.0.require_code_owner_reviews = true
		  required_status_checks.# = 1
		  required_status_checks.0.contexts.# = 1
		  required_status_checks.0.contexts.663644092 = github/foo
		  required_status_checks.0.include_admins = false
		  required_status_checks.0.strict = true
		  restrictions.# = 1
		  restrictions.0.teams.# = 0
		  restrictions.0.users.# = 0

		  Dependencies:
		    github_repository.test
		github_repository.test:
		  ID = 9pfio
		  provider = provider.github
		  allow_merge_commit = true
		  allow_rebase_merge = true
		  allow_squash_merge = true
		  archived = false
		  auto_init = true
		  default_branch = master
		  description = Terraform Acceptance Test 9pfio
		  etag = W/"82e7f8a78e74dd1c9fb4fd251cd0534e"
		  full_name = terraformtesting/9pfio
		  git_clone_url = git://github.com/terraformtesting/9pfio.git
		  has_downloads = false
		  has_issues = false
		  has_wiki = false
		  homepage_url =
		  html_url = https://github.com/terraformtesting/9pfio
		  http_clone_url = https://github.com/terraformtesting/9pfio.git
		  name = 9pfio
		  private = false
		  ssh_clone_url = git@github.com:terraformtesting/9pfio.git
		  svn_url = https://github.com/terraformtesting/9pfio
		  topics.# = 0
=== RUN   TestAccGithubIssueLabel_basic
--- PASS: TestAccGithubIssueLabel_basic (5.72s)
=== RUN   TestAccGithubIssueLabel_existingLabel
--- PASS: TestAccGithubIssueLabel_existingLabel (3.86s)
=== RUN   TestAccGithubIssueLabel_importBasic
--- PASS: TestAccGithubIssueLabel_importBasic (3.29s)
=== RUN   TestAccGithubIssueLabel_description
--- PASS: TestAccGithubIssueLabel_description (7.53s)
=== RUN   TestAccGithubMembership_basic
--- PASS: TestAccGithubMembership_basic (1.61s)
=== RUN   TestAccGithubMembership_importBasic
--- PASS: TestAccGithubMembership_importBasic (1.54s)
=== RUN   TestAccGithubOrganizationProject_basic
--- PASS: TestAccGithubOrganizationProject_basic (1.51s)
=== RUN   TestAccGithubOrganizationProject_importBasic
--- PASS: TestAccGithubOrganizationProject_importBasic (1.60s)
=== RUN   TestAccGithubOrganizationWebhook_basic
--- PASS: TestAccGithubOrganizationWebhook_basic (2.02s)
=== RUN   TestAccGithubOrganizationWebhook_secret
--- PASS: TestAccGithubOrganizationWebhook_secret (1.23s)
=== RUN   TestAccGithubRepositoryCollaborator_basic
--- PASS: TestAccGithubRepositoryCollaborator_basic (3.53s)
=== RUN   TestAccGithubRepositoryCollaborator_importBasic
--- PASS: TestAccGithubRepositoryCollaborator_importBasic (4.15s)
=== RUN   TestSuppressDeployKeyDiff
--- PASS: TestSuppressDeployKeyDiff (0.00s)
=== RUN   TestAccGithubRepositoryDeployKey_basic
--- PASS: TestAccGithubRepositoryDeployKey_basic (3.12s)
=== RUN   TestAccGithubRepositoryDeployKey_importBasic
--- PASS: TestAccGithubRepositoryDeployKey_importBasic (3.05s)
=== RUN   TestAccGithubRepositoryProject_basic
--- PASS: TestAccGithubRepositoryProject_basic (3.41s)
=== RUN   TestAccGithubRepositoryProject_importBasic
--- PASS: TestAccGithubRepositoryProject_importBasic (3.35s)
=== RUN   TestAccGithubRepository_basic
--- PASS: TestAccGithubRepository_basic (3.73s)
=== RUN   TestAccGithubRepository_archive
--- PASS: TestAccGithubRepository_archive (2.60s)
=== RUN   TestAccGithubRepository_archiveUpdate
--- PASS: TestAccGithubRepository_archiveUpdate (3.80s)
=== RUN   TestAccGithubRepository_importBasic
--- PASS: TestAccGithubRepository_importBasic (2.44s)
=== RUN   TestAccGithubRepository_defaultBranch
--- PASS: TestAccGithubRepository_defaultBranch (7.52s)
=== RUN   TestAccGithubRepository_templates
--- PASS: TestAccGithubRepository_templates (3.51s)
=== RUN   TestAccGithubRepository_topics
--- PASS: TestAccGithubRepository_topics (5.78s)
=== RUN   TestAccGithubRepository_autoInitForceNew
--- PASS: TestAccGithubRepository_autoInitForceNew (5.95s)
=== RUN   TestAccGithubRepositoryWebhook_basic
--- PASS: TestAccGithubRepositoryWebhook_basic (5.22s)
=== RUN   TestAccGithubRepositoryWebhook_secret
--- PASS: TestAccGithubRepositoryWebhook_secret (3.51s)
=== RUN   TestAccGithubRepositoryWebhook_importBasic
--- PASS: TestAccGithubRepositoryWebhook_importBasic (3.36s)
=== RUN   TestAccGithubRepositoryWebhook_importSecret
--- PASS: TestAccGithubRepositoryWebhook_importSecret (4.07s)
=== RUN   TestAccGithubTeamMembership_basic
--- PASS: TestAccGithubTeamMembership_basic (4.48s)
=== RUN   TestAccGithubTeamMembership_importBasic
--- PASS: TestAccGithubTeamMembership_importBasic (2.44s)
=== RUN   TestAccGithubTeamRepository_basic
--- PASS: TestAccGithubTeamRepository_basic (4.79s)
=== RUN   TestAccGithubTeamRepository_importBasic
--- PASS: TestAccGithubTeamRepository_importBasic (3.65s)
=== RUN   TestAccCheckGetPermissions
--- PASS: TestAccCheckGetPermissions (0.00s)
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (2.81s)
=== RUN   TestAccGithubTeam_slug
--- PASS: TestAccGithubTeam_slug (1.41s)
=== RUN   TestAccGithubTeam_hierarchical
--- PASS: TestAccGithubTeam_hierarchical (2.85s)
=== RUN   TestAccGithubTeam_importBasic
--- PASS: TestAccGithubTeam_importBasic (1.45s)
=== RUN   TestAccGithubUserGpgKey_basic
--- PASS: TestAccGithubUserGpgKey_basic (2.00s)
=== RUN   TestAccGithubUserSshKey_basic
--- PASS: TestAccGithubUserSshKey_basic (1.33s)
=== RUN   TestAccGithubUserSshKey_importBasic
--- PASS: TestAccGithubUserSshKey_importBasic (1.33s)
=== RUN   TestEtagTransport
--- PASS: TestEtagTransport (0.00s)
=== RUN   TestAccGithubUtilRole_validation
--- PASS: TestAccGithubUtilRole_validation (0.00s)
=== RUN   TestAccGithubUtilTwoPartID
--- PASS: TestAccGithubUtilTwoPartID (0.00s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-github/github	167.029s
```
Test failures are result of eventually consistent GitHub API.