### PR TITLE
r/github_branch_protection: check invalid users

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -146,13 +147,17 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Creating branch protection: %s/%s (%s)",
 		orgName, repoName, branch)
-	_, _, err = client.Repositories.UpdateBranchProtection(ctx,
+	protection, _, err := client.Repositories.UpdateBranchProtection(ctx,
 		orgName,
 		repoName,
 		branch,
 		protectionRequest,
 	)
 	if err != nil {
+		return err
+	}
+
+	if err := checkBranchRestrictionsUsers(protection.GetRestrictions(), protectionRequest.GetRestrictions()); err != nil {
 		return err
 	}
 
@@ -232,13 +237,17 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Updating branch protection: %s/%s (%s)",
 		orgName, repoName, branch)
-	_, _, err = client.Repositories.UpdateBranchProtection(ctx,
+	protection, _, err := client.Repositories.UpdateBranchProtection(ctx,
 		orgName,
 		repoName,
 		branch,
 		protectionRequest,
 	)
 	if err != nil {
+		return err
+	}
+
+	if err := checkBranchRestrictionsUsers(protection.GetRestrictions(), protectionRequest.GetRestrictions()); err != nil {
 		return err
 	}
 
@@ -473,4 +482,35 @@ func expandNestedSet(m map[string]interface{}, target string) []string {
 		}
 	}
 	return res
+}
+
+func checkBranchRestrictionsUsers(actual *github.BranchRestrictions, expected *github.BranchRestrictionsRequest) error {
+	if expected == nil {
+		return nil
+	}
+
+	expectedUsers := expected.Users
+
+	if actual == nil {
+		return fmt.Errorf("unable to add users in restrictions: %s", strings.Join(expectedUsers, ", "))
+	}
+
+	actualLoopUp := make(map[string]struct{}, len(actual.Users))
+	for _, a := range actual.Users {
+		actualLoopUp[a.GetLogin()] = struct{}{}
+	}
+
+	notFounds := make([]string, 0, len(actual.Users))
+
+	for _, e := range expectedUsers {
+		if _, ok := actualLoopUp[e]; !ok {
+			notFounds = append(notFounds, e)
+		}
+	}
+
+	if len(notFounds) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("unable to add users in restrictions: %s", strings.Join(notFounds, ", "))
 }

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -58,6 +59,36 @@ func TestAccGithubBranchProtection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_pull_request_reviews.#", "0"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "restrictions.#", "0"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccGithubBranchProtection_users(t *testing.T) {
+	rString := acctest.RandString(5)
+	repoName := fmt.Sprintf("tf-acc-test-branch-prot-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGithubBranchProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccGithubBranchProtectionConfigUser(repoName, "user_with_underscore"),
+				ExpectError: regexp.MustCompile("unable to add users in restrictions: user_with_underscore"),
+			},
+			{
+				Config: testAccGithubBranchProtectionConfigUser(repoName, testUser),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("github_branch_protection.master", "repository", repoName),
+					resource.TestCheckResourceAttr("github_branch_protection.master", "branch", "master"),
+					resource.TestCheckResourceAttr("github_branch_protection.master", "enforce_admins", "true"),
+					resource.TestCheckResourceAttr("github_branch_protection.master", "restrictions.0.users.#", "1"),
+				),
+			},
+			{
+				Config:      testAccGithubBranchProtectionConfigUser(repoName, "user_with_underscore"),
+				ExpectError: regexp.MustCompile("unable to add users in restrictions: user_with_underscore"),
 			},
 		},
 	})
@@ -469,4 +500,24 @@ resource "github_branch_protection" "master" {
   }
 }
 `, repoName, repoName, firstTeamName, secondTeamName)
+}
+
+func testAccGithubBranchProtectionConfigUser(repoName, user string) string {
+	return fmt.Sprintf(`
+resource "github_repository" "test" {
+  name        = "%s"
+  description = "Terraform Acceptance Test %s"
+  auto_init   = true
+}
+
+resource "github_branch_protection" "master" {
+  repository = "${github_repository.test.name}"
+  branch     = "master"
+  enforce_admins = true
+
+  restrictions {
+    users = ["%s"]
+  }
+}
+`, repoName, repoName, user)
 }


### PR DESCRIPTION
Hi, this is PR an attempt to fix #95. As reported in the issue the GitHUB V3 API does not report error when invalid user login are submitted to [replace user restrictions of protected branch](https://developer.github.com/v3/repos/branches/#replace-user-restrictions-of-protected-branch).  It seems that the API ignores the invalid user and update the list only with the valid ones. It also return the updated list as part of the response.

```
$ curl -i -d '["shihanng", "shihan_ng"]' -X PUT -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" https://api.github.com/repos/shihanng-org/test/branches/master/protection/restrictions/users
HTTP/1.1 200 OK
Date: Wed, 03 Oct 2018 02:30:48 GMT
...

[
  {
    "login": "shihanng",
    ...
    "type": "User",
    "site_admin": false
  }
]
```

This PR includes a way to check the resulting users list from the response and compare it with the user input in order to report the error properly.

Please let me know what you think. Thank you.
