### PR TITLE
td-update-to-parallel-tests

### DIFF
--- a/github/data_source_github_collaborators_test.go
+++ b/github/data_source_github_collaborators_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccGithubCollaboratorsDataSource_basic(t *testing.T) {
 	repoName := fmt.Sprintf("tf-acc-test-collab-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},

--- a/github/data_source_github_ip_ranges_test.go
+++ b/github/data_source_github_ip_ranges_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAccGithubIpRangesDataSource_existing(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},

--- a/github/data_source_github_repositories_test.go
+++ b/github/data_source_github_repositories_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccGithubRepositoriesDataSource_basic(t *testing.T) {
 	query := "org:hashicorp repository:terraform"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -28,7 +28,7 @@ func TestAccGithubRepositoriesDataSource_basic(t *testing.T) {
 	})
 }
 func TestAccGithubRepositoriesDataSource_Sort(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -56,7 +56,7 @@ func TestAccGithubRepositoriesDataSource_Sort(t *testing.T) {
 
 func TestAccGithubRepositoriesDataSource_noMatch(t *testing.T) {
 	query := "klsafj_23434_doesnt_exist"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccGithubRepositoryDataSource_fullName_noMatchReturnsError(t *testing.T) {
 	fullName := "klsafj_23434_doesnt_exist/not-exists"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -26,7 +26,7 @@ func TestAccGithubRepositoryDataSource_fullName_noMatchReturnsError(t *testing.T
 
 func TestAccGithubRepositoryDataSource_name_noMatchReturnsError(t *testing.T) {
 	name := "not-exists"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -42,7 +42,7 @@ func TestAccGithubRepositoryDataSource_name_noMatchReturnsError(t *testing.T) {
 
 func TestAccGithubRepositoryDataSource_fullName_existing(t *testing.T) {
 	fullName := testOrganization + "/test-repo"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -58,7 +58,7 @@ func TestAccGithubRepositoryDataSource_fullName_existing(t *testing.T) {
 
 func TestAccGithubRepositoryDataSource_name_existing(t *testing.T) {
 	name := "test-repo"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},

--- a/github/data_source_github_team_test.go
+++ b/github/data_source_github_team_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccGithubTeamDataSource_noMatchReturnsError(t *testing.T) {
 	slug := "non-existing"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},

--- a/github/data_source_github_user_test.go
+++ b/github/data_source_github_user_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccGithubUserDataSource_noMatchReturnsError(t *testing.T) {
 	username := "admin"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -26,7 +26,7 @@ func TestAccGithubUserDataSource_noMatchReturnsError(t *testing.T) {
 
 func TestAccGithubUserDataSource_existing(t *testing.T) {
 	username := "raphink"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -88,7 +88,7 @@ func TestProvider_insecure(t *testing.T) {
 `
 
 	username := "hashibot"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -19,7 +19,7 @@ func TestAccGithubBranchProtection_basic(t *testing.T) {
 	rString := acctest.RandString(5)
 	repoName := fmt.Sprintf("tf-acc-test-branch-prot-%s", rString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubBranchProtectionDestroy,
@@ -73,7 +73,7 @@ func TestAccGithubBranchProtection_teams(t *testing.T) {
 	secondTeamName := fmt.Sprintf("team 2 %s", rString)
 	secondTeamSlug := fmt.Sprintf("team-2-%s", rString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubBranchProtectionDestroy,
@@ -142,7 +142,7 @@ func TestAccGithubBranchProtection_emptyItems(t *testing.T) {
 	rString := acctest.RandString(5)
 	repoName := fmt.Sprintf("tf-acc-test-branch-prot-%s", rString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubBranchProtectionDestroy,
@@ -166,7 +166,7 @@ func TestAccGithubBranchProtection_emptyItems(t *testing.T) {
 func TestAccGithubBranchProtection_importBasic(t *testing.T) {
 	rString := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubBranchProtectionDestroy,

--- a/github/resource_github_issue_label_test.go
+++ b/github/resource_github_issue_label_test.go
@@ -17,7 +17,7 @@ func TestAccGithubIssueLabel_basic(t *testing.T) {
 	rString := acctest.RandString(5)
 	repoName := fmt.Sprintf("tf-acc-test-branch-issue-label-%s", rString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubIssueLabelDestroy,
@@ -46,7 +46,7 @@ func TestAccGithubIssueLabel_existingLabel(t *testing.T) {
 	rString := acctest.RandString(5)
 	repoName := fmt.Sprintf("tf-acc-test-branch-issue-label-%s", rString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubIssueLabelDestroy,
@@ -66,7 +66,7 @@ func TestAccGithubIssueLabel_importBasic(t *testing.T) {
 	rString := acctest.RandString(5)
 	repoName := fmt.Sprintf("tf-acc-test-branch-issue-label-%s", rString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubIssueLabelDestroy,
@@ -91,7 +91,7 @@ func TestAccGithubIssueLabel_description(t *testing.T) {
 	description := "Terraform Acceptance Test"
 	updatedDescription := "Terraform Acceptance Test Updated"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubIssueLabelDestroy,

--- a/github/resource_github_membership_test.go
+++ b/github/resource_github_membership_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccGithubMembership_basic(t *testing.T) {
 	var membership github.Membership
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubMembershipDestroy,
@@ -30,7 +30,7 @@ func TestAccGithubMembership_basic(t *testing.T) {
 }
 
 func TestAccGithubMembership_importBasic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubMembershipDestroy,

--- a/github/resource_github_organization_project_test.go
+++ b/github/resource_github_organization_project_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccGithubOrganizationProject_basic(t *testing.T) {
 	var project github.Project
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubOrganizationProjectDestroy,
@@ -35,7 +35,7 @@ func TestAccGithubOrganizationProject_basic(t *testing.T) {
 }
 
 func TestAccGithubOrganizationProject_importBasic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubOrganizationProjectDestroy,

--- a/github/resource_github_organization_webhook_test.go
+++ b/github/resource_github_organization_webhook_test.go
@@ -16,7 +16,7 @@ import (
 func TestAccGithubOrganizationWebhook_basic(t *testing.T) {
 	var hook github.Hook
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubOrganizationWebhookDestroy,
@@ -58,7 +58,7 @@ func TestAccGithubOrganizationWebhook_basic(t *testing.T) {
 func TestAccGithubOrganizationWebhook_secret(t *testing.T) {
 	var hook github.Hook
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubOrganizationWebhookDestroy,

--- a/github/resource_github_project_column_test.go
+++ b/github/resource_github_project_column_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccGithubProjectColumn_basic(t *testing.T) {
 	var column github.ProjectColumn
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubProjectColumnDestroy,
@@ -42,7 +42,7 @@ func TestAccGithubProjectColumn_basic(t *testing.T) {
 }
 
 func TestAccGithubProjectColumn_importBasic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubProjectColumnDestroy,

--- a/github/resource_github_repository_collaborator_test.go
+++ b/github/resource_github_repository_collaborator_test.go
@@ -17,7 +17,7 @@ func TestAccGithubRepositoryCollaborator_basic(t *testing.T) {
 	resourceName := "github_repository_collaborator.test_repo_collaborator"
 	repoName := fmt.Sprintf("tf-acc-test-collab-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryCollaboratorDestroy,
@@ -38,7 +38,7 @@ func TestAccGithubRepositoryCollaborator_basic(t *testing.T) {
 func TestAccGithubRepositoryCollaborator_importBasic(t *testing.T) {
 	repoName := fmt.Sprintf("tf-acc-test-collab-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryCollaboratorDestroy,

--- a/github/resource_github_repository_deploy_key_test.go
+++ b/github/resource_github_repository_deploy_key_test.go
@@ -55,7 +55,7 @@ func TestAccGithubRepositoryDeployKey_basic(t *testing.T) {
 	repositoryName := fmt.Sprintf("acctest-%s", rs)
 	keyPath := filepath.Join("test-fixtures", "id_rsa.pub")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDeployKeyDestroy,
@@ -79,7 +79,7 @@ func TestAccGithubRepositoryDeployKey_importBasic(t *testing.T) {
 	repositoryName := fmt.Sprintf("acctest-%s", rs)
 	keyPath := filepath.Join("test-fixtures", "id_rsa.pub")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDeployKeyDestroy,

--- a/github/resource_github_repository_project_test.go
+++ b/github/resource_github_repository_project_test.go
@@ -18,7 +18,7 @@ func TestAccGithubRepositoryProject_basic(t *testing.T) {
 	randRepoName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	var project github.Project
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubRepositoryProjectDestroy,
@@ -41,7 +41,7 @@ func TestAccGithubRepositoryProject_basic(t *testing.T) {
 func TestAccGithubRepositoryProject_importBasic(t *testing.T) {
 	randRepoName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubRepositoryProjectDestroy,

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -56,7 +56,7 @@ func TestAccGithubRepository_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 	description := fmt.Sprintf("Terraform acceptance tests %s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,
@@ -108,7 +108,7 @@ func TestAccGithubRepository_archive(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 	description := fmt.Sprintf("Terraform acceptance tests %s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,
@@ -142,7 +142,7 @@ func TestAccGithubRepository_archiveUpdate(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 	description := fmt.Sprintf("Terraform acceptance tests %s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,
@@ -192,7 +192,7 @@ func TestAccGithubRepository_archiveUpdate(t *testing.T) {
 func TestAccGithubRepository_importBasic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,
@@ -212,7 +212,7 @@ func TestAccGithubRepository_importBasic(t *testing.T) {
 func TestAccGithubRepository_importHasProjects(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,
@@ -238,7 +238,7 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 	description := fmt.Sprintf("Terraform acceptance tests %s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,
@@ -296,7 +296,7 @@ func TestAccGithubRepository_templates(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 	description := fmt.Sprintf("Terraform acceptance tests %s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,
@@ -333,7 +333,7 @@ func TestAccGithubRepository_topics(t *testing.T) {
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 	description := fmt.Sprintf("Terraform acceptance tests %s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,
@@ -413,7 +413,7 @@ func TestAccGithubRepository_autoInitForceNew(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,

--- a/github/resource_github_repository_webhook_test.go
+++ b/github/resource_github_repository_webhook_test.go
@@ -18,7 +18,7 @@ func TestAccGithubRepositoryWebhook_basic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	var hook github.Hook
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryWebhookDestroy,
@@ -61,7 +61,7 @@ func TestAccGithubRepositoryWebhook_secret(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	var hook github.Hook
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryWebhookDestroy,
@@ -89,7 +89,7 @@ func TestAccGithubRepositoryWebhook_secret(t *testing.T) {
 func TestAccGithubRepositoryWebhook_importBasic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,
@@ -110,7 +110,7 @@ func TestAccGithubRepositoryWebhook_importBasic(t *testing.T) {
 func TestAccGithubRepositoryWebhook_importSecret(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryDestroy,

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -16,7 +16,7 @@ func TestAccGithubTeamMembership_basic(t *testing.T) {
 	var membership github.Membership
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamMembershipDestroy,
@@ -42,7 +42,7 @@ func TestAccGithubTeamMembership_basic(t *testing.T) {
 func TestAccGithubTeamMembership_importBasic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamMembershipDestroy,

--- a/github/resource_github_team_repository_test.go
+++ b/github/resource_github_team_repository_test.go
@@ -18,7 +18,7 @@ func TestAccGithubTeamRepository_basic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	repoName := fmt.Sprintf("tf-acc-test-team-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamRepositoryDestroy,
@@ -45,7 +45,7 @@ func TestAccGithubTeamRepository_importBasic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	repoName := fmt.Sprintf("tf-acc-test-team-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamRepositoryDestroy,

--- a/github/resource_github_team_test.go
+++ b/github/resource_github_team_test.go
@@ -20,7 +20,7 @@ func TestAccGithubTeam_basic(t *testing.T) {
 	description := "Terraform acc test group"
 	updatedDescription := "Terraform acc test group - updated"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamDestroy,
@@ -62,7 +62,7 @@ func TestAccGithubTeam_slug(t *testing.T) {
 	description := "Terraform acc test group"
 	expectedSlug := fmt.Sprintf("tf-acc-test-%s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamDestroy,
@@ -90,7 +90,7 @@ func TestAccGithubTeam_hierarchical(t *testing.T) {
 	parentName := fmt.Sprintf("tf-acc-parent-%s", randString)
 	childName := fmt.Sprintf("tf-acc-child-%s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamDestroy,
@@ -112,7 +112,7 @@ func TestAccGithubTeam_importBasic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamDestroy,

--- a/github/resource_github_user_gpg_key_test.go
+++ b/github/resource_github_user_gpg_key_test.go
@@ -18,7 +18,7 @@ func TestAccGithubUserGpgKey_basic(t *testing.T) {
 	keyRe := regexp.MustCompile("^-----BEGIN PGP PUBLIC KEY BLOCK-----")
 	pubKeyPath := filepath.Join("test-fixtures", "gpg-pubkey.asc")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubUserGpgKeyDestroy,

--- a/github/resource_github_user_invitation_accepter_test.go
+++ b/github/resource_github_user_invitation_accepter_test.go
@@ -23,7 +23,7 @@ func TestAccGithubUserInvitationAccepter_basic(t *testing.T) {
 
 	var providers []*schema.Provider
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckGithubUserInvitationAccepterDestroy,

--- a/github/resource_github_user_ssh_key_test.go
+++ b/github/resource_github_user_ssh_key_test.go
@@ -20,7 +20,7 @@ func TestAccGithubUserSshKey_basic(t *testing.T) {
 	keyRe := regexp.MustCompile("^ecdsa-sha2-nistp384 ")
 	urlRe := regexp.MustCompile("^https://api.github.com/[a-z0-9]+/keys/")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubUserSshKeyDestroy,
@@ -42,7 +42,7 @@ func TestAccGithubUserSshKey_importBasic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	title := fmt.Sprintf("tf-acc-test-%s", randString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubUserSshKeyDestroy,

--- a/github/resource_organization_block_test.go
+++ b/github/resource_organization_block_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccOrganizationBlock_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccOrganizationBlockDestroy,
@@ -26,7 +26,7 @@ func TestAccOrganizationBlock_basic(t *testing.T) {
 }
 
 func TestAccOrganizationBlock_importBasic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccOrganizationBlockDestroy,


### PR DESCRIPTION
Updates all tests to `resource.ParallelTest`. May not gain us much speed, but keeps provider in line with other providers.