### PR TITLE
Support for 'maintain' and 'triage' as team permissions

### DIFF
--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -36,7 +36,7 @@ func resourceGithubTeamRepository() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "pull",
-				ValidateFunc: validateValueFunc([]string{"pull", "push", "admin"}),
+				ValidateFunc: validateValueFunc([]string{"pull", "triage", "push", "maintain", "admin"}),
 			},
 			"etag": {
 				Type:     schema.TypeString,

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -36,7 +36,7 @@ func resourceGithubTeamRepository() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "pull",
-				ValidateFunc: validateValueFunc([]string{"pull", "triage", "push", "maintain", "admin"}),
+				ValidateFunc: validateValueFunc([]string{"pull", "push", "admin"}),
 			},
 			"etag": {
 				Type:     schema.TypeString,

--- a/vendor/github.com/google/go-github/v28/github/apps.go
+++ b/vendor/github.com/google/go-github/v28/github/apps.go
@@ -26,8 +26,9 @@ type App struct {
 	Description *string    `json:"description,omitempty"`
 	ExternalURL *string    `json:"external_url,omitempty"`
 	HTMLURL     *string    `json:"html_url,omitempty"`
-	CreatedAt   *Timestamp `json:"created_at,omitempty"`
-	UpdatedAt   *Timestamp `json:"updated_at,omitempty"`
+	CreatedAt   *time.Time `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+	Slug        *string    `json:"slug,omitempty"`
 }
 
 // InstallationToken represents an installation token.

--- a/vendor/github.com/google/go-github/v28/github/repos.go
+++ b/vendor/github.com/google/go-github/v28/github/repos.go
@@ -771,6 +771,7 @@ type BranchRestrictions struct {
 	Users []*User `json:"users"`
 	// The list of team slugs with push access.
 	Teams []*Team `json:"teams"`
+	Apps  []*App  `json:"apps"`
 }
 
 // BranchRestrictionsRequest represents the request to create/edit the
@@ -782,6 +783,7 @@ type BranchRestrictionsRequest struct {
 	Users []string `json:"users"`
 	// The list of team slugs with push access. (Required; use []string{} instead of nil for empty list.)
 	Teams []string `json:"teams"`
+	Apps  []string `json:"apps"`
 }
 
 // DismissalRestrictions specifies which users and teams can dismiss pull request reviews.


### PR DESCRIPTION
Simple PR to add support for triage and maintain as team roles.

Successfully tested using a terraform apply in our environment.  It works despite Github API documentation not officially showing this is available (as of 11/15/2019).