### PR TITLE
Update github_repository docs

### DIFF
--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -55,12 +55,11 @@ The following arguments are supported:
 * `has_downloads` - (Optional) Set to `true` to enable the (deprecated)
   downloads features on the repository.
 
-* `auto_init` - (Optional) Meaningful only during create; set to `true` to
-  produce an initial commit in the repository.
+* `auto_init` - (Optional) Set to `true` to produce an initial commit in the repository.
 
-* `gitignore_template` - (Optional) Meaningful only during create, will be ignored after repository creation. Use the [name of the template](https://github.com/github/gitignore) without the extension. For example, "Haskell".
+* `gitignore_template` - (Optional) Use the [name of the template](https://github.com/github/gitignore) without the extension. For example, "Haskell".
 
-* `license_template` - (Optional) Meaningful only during create, will be ignored after repository creation. Use the [name of the template](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses) without the extension. For example, "mit" or "mpl-2.0".
+* `license_template` - (Optional) Use the [name of the template](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses) without the extension. For example, "mit" or "mpl-2.0".
 
 * `default_branch` - (Optional) The name of the default branch of the repository. **NOTE:** This can only be set after a repository has already been created,
 and after a correct reference has been created for the target branch inside the repository. This means a user will have to omit this parameter from the


### PR DESCRIPTION
After PR #135, auto_init, license_template, and gitignore_template now all
have ForceNew set to true, which means they *will* affect the resource after
initial creation. See also #148, #155, #164
