### PR TITLE
Provide "require signed commits" on `github_branch_protection`

### DIFF
--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -34,6 +34,7 @@ func TestAccGithubBranchProtection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("github_branch_protection.master", "repository", repoName),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "branch", "master"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "enforce_admins", "true"),
+					resource.TestCheckResourceAttr("github_branch_protection.master", "require_signed_commits", "true"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_status_checks.0.strict", "true"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_status_checks.0.contexts.#", "1"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_pull_request_reviews.0.dismiss_stale_reviews", "true"),
@@ -53,6 +54,7 @@ func TestAccGithubBranchProtection_basic(t *testing.T) {
 					testAccCheckGithubBranchProtectionNoPullRequestReviewsExist(&protection),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "repository", repoName),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "branch", "master"),
+					resource.TestCheckResourceAttr("github_branch_protection.master", "require_signed_commits", "false"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_status_checks.0.strict", "false"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_status_checks.0.contexts.#", "1"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_pull_request_reviews.#", "0"),
@@ -106,6 +108,7 @@ func TestAccGithubBranchProtection_teams(t *testing.T) {
 					resource.TestCheckResourceAttr("github_branch_protection.master", "repository", repoName),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "branch", "master"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "enforce_admins", "true"),
+					resource.TestCheckResourceAttr("github_branch_protection.master", "require_signed_commits", "false"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_status_checks.#", "1"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_pull_request_reviews.#", "1"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "restrictions.#", "1"),
@@ -154,6 +157,7 @@ func TestAccGithubBranchProtection_emptyItems(t *testing.T) {
 					resource.TestCheckResourceAttr("github_branch_protection.master", "repository", repoName),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "branch", "master"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "enforce_admins", "true"),
+					resource.TestCheckResourceAttr("github_branch_protection.master", "require_signed_commits", "false"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_status_checks.#", "1"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "required_pull_request_reviews.#", "1"),
 					resource.TestCheckResourceAttr("github_branch_protection.master", "restrictions.#", "1"),
@@ -358,6 +362,7 @@ resource "github_branch_protection" "master" {
   repository = "${github_repository.test.name}"
   branch     = "master"
   enforce_admins = true
+  require_signed_commits = true
 
   required_status_checks {
     strict         = true

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
 * `repository` - (Required) The GitHub repository name.
 * `branch` - (Required) The Git branch to protect.
 * `enforce_admins` - (Optional) Boolean, setting this to `true` enforces status checks for repository administrators.
+* `require_signed_commits` - (Optional) Boolean, setting this to `true` requires all commits to be signed with GPG.
 * `required_status_checks` - (Optional) Enforce restrictions for required status checks. See [Required Status Checks](#required-status-checks) below for details.
 * `required_pull_request_reviews` - (Optional) Enforce restrictions for pull request reviews. See [Required Pull Request Reviews](#required-pull-request-reviews) below for details.
 * `restrictions` - (Optional) Enforce restrictions for the users and teams that may push to the branch. See [Restrictions](#restrictions) below for details.


### PR DESCRIPTION
This commit provides changing the toggle to require signed commits on branch protection.

The [API for signed commits](https://developer.github.com/v3/repos/branches/#get-required-signatures-of-protected-branch) is separate endpoint from the branch protection url, and does not come on the same payload. This means that we need to make an extra request to read and modify it.

Closes https://github.com/terraform-providers/terraform-provider-github/issues/87