### PR TITLE
Do not error when deleting a repository that does not exist

### DIFF
--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -177,7 +177,14 @@ func resourceGithubTeamRepositoryDelete(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] Deleting team repository association: %s (%s/%s)",
 		teamIdString, orgName, repoName)
-	_, err = client.Organizations.RemoveTeamRepo(ctx,
+	res, err := client.Organizations.RemoveTeamRepo(ctx,
 		teamId, orgName, repoName)
+
+	// Deleting a non-existant repo should not cause an error when doing a terraform apply.
+	// It should simply be removed from state.
+	if res.StatusCode == 404 {
+		return nil
+	}
+
 	return err
 }


### PR DESCRIPTION
We had to manually amend state to remove a repository that was manually deleted. That seems wrong. If it 404s just remove it from terraform state. (let me know if you want an ACC test for this scenario)

https://postimg.cc/2LxR6WGF