### PR TITLE
Add instructions for getting the acceptance tests passing with any test org

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ $ gnumake build
 
 Using the provider
 ----------------------
-## Fill in for each provider
+
+Detailed documentation for the GitHub provider can be found [here](https://www.terraform.io/docs/providers/github/index.html).
 
 Developing the Provider
 ---------------------------
@@ -63,3 +64,38 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 ```sh
 $ make testacc
 ```
+
+Acceptance test prerequisites
+-----------------------------
+In order to successfully run the full suite of acceptance tests, you will need to have the following:
+
+### GitHub personal access token
+You will need to create a [personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) for
+testing. It will need to have the following scopes selected:
+* repo
+* admin:org
+* admin:public_key
+* admin:repo_hook
+* admin:org_hook
+* user
+* delete_repo
+* admin:gpg_key
+
+Once the token has been created, it must be exported in your environment as `GITHUB_TOKEN`.
+
+### GitHub organization
+If you do not have an organization already that you are comfortable running tests again, you will need to [create one](https://help.github.com/en/articles/creating-a-new-organization-from-scratch). The free "Team for Open Source" org type is fine for these tests. The name of the
+organization must then be exported in your environment as `GITHUB_ORGANIZATION`.
+
+### Test repository
+In the organization you are using above, create a test repository named `test-repo`. Make sure the repository is configured as follows:
+* The description should be `Test description, used in GitHub Terraform provider acceptance test.`
+* The website url should be `http://www.example.com`
+* Create two topics within the repo named `test-topic` and `second-test-topic`
+* In the repo settings, make sure all features and merge button options are enabled.
+
+### GitHub users
+Export your github username (the one you used to create the personal access token above) as `GITHUB_TEST_USER`. You will need to export a
+different github username as `GITHUB_TEST_COLLABORATOR`. Please note that these usernames cannot be the same as each other, and both of them
+must be real github usernames. The collaborator user does not need to be added as a collaborator to your test repo or organization, but as
+the acceptance tests do real things (and will trigger some notifications for this user), you should probably make sure the person you specify knows that you're doing this just to be nice.

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -41,7 +41,7 @@ func TestAccGithubRepositoryDataSource_name_noMatchReturnsError(t *testing.T) {
 }
 
 func TestAccGithubRepositoryDataSource_fullName_existing(t *testing.T) {
-	fullName := "terraformtesting/test-repo"
+	fullName := testOrganization + "/test-repo"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -85,13 +85,13 @@ func testRepoCheck() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr("data.github_repository.test", "allow_squash_merge", "true"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "allow_rebase_merge", "true"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "has_downloads", "true"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "full_name", "terraformtesting/test-repo"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "full_name", testOrganization+"/test-repo"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "default_branch", "master"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "html_url", "https://github.com/terraformtesting/test-repo"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "ssh_clone_url", "git@github.com:terraformtesting/test-repo.git"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "svn_url", "https://github.com/terraformtesting/test-repo"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "git_clone_url", "git://github.com/terraformtesting/test-repo.git"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "http_clone_url", "https://github.com/terraformtesting/test-repo.git"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "html_url", "https://github.com/"+testOrganization+"/test-repo"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "ssh_clone_url", "git@github.com:"+testOrganization+"/test-repo.git"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "svn_url", "https://github.com/"+testOrganization+"/test-repo"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "git_clone_url", "git://github.com/"+testOrganization+"/test-repo.git"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "http_clone_url", "https://github.com/"+testOrganization+"/test-repo.git"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "archived", "false"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "topics.#", "2"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "topics.0", "second-test-topic"),

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -17,6 +17,7 @@ import (
 
 var testUser string = os.Getenv("GITHUB_TEST_USER")
 var testCollaborator string = os.Getenv("GITHUB_TEST_COLLABORATOR")
+var testOrganization string = os.Getenv("GITHUB_ORGANIZATION")
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProviderFactories func(providers *[]*schema.Provider) map[string]terraform.ResourceProviderFactory


### PR DESCRIPTION
The acceptance tests used to be hardcoded to a specific `terraformtesting` organization. This changes that to a variable and adds instructions for people to set up and run the acceptance tests with their own organization.