### PR TITLE
[v0.12-beta2] Include required review count

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceGithubBranchProtection() *schema.Resource {
@@ -95,6 +96,12 @@ func resourceGithubBranchProtection() *schema.Resource {
 						"require_code_owner_reviews": {
 							Type:     schema.TypeBool,
 							Optional: true,
+						},
+						"required_approving_review_count": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      1,
+							ValidateFunc: validation.IntBetween(1, 6),
 						},
 					},
 				},
@@ -338,10 +345,11 @@ func flattenAndSetRequiredPullRequestReviews(d *schema.ResourceData, protection 
 
 		return d.Set("required_pull_request_reviews", []interface{}{
 			map[string]interface{}{
-				"dismiss_stale_reviews":      rprr.DismissStaleReviews,
-				"dismissal_users":            schema.NewSet(schema.HashString, users),
-				"dismissal_teams":            schema.NewSet(schema.HashString, teams),
-				"require_code_owner_reviews": rprr.RequireCodeOwnerReviews,
+				"dismiss_stale_reviews":           rprr.DismissStaleReviews,
+				"dismissal_users":                 schema.NewSet(schema.HashString, users),
+				"dismissal_teams":                 schema.NewSet(schema.HashString, teams),
+				"require_code_owner_reviews":      rprr.RequireCodeOwnerReviews,
+				"required_approving_review_count": rprr.RequiredApprovingReviewCount,
 			},
 		})
 	}
@@ -427,6 +435,7 @@ func expandRequiredPullRequestReviews(d *schema.ResourceData) (*github.PullReque
 			rprr.DismissalRestrictionsRequest = drr
 			rprr.DismissStaleReviews = m["dismiss_stale_reviews"].(bool)
 			rprr.RequireCodeOwnerReviews = m["require_code_owner_reviews"].(bool)
+			rprr.RequiredApprovingReviewCount = m["required_approving_review_count"].(int)
 		}
 
 		return rprr, nil


### PR DESCRIPTION
This PR is important when upgrading `go-github`, otherwise updates using this provider will fail.

This commit includes the `required_approving_review_count` field on the
`github_branch_protection` resource, allowing to manage the minimum
amount of reviewers to allow a merge to happen.

This field must be between 1 - 6, according to the docs, and must be
valid if present.

Bumping the `go-github` to `v24` made it default to `0` when not
present, causing the following error

<details>
<summary>GitHub API error when count is 0</summary>

```
422 Invalid request.

No subschema in "anyOf" matched.
0 must be greater than or equal to 1.
Not all subschemas of "allOf" matched.
For 'anyOf/1', {"dismissal_restrictions"=>{"users"=>[], "teams"=>[]}, "dismiss_stale_reviews"=>false, "require_code_owner_reviews"=>true, "required_approving_review_count"=>0} is not a null. []

Payload:
{
 "required_status_checks": {
  "strict": true,
  "contexts": [
   "lint",
   "test"
  ]
 },
 "required_pull_request_reviews": {
  "dismissal_restrictions": {
   "users": [],
   "teams": []
  },
  "dismiss_stale_reviews": false,
  "require_code_owner_reviews": true,
  "required_approving_review_count": 0
 },
 "enforce_admins": true,
 "restrictions": null
}
```
</details>

#### Needs
- [ ] [v0.12-beta2] Bump go-github version v24 (https://github.com/terraform-providers/terraform-provider-github/pull/215)