### PR TITLE
Add option to skip RateLimitTransport

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -12,11 +12,11 @@ import (
 )
 
 type Config struct {
-	Token        string
-	Organization string
-	BaseURL      string
-	Insecure     bool
-	Serial       bool
+	Token          string
+	Organization   string
+	BaseURL        string
+	Insecure       bool
+	SerialRequests bool
 }
 
 type Organization struct {
@@ -44,7 +44,7 @@ func (c *Config) Client() (interface{}, error) {
 
 	tc.Transport = NewEtagTransport(tc.Transport)
 
-	if c.Serial {
+	if c.SerialRequests {
 		tc.Transport = NewRateLimitTransport(tc.Transport)
 	}
 

--- a/github/config.go
+++ b/github/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Organization string
 	BaseURL      string
 	Insecure     bool
+	Serial       bool
 }
 
 type Organization struct {
@@ -43,7 +44,9 @@ func (c *Config) Client() (interface{}, error) {
 
 	tc.Transport = NewEtagTransport(tc.Transport)
 
-	tc.Transport = NewRateLimitTransport(tc.Transport)
+	if c.Serial {
+		tc.Transport = NewRateLimitTransport(tc.Transport)
+	}
 
 	tc.Transport = logging.NewTransport("Github", tc.Transport)
 

--- a/github/provider.go
+++ b/github/provider.go
@@ -33,11 +33,11 @@ func Provider() terraform.ResourceProvider {
 				Default:     false,
 				Description: descriptions["insecure"],
 			},
-			"serial": {
+			"serial_requests": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: descriptions["serial"],
+				Description: descriptions["serial_requests"],
 			},
 		},
 
@@ -89,7 +89,7 @@ func init() {
 		"insecure": "Whether server should be accessed " +
 			"without verifying the TLS certificate.",
 
-		"serial": "Whether server should be accessed " +
+		"serial_requests": "Whether server should be accessed " +
 			"serially or concurrently. " +
 			"Concurrent is faster but requests may reach Github API " +
 			"rate limit when more than 5000 requests are made " +
@@ -100,11 +100,11 @@ func init() {
 func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 	return func(d *schema.ResourceData) (interface{}, error) {
 		config := Config{
-			Token:        d.Get("token").(string),
-			Organization: d.Get("organization").(string),
-			BaseURL:      d.Get("base_url").(string),
-			Insecure:     d.Get("insecure").(bool),
-			Serial:       d.Get("serial").(bool),
+			Token:          d.Get("token").(string),
+			Organization:   d.Get("organization").(string),
+			BaseURL:        d.Get("base_url").(string),
+			Insecure:       d.Get("insecure").(bool),
+			SerialRequests: d.Get("serial_requests").(bool),
 		}
 
 		meta, err := config.Client()

--- a/github/provider.go
+++ b/github/provider.go
@@ -93,7 +93,7 @@ func init() {
 			"serially or concurrently. " +
 			"Concurrent is faster but requests may reach Github API " +
 			"rate limit when more than 5000 requests are made " +
-			"within an hour and can't be retried.",
+			"within an hour. Concurrent requests can't be retried.",
 	}
 }
 

--- a/github/provider.go
+++ b/github/provider.go
@@ -33,6 +33,12 @@ func Provider() terraform.ResourceProvider {
 				Default:     false,
 				Description: descriptions["insecure"],
 			},
+			"serial": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: descriptions["serial"],
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -82,6 +88,12 @@ func init() {
 
 		"insecure": "Whether server should be accessed " +
 			"without verifying the TLS certificate.",
+
+		"serial": "Whether server should be accessed " +
+			"serially or concurrently. " +
+			"Concurrent is faster but requests may reach Github API " +
+			"rate limit when more than 5000 requests are made " +
+			"within an hour and can't be retried.",
 	}
 }
 
@@ -92,6 +104,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			Organization: d.Get("organization").(string),
 			BaseURL:      d.Get("base_url").(string),
 			Insecure:     d.Get("insecure").(bool),
+			Serial:       d.Get("serial").(bool),
 		}
 
 		meta, err := config.Client()

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -51,3 +51,9 @@ The following arguments are supported in the `provider` block:
   There is a number of ways to obtain trusted certificate for free, e.g. from [Let's Encrypt](https://letsencrypt.org/).
   Such trusted certificate *does not require* this option to be enabled.
   Defaults to `false`.
+
+* `serial_requests` - (Optional) Whether the server should be accessed serially or concurrently.
+  Concurrent is faster but requests may reach Github API rate limit when more than 5000 requests are made 
+  within an hour. Concurrent requests can't be retried. This option is better suited for smaller teams or 
+  unfrequent changes. If this is turned off and the request limit is reached errors will not be handled 
+  automatically.


### PR DESCRIPTION
As RateLimitTransport requires requests not to be concurrent (https://github.com/terraform-providers/terraform-provider-github/pull/145), this PR adds the option to skip that.

Many users will not hit the 5000 requests per hour stated by Github or can handle it manually. Making all requests serially to everyone adds a time burden that small teams do not need to handle, thus could be explicitly skipped.