### PR TITLE
Adds name attribute back to docs.

### DIFF
--- a/website/docs/r/organization_webhook.html.markdown
+++ b/website/docs/r/organization_webhook.html.markdown
@@ -14,6 +14,8 @@ This resource allows you to create and manage webhooks for GitHub organization.
 
 ```hcl
 resource "github_organization_webhook" "foo" {
+  name = "web"
+
   configuration {
     url          = "https://google.de/"
     content_type = "form"
@@ -35,6 +37,8 @@ The following arguments are supported:
 * `configuration` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`.
 
 * `active` - (Optional) Indicate of the webhook should receive events. Defaults to `true`.
+
+* `name` - (Optional) The type of the webhook. `web` is the default and the only option.
 
 ## Attributes Reference
 

--- a/website/docs/r/repository_webhook.html.markdown
+++ b/website/docs/r/repository_webhook.html.markdown
@@ -28,6 +28,8 @@ resource "github_repository" "repo" {
 resource "github_repository_webhook" "foo" {
   repository = "${github_repository.repo.name}"
 
+  name = "web"
+
   configuration {
     url          = "https://google.de/"
     content_type = "form"
@@ -51,6 +53,8 @@ The following arguments are supported:
 * `configuration` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`. `secret` is [the shared secret, see API documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook).
 
 * `active` - (Optional) Indicate of the webhook should receive events. Defaults to `true`.
+
+* `name` - (Optional) The type of the webhook. `web` is the default and the only option.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #197

- Adds `name` attribute back into documentation for `github_organization_webhook` & `github_repository_webhook` (see [CHANGELOG](https://github.com/terraform-providers/terraform-provider-github/blob/master/CHANGELOG.md#210-may-15-2019))