### PR TITLE
Bug Fix: import `github_repository`

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -225,6 +225,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("homepage_url", repo.Homepage)
 	d.Set("private", repo.Private)
 	d.Set("has_issues", repo.HasIssues)
+	d.Set("has_projects", repo.HasProjects)
 	d.Set("has_wiki", repo.HasWiki)
 	d.Set("allow_merge_commit", repo.AllowMergeCommit)
 	d.Set("allow_squash_merge", repo.AllowSquashMerge)

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -209,6 +209,29 @@ func TestAccGithubRepository_importBasic(t *testing.T) {
 	})
 }
 
+func TestAccGithubRepository_importHasProjects(t *testing.T) {
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubRepositoryConfigHasProjects(randString),
+			},
+			{
+				ResourceName:      "github_repository.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"auto_init",
+				},
+			},
+		},
+	})
+}
+
 func TestAccGithubRepository_defaultBranch(t *testing.T) {
 	var repo github.Repository
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -478,6 +501,9 @@ func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testA
 		if *repo.HasIssues != want.HasIssues {
 			return fmt.Errorf("got has issues %#v; want %#v", *repo.HasIssues, want.HasIssues)
 		}
+		if *repo.HasProjects != want.HasProjects {
+			return fmt.Errorf("got has projects %#v; want %#v", *repo.HasProjects, want.HasProjects)
+		}
 		if *repo.HasWiki != want.HasWiki {
 			return fmt.Errorf("got has wiki %#v; want %#v", *repo.HasWiki, want.HasWiki)
 		}
@@ -641,6 +667,15 @@ resource "github_repository" "foo" {
   auto_init = false
 }
 `, randString, randString)
+}
+
+func testAccGithubRepositoryConfigHasProjects(randString string) string {
+	return fmt.Sprintf(`
+resource "github_repository" "foo" {
+  name = "tf-acc-test-%s"
+  has_projects = true
+}
+`, randString)
 }
 
 func testAccGithubRepositoryUpdateConfig(randString string) string {

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -672,7 +672,7 @@ resource "github_repository" "foo" {
 func testAccGithubRepositoryConfigHasProjects(randString string) string {
 	return fmt.Sprintf(`
 resource "github_repository" "foo" {
-  name = "tf-acc-test-%s"
+  name         = "tf-acc-test-%s"
   has_projects = true
 }
 `, randString)


### PR DESCRIPTION
Addressing #229 where `has_projects` wasn't being imported
Before fix:
```
        (map[string]string) (len=1) {
         (string) (len=12) "has_projects": (string) (len=4) "true"
        }

FAIL
```
After fix:
```
=== RUN   TestAccGithubRepository_importHasProjects
--- PASS: TestAccGithubRepository_importHasProjects (7.24s)
PASS
```