### PR TITLE
Implement & use RateLimitTransport

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -43,6 +43,8 @@ func (c *Config) Client() (interface{}, error) {
 
 	tc.Transport = NewEtagTransport(tc.Transport)
 
+	tc.Transport = NewRateLimitTransport(tc.Transport)
+
 	tc.Transport = logging.NewTransport("Github", tc.Transport)
 
 	org.client = github.NewClient(tc)

--- a/github/transport.go
+++ b/github/transport.go
@@ -1,12 +1,21 @@
 package github
 
 import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/go-github/github"
 )
 
 const (
-	ctxEtag = "etag"
-	ctxId   = "id"
+	ctxEtag    = "etag"
+	ctxId      = "id"
+	writeDelay = 1 * time.Second
 )
 
 // etagTransport allows saving API quota by passing previously stored Etag
@@ -28,4 +37,120 @@ func (ett *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func NewEtagTransport(rt http.RoundTripper) *etagTransport {
 	return &etagTransport{transport: rt}
+}
+
+// rateLimitTransport implements GitHub's best practices
+// for avoiding rate limits
+// https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits
+type rateLimitTransport struct {
+	transport        http.RoundTripper
+	delayNextRequest bool
+	responseBody     []byte
+
+	m sync.Mutex
+}
+
+func (rlt *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Make requests for a single user or client ID serially
+	// This is also necessary for safely saving
+	// and restoring bodies between retries below
+	rlt.lock(req)
+
+	// If you're making a large number of POST, PATCH, PUT, or DELETE requests
+	// for a single user or client ID, wait at least one second between each request.
+	if rlt.delayNextRequest {
+		log.Printf("[DEBUG] Sleeping %s between write operations", writeDelay)
+		time.Sleep(writeDelay)
+	}
+	if rlt.isWriteMethod(req.Method) {
+		rlt.delayNextRequest = true
+	} else {
+		rlt.delayNextRequest = false
+	}
+
+	resp, err := rlt.transport.RoundTrip(req)
+	if err != nil {
+		rlt.unlock(req)
+		return resp, err
+	}
+
+	// Make response body accessible for retries & debugging
+	// (work around bug in GitHub SDK)
+	// See https://github.com/google/go-github/pull/986
+	r1, r2, err := rlt.drainBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = r1
+	ghErr := github.CheckResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = r2
+
+	// When you have been limited, use the Retry-After response header to slow down.
+	if arlErr, ok := ghErr.(*github.AbuseRateLimitError); ok {
+		rlt.delayNextRequest = false
+		retryAfter := arlErr.GetRetryAfter()
+		log.Printf("[DEBUG] Abuse detection mechanism triggered, sleeping for %s before retrying",
+			retryAfter)
+		time.Sleep(retryAfter)
+		rlt.unlock(req)
+		return rlt.RoundTrip(req)
+	}
+
+	if rlErr, ok := ghErr.(*github.RateLimitError); ok {
+		rlt.delayNextRequest = false
+		retryAfter := rlErr.Rate.Reset.Sub(time.Now())
+		log.Printf("[DEBUG] Rate limit %d reached, sleeping for %s (until %s) before retrying",
+			rlErr.Rate.Limit, retryAfter, time.Now().Add(retryAfter))
+		time.Sleep(retryAfter)
+		rlt.unlock(req)
+		return rlt.RoundTrip(req)
+	}
+
+	rlt.unlock(req)
+
+	return resp, nil
+}
+
+// drainBody reads all of b to memory and then returns two equivalent
+// ReadClosers yielding the same bytes.
+func (rlt *rateLimitTransport) drainBody(b io.ReadCloser) (r1, r2 io.ReadCloser, err error) {
+	if b == http.NoBody {
+		// No copying needed. Preserve the magic sentinel meaning of NoBody.
+		return http.NoBody, http.NoBody, nil
+	}
+	var buf bytes.Buffer
+	if _, err = buf.ReadFrom(b); err != nil {
+		return nil, b, err
+	}
+	if err = b.Close(); err != nil {
+		return nil, b, err
+	}
+	return ioutil.NopCloser(&buf), ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+}
+
+func (rlt *rateLimitTransport) lock(req *http.Request) {
+	ctx := req.Context()
+	log.Printf("[TRACE] Aquiring lock for GitHub API request (%q)", ctx.Value(ctxId))
+	rlt.m.Lock()
+}
+
+func (rlt *rateLimitTransport) unlock(req *http.Request) {
+	ctx := req.Context()
+	log.Printf("[TRACE] Releasing lock for GitHub API request (%q)", ctx.Value(ctxId))
+	rlt.m.Unlock()
+}
+
+func (rlt *rateLimitTransport) isWriteMethod(method string) bool {
+	switch method {
+	case "POST", "PATCH", "PUT", "DELETE":
+		return true
+	}
+	return false
+}
+
+func NewRateLimitTransport(rt http.RoundTripper) *rateLimitTransport {
+	return &rateLimitTransport{transport: rt}
 }


### PR DESCRIPTION
As described in attached code comments this PR implements best practices GitHub describes [in their official documentation](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits).

This is second of two PRs addressing #5 
Closes #5

The upside is that with this patch user should never see rate-limit related errors anymore as we'll always retry accordingly and more importantly avoid hitting the limit.

Downsides include slowdown of CUD operations and generally slower UX when managing large number of resources. Admittedly if the previous/current experience was "rate limit errors" and now is slow, but successful apply/destroy I'd still call that a win. 🤷‍♂️ See some figures below.

We could in theory expose a flag to turn off the sleep logic and/or mutex, but I'm not too keen on doing that pre-emptively without further context, esp. because we're _just_ implementing GitHub's own best practices.

## 100 repositories test

### Current implementation

 - creation: 16 seconds
 - refresh: 4 seconds
 - destroy: 9 seconds

### Serializing requests via mutex

 - creation: 147 seconds (`9x` slower)
 - refresh: 25 seconds (`6x` slower)
 - destroy: 48 seconds (`5x` slower)

### 1sec delay between write operations

 - creation: 352 seconds (`22x` and `2.4x` slower)
 - refresh: 25 seconds (`6x` slower and equal)
 - destroy: 150 seconds (`16x` and `3x` slower)
