### PR TITLE
Bug Fix: Webhook secret stored incorrectly in state

### DIFF
--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -92,6 +92,11 @@ func resourceGithubOrganizationWebhookCreate(d *schema.ResourceData, meta interf
 	}
 	d.SetId(strconv.FormatInt(*hook.ID, 10))
 
+	if hook.Config["secret"] != nil {
+		hook.Config["secret"] = webhookObj.Config["secret"]
+	}
+	d.Set("configuration", []interface{}{hook.Config})
+
 	return resourceGithubOrganizationWebhookRead(d, meta)
 }
 
@@ -134,6 +139,15 @@ func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interfac
 	d.Set("url", hook.URL)
 	d.Set("active", hook.Active)
 	d.Set("events", hook.Events)
+
+	if len(d.Get("configuration").([]interface{})) > 0 {
+		currentSecret := d.Get("configuration").([]interface{})[0].(map[string]interface{})["secret"]
+
+		if hook.Config["secret"] != nil {
+			hook.Config["secret"] = currentSecret
+		}
+	}
+
 	d.Set("configuration", []interface{}{hook.Config})
 
 	return nil

--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -92,6 +92,9 @@ func resourceGithubOrganizationWebhookCreate(d *schema.ResourceData, meta interf
 	}
 	d.SetId(strconv.FormatInt(*hook.ID, 10))
 
+	// GitHub returns the secret as a string of 8 astrisks "********"
+	// We would prefer to store the real secret in state, so we'll
+	// write the configuration secret in state from our request to GitHub
 	if hook.Config["secret"] != nil {
 		hook.Config["secret"] = webhookObj.Config["secret"]
 	}
@@ -140,6 +143,10 @@ func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interfac
 	d.Set("active", hook.Active)
 	d.Set("events", hook.Events)
 
+	// GitHub returns the secret as a string of 8 astrisks "********"
+	// We would prefer to store the real secret in state, so we'll
+	// write the configuration secret in state from what we get from
+	// ResourceData
 	if len(d.Get("configuration").([]interface{})) > 0 {
 		currentSecret := d.Get("configuration").([]interface{})[0].(map[string]interface{})["secret"]
 

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -111,6 +111,11 @@ func resourceGithubRepositoryWebhookCreate(d *schema.ResourceData, meta interfac
 	}
 	d.SetId(strconv.FormatInt(*hook.ID, 10))
 
+	if hook.Config["secret"] != nil {
+		hook.Config["secret"] = hk.Config["secret"]
+	}
+	d.Set("configuration", []interface{}{hook.Config})
+
 	return resourceGithubRepositoryWebhookRead(d, meta)
 }
 
@@ -152,6 +157,15 @@ func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{
 	d.Set("url", hook.URL)
 	d.Set("active", hook.Active)
 	d.Set("events", hook.Events)
+
+	if len(d.Get("configuration").([]interface{})) > 0 {
+		currentSecret := d.Get("configuration").([]interface{})[0].(map[string]interface{})["secret"]
+
+		if hook.Config["secret"] != nil {
+			hook.Config["secret"] = currentSecret
+		}
+	}
+
 	d.Set("configuration", []interface{}{hook.Config})
 
 	return nil

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -111,6 +111,9 @@ func resourceGithubRepositoryWebhookCreate(d *schema.ResourceData, meta interfac
 	}
 	d.SetId(strconv.FormatInt(*hook.ID, 10))
 
+	// GitHub returns the secret as a string of 8 astrisks "********"
+	// We would prefer to store the real secret in state, so we'll
+	// write the configuration secret in state from our request to GitHub
 	if hook.Config["secret"] != nil {
 		hook.Config["secret"] = hk.Config["secret"]
 	}
@@ -158,6 +161,10 @@ func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{
 	d.Set("active", hook.Active)
 	d.Set("events", hook.Events)
 
+	// GitHub returns the secret as a string of 8 astrisks "********"
+	// We would prefer to store the real secret in state, so we'll
+	// write the configuration secret in state from what we get from
+	// ResourceData
 	if len(d.Get("configuration").([]interface{})) > 0 {
 		currentSecret := d.Get("configuration").([]interface{})[0].(map[string]interface{})["secret"]
 

--- a/github/resource_github_repository_webhook_test.go
+++ b/github/resource_github_repository_webhook_test.go
@@ -119,10 +119,11 @@ func TestAccGithubRepositoryWebhook_importSecret(t *testing.T) {
 				Config: testAccGithubRepositoryWebhookConfig_secret(randString),
 			},
 			{
-				ResourceName:        "github_repository_webhook.foo",
-				ImportState:         true,
-				ImportStateVerify:   true,
-				ImportStateIdPrefix: fmt.Sprintf("foo-%s/", randString),
+				ResourceName:            "github_repository_webhook.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("foo-%s/", randString),
+				ImportStateVerifyIgnore: []string{"configuration.0.secret"}, // github does not allow a read of the actual secret
 			},
 		},
 	})

--- a/github/resource_github_repository_webhook_test.go
+++ b/github/resource_github_repository_webhook_test.go
@@ -117,6 +117,9 @@ func TestAccGithubRepositoryWebhook_importSecret(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGithubRepositoryWebhookConfig_secret(randString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubRepositoryWebhookSecret("github_repository_webhook.foo", "RandomSecretString"),
+				),
 			},
 			{
 				ResourceName:            "github_repository_webhook.foo",
@@ -175,6 +178,21 @@ func testAccCheckGithubRepositoryWebhookAttributes(hook *github.Hook, want *test
 		}
 		if !reflect.DeepEqual(hook.Config, want.Configuration) {
 			return fmt.Errorf("got hook configuration %q; want %q", hook.Config, want.Configuration)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGithubRepositoryWebhookSecret(r, secret string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[r]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", r)
+		}
+
+		if rs.Primary.Attributes["configuration.0.secret"] != secret {
+			return fmt.Errorf("Configured secret in %s does not match secret in state.  (Expected: %s, Actual: %s)", r, secret, rs.Primary.Attributes["configuration.0.secret"])
 		}
 
 		return nil

--- a/github/schema_webhook_configuration.go
+++ b/github/schema_webhook_configuration.go
@@ -23,15 +23,6 @@ func webhookConfigurationSchema() *schema.Schema {
 					Type:      schema.TypeString,
 					Optional:  true,
 					Sensitive: true,
-					DiffSuppressFunc: func(k, oldV, newV string, d *schema.ResourceData) bool {
-						// Undocumented GitHub feature where API returns 8 asterisks in place of the secret
-						maskedSecret := "********"
-						if oldV == maskedSecret {
-							return true
-						}
-
-						return oldV == newV
-					},
 				},
 				"insecure_ssl": {
 					Type:     schema.TypeString,

--- a/website/docs/r/repository_webhook.html.markdown
+++ b/website/docs/r/repository_webhook.html.markdown
@@ -68,3 +68,5 @@ Importing uses the name of the repository, as well as the ID of the webhook, e.g
 ```
 $ terraform import github_repository_webhook.terraform terraform/11235813
 ```
+
+If secret is populated in the webhook's configuration, the value will be imported as "********".


### PR DESCRIPTION
Addressing #171 where the webhook secret set in Terraform makes signatures not match.
Before fix:
```
--- FAIL: TestAccGithubRepositoryWebhook_importSecret (9.38s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) (len=1) {
         (string) (len=22) "configuration.0.secret": (string) (len=8) "********"
        }


        (map[string]string) (len=1) {
         (string) (len=22) "configuration.0.secret": (string) (len=18) "RandomSecretString"
        }
```
After fix:
```
=== RUN   TestAccGithubRepositoryWebhook_importSecret
=== PAUSE TestAccGithubRepositoryWebhook_importSecret
=== CONT  TestAccGithubRepositoryWebhook_importSecret
--- PASS: TestAccGithubRepositoryWebhook_importSecret (9.66s)
PASS
```