### PR TITLE
Remove depricated "sidebar_current" from docs website

### DIFF
--- a/website/docs/d/collaborators.html.markdown
+++ b/website/docs/d/collaborators.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_collaborators"
-sidebar_current: "docs-github-datasource-collaborators"
 description: |-
   Get the collaborators for a given repository.
 ---

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_ip_ranges"
-sidebar_current: "docs-github-datasource-ip-ranges"
 description: |-
   Get information on a GitHub's IP addresses.
 ---

--- a/website/docs/d/repositories.html.markdown
+++ b/website/docs/d/repositories.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_repositories"
-sidebar_current: "docs-github-datasource-repositories"
 description: |-
   Search for GitHub repositories
 ---

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_repository"
-sidebar_current: "docs-github-datasource-repository"
 description: |-
   Get details about GitHub repository
 ---

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_team"
-sidebar_current: "docs-github-datasource-team"
 description: |-
   Get information on a GitHub team.
 ---

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_user"
-sidebar_current: "docs-github-datasource-user"
 description: |-
   Get information on a GitHub user.
 ---

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "Provider: GitHub"
-sidebar_current: "docs-github-index"
 description: |-
   The GitHub provider is used to interact with GitHub organization resources.
 ---

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_branch_protection"
-sidebar_current: "docs-github-resource-branch-protection"
 description: |-
   Protects a GitHub branch.
 ---

--- a/website/docs/r/issue_label.html.markdown
+++ b/website/docs/r/issue_label.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_issue_label"
-sidebar_current: "docs-github-resource-issue-label"
 description: |-
   Provides a GitHub issue label resource.
 ---

--- a/website/docs/r/membership.html.markdown
+++ b/website/docs/r/membership.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_membership"
-sidebar_current: "docs-github-resource-membership"
 description: |-
   Provides a GitHub membership resource.
 ---

--- a/website/docs/r/organization_block.html.markdown
+++ b/website/docs/r/organization_block.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_organization_block"
-sidebar_current: "docs-github-resource-organization-block"
 description: |-
   Creates and manages blocks for GitHub organizations
 ---

--- a/website/docs/r/organization_project.html.markdown
+++ b/website/docs/r/organization_project.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_organization_project"
-sidebar_current: "docs-github-resource-organization-project"
 description: |-
   Creates and manages projects for GitHub organizations
 ---

--- a/website/docs/r/organization_webhook.html.markdown
+++ b/website/docs/r/organization_webhook.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_organization_webhook"
-sidebar_current: "docs-github-resource-organization-webhook"
 description: |-
   Creates and manages webhooks for GitHub organizations
 ---

--- a/website/docs/r/project_column.html.markdown
+++ b/website/docs/r/project_column.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_project_column"
-sidebar_current: "docs-github-resource-project-column"
 description: |-
   Creates and manages project columns for GitHub projects
 ---

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_repository"
-sidebar_current: "docs-github-resource-repository-x"
 description: |-
   Creates and manages repositories within GitHub organizations
 ---

--- a/website/docs/r/repository_collaborator.html.markdown
+++ b/website/docs/r/repository_collaborator.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_repository_collaborator"
-sidebar_current: "docs-github-resource-repository-collaborator"
 description: |-
   Provides a GitHub repository collaborator resource.
 ---

--- a/website/docs/r/repository_deploy_key.html.markdown
+++ b/website/docs/r/repository_deploy_key.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_repository_deploy_key"
-sidebar_current: "docs-github-resource-repository-deploy-key"
 description: |-
   Provides a GitHub repository deploy key resource.
 ---

--- a/website/docs/r/repository_project.html.markdown
+++ b/website/docs/r/repository_project.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_repository_project"
-sidebar_current: "docs-github-resource-repository-project"
 description: |-
   Creates and manages projects for GitHub repositories
 ---

--- a/website/docs/r/repository_webhook.html.markdown
+++ b/website/docs/r/repository_webhook.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_repository_webhook"
-sidebar_current: "docs-github-resource-repository-webhook"
 description: |-
   Creates and manages repository webhooks within GitHub organizations
 ---

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_team"
-sidebar_current: "docs-github-resource-team-x"
 description: |-
   Provides a GitHub team resource.
 ---

--- a/website/docs/r/team_membership.html.markdown
+++ b/website/docs/r/team_membership.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_team_membership"
-sidebar_current: "docs-github-resource-team-membership"
 description: |-
   Provides a GitHub team membership resource.
 ---

--- a/website/docs/r/team_repository.html.markdown
+++ b/website/docs/r/team_repository.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_team_repository"
-sidebar_current: "docs-github-resource-team-repository"
 description: |-
   Manages the associations between teams and repositories.
 ---

--- a/website/docs/r/user_gpg_key.html.markdown
+++ b/website/docs/r/user_gpg_key.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_user_gpg_key"
-sidebar_current: "docs-github-resource-user-gpg-key"
 description: |-
   Provides a GitHub user's GPG key resource.
 ---

--- a/website/docs/r/user_invitation_accepter.html.markdown
+++ b/website/docs/r/user_invitation_accepter.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_user_invitation_accepter"
-sidebar_current: "docs-github-resource-user-invitation-accepter"
 description: |-
   Provides a resource to manage GitHub repository collaborator invitations.
 ---

--- a/website/docs/r/user_ssh_key.html.markdown
+++ b/website/docs/r/user_ssh_key.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "github"
 page_title: "GitHub: github_user_ssh_key"
-sidebar_current: "docs-github-resource-user-ssh-key"
 description: |-
   Provides a GitHub user's SSH key resource.
 ---

--- a/website/github.erb
+++ b/website/github.erb
@@ -2,93 +2,93 @@
   <% content_for :sidebar do %>
     <div class="docs-sidebar hidden-print affix-top" role="complementary">
       <ul class="nav docs-sidenav">
-        <li<%= sidebar_current("docs-home") %>>
+        <li>
         <a href="/docs/providers/index.html">All Providers</a>
         </li>
 
-        <li<%= sidebar_current("docs-github-index") %>>
+        <li>
         <a href="/docs/providers/github/index.html">GitHub Provider</a>
         </li>
 
-        <li<%= sidebar_current("docs-github-datasource") %>>
+        <li>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-github-datasource-collaborators") %>>
+            <li>
               <a href="/docs/providers/github/d/collaborators.html">github_collaborators</a>
             </li>
-            <li<%= sidebar_current("docs-github-datasource-ip-ranges") %>>
+            <li>
               <a href="/docs/providers/github/d/ip_ranges.html">github_ip_ranges</a>
             </li>
-            <li<%= sidebar_current("docs-github-datasource-repositories") %>>
+            <li>
               <a href="/docs/providers/github/d/repositories.html">github_repositories</a>
             </li>
-            <li<%= sidebar_current("docs-github-datasource-repository") %>>
+            <li>
               <a href="/docs/providers/github/d/repository.html">github_repository</a>
             </li>
-            <li<%= sidebar_current("docs-github-datasource-user") %>>
+            <li>
               <a href="/docs/providers/github/d/user.html">github_user</a>
             </li>
-            <li<%= sidebar_current("docs-github-datasource-team") %>>
+            <li>
               <a href="/docs/providers/github/d/team.html">github_team</a>
             </li>
           </ul>
         </li>
 
-        <li<%= sidebar_current("docs-github-resource") %>>
+        <li>
         <a href="#">Resources</a>
         <ul class="nav nav-visible">
-          <li<%= sidebar_current("docs-github-resource-branch-protection") %>>
+          <li>
             <a href="/docs/providers/github/r/branch_protection.html">github_branch_protection</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-issue-label") %>>
+          <li>
             <a href="/docs/providers/github/r/issue_label.html">github_issue_label</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-membership") %>>
+          <li>
           <a href="/docs/providers/github/r/membership.html">github_membership</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-organization-block") %>>
+          <li>
             <a href="/docs/providers/github/r/organization_block.html">github_organization_block</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-organization-project") %>>
+          <li>
             <a href="/docs/providers/github/r/organization_project.html">github_organization_project</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-organization-webhook") %>>
+          <li>
             <a href="/docs/providers/github/r/organization_webhook.html">github_organization_webhook</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-project-column") %>>
+          <li>
               <a href="/docs/providers/github/r/project_column.html">github_project_column</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-repository-x") %>>
+          <li>
             <a href="/docs/providers/github/r/repository.html">github_repository</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-repository-collaborator") %>>
+          <li>
             <a href="/docs/providers/github/r/repository_collaborator.html">github_repository_collaborator</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-repository-deploy-key") %>>
+          <li>
             <a href="/docs/providers/github/r/repository_deploy_key.html">github_repository_deploy_key</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-repository-project") %>>
+          <li>
             <a href="/docs/providers/github/r/repository_project.html">github_repository_project</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-repository-webhook") %>>
+          <li>
             <a href="/docs/providers/github/r/repository_webhook.html">github_repository_webhook</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-team-x") %>>
+          <li>
             <a href="/docs/providers/github/r/team.html">github_team</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-team-membership") %>>
+          <li>
             <a href="/docs/providers/github/r/team_membership.html">github_team_membership</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-team-repository") %>>
+          <li>
             <a href="/docs/providers/github/r/team_repository.html">github_team_repository</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-user-gpg-key") %>>
+          <li>
             <a href="/docs/providers/github/r/user_gpg_key.html">github_user_gpg_key</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-user-invitation-accepter") %>>
+          <li>
             <a href="/docs/providers/github/r/user_invitation_accepter.html">github_user_invitation_accepter</a>
           </li>
-          <li<%= sidebar_current("docs-github-resource-user-ssh-key") %>>
+          <li>
             <a href="/docs/providers/github/r/user_ssh_key.html">github_user_ssh_key</a>
           </li>
         </ul>


### PR DESCRIPTION
This PR removes the now [deprecated](https://github.com/hashicorp/terraform-website#yaml-frontmatter) `sidebar_current` YAML Frontmatter from all docs pages. In addition, this PR removes calls to the `sidebar_current` method in the navigation sidebar because, "they were for a hack that isn't needed anymore." [[source](https://github.com/hashicorp/terraform-website#css-classes-for-sidebars)]

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```