### PR TITLE
Check team ID format at plan

### DIFF
--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -24,9 +24,10 @@ func resourceGithubTeamMembership() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"team_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateTeamIDFunc,
 			},
 			"username": {
 				Type:             schema.TypeString,

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -22,9 +22,10 @@ func resourceGithubTeamRepository() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"team_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateTeamIDFunc,
 			},
 			"repository": {
 				Type:     schema.TypeString,

--- a/github/util.go
+++ b/github/util.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -90,4 +91,17 @@ type unconvertibleIdError struct {
 func (e *unconvertibleIdError) Error() string {
 	return fmt.Sprintf("Unexpected ID format (%q), expected numerical ID. %s",
 		e.OriginalId, e.OriginalError.Error())
+}
+
+func validateTeamIDFunc(v interface{}, keyName string) (we []string, errors []error) {
+	teamIDString, ok := v.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %s to be string", keyName)}
+	}
+	// Check that the team ID can be converted to an int
+	if _, err := strconv.ParseInt(teamIDString, 10, 64); err != nil {
+		return nil, []error{unconvertibleIdErr(teamIDString, err)}
+	}
+
+	return
 }

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -5,6 +5,37 @@ import (
 	"unicode"
 )
 
+func TestAccValidateTeamIDFunc(t *testing.T) {
+	// warnings, errors := validateTeamIDFunc(interface{"1234567"})
+
+	cases := []struct {
+		TeamID   interface{}
+		ErrCount int
+	}{
+		{
+
+			TeamID:   "1234567",
+			ErrCount: 0,
+		},
+		{
+			// an int cannot be cast to a string
+			TeamID:   1234567,
+			ErrCount: 1,
+		},
+		{
+			TeamID:   "notAnInt",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateTeamIDFunc(tc.TeamID, "keyName")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %d validation error but got %d", tc.ErrCount, len(errors))
+		}
+	}
+}
+
 func TestAccGithubUtilRole_validation(t *testing.T) {
 	cases := []struct {
 		Value    string


### PR DESCRIPTION
Hi,

I stumble on a _bug_ while authorizing team on a repository using `github_team_repository`.

The faulty code was something like : 
```hcl
resource "github_team_repository" "some_team_repo" {
  team_id    = "github_team.some_team.id"
  repository = "${github_repository.some_repo.name}"
  permission = "pull"
}
```
Simple bug : I forgot to interpolate `github_team.some_team.id` so the provider get the string `github_team.some_team.id` instead of a proper team ID.

It fails at apply with `Unexpected ID format ("github_team.some_team.id"), expected numerical ID. strconv.ParseInt: parsing "github_team.some_team.id": invalid syntax` 

I think it's a kind of error you can catch at plan time easily. 

This PR introduce a validation of `team_id` on the two resource using it as parameters : `github_team_repository` and  `github_team_membership`. 
It is a very basic check function that :
- try to cast the value as a string
- try to convert the string to an int

I tried the github provider on my faulty code it detects the error at plan time as expected.