### PR TITLE
resource/github_repository: Prefill auto_init during import

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -17,7 +17,10 @@ func resourceGithubRepository() *schema.Resource {
 		Update: resourceGithubRepositoryUpdate,
 		Delete: resourceGithubRepositoryDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.Set("auto_init", false)
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -625,6 +625,7 @@ resource "github_repository" "foo" {
   allow_squash_merge = false
   allow_rebase_merge = false
   has_downloads = true
+  auto_init = false
 }
 `, randString, randString)
 }


### PR DESCRIPTION
Fixes #148

```
TF_ACC=1 go test ./github -v -run=TestAccGithubRepository_ -timeout 120m
=== RUN   TestAccGithubRepository_basic
--- PASS: TestAccGithubRepository_basic (8.32s)
=== RUN   TestAccGithubRepository_archive
--- PASS: TestAccGithubRepository_archive (5.80s)
=== RUN   TestAccGithubRepository_archiveUpdate
--- PASS: TestAccGithubRepository_archiveUpdate (8.11s)
=== RUN   TestAccGithubRepository_importBasic
--- PASS: TestAccGithubRepository_importBasic (5.76s)
=== RUN   TestAccGithubRepository_defaultBranch
--- PASS: TestAccGithubRepository_defaultBranch (9.76s)
=== RUN   TestAccGithubRepository_templates
--- PASS: TestAccGithubRepository_templates (5.91s)
=== RUN   TestAccGithubRepository_topics
--- PASS: TestAccGithubRepository_topics (17.51s)
=== RUN   TestAccGithubRepository_autoInitForceNew
--- PASS: TestAccGithubRepository_autoInitForceNew (15.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	76.320s
```