### PR TITLE
Gposton/branch protection apps

### DIFF
--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 Protects a GitHub branch.
 
-This resource allows you to configure branch protection for repositories in your organization. When applied, the branch will be protected from forced pushes and deletion. Additional constraints, such as required status checks or restrictions on users and teams, can also be configured.
+This resource allows you to configure branch protection for repositories in your organization. When applied, the branch will be protected from forced pushes and deletion. Additional constraints, such as required status checks or restrictions on users, teams, and apps, can also be configured.
 
 ## Example Usage
 
@@ -36,6 +36,7 @@ resource "github_branch_protection" "example" {
   restrictions {
     users = ["foo-user"]
     teams = ["${github_team.example.slug}"]
+    apps  = ["foo-app"]
   }
 }
 
@@ -86,6 +87,7 @@ The following arguments are supported:
 
 * `users`: (Optional) The list of user logins with push access.
 * `teams`: (Optional) The list of team slugs with push access.
+* `apps`: (Optional) The list of app slugs with push access.
   Always use `slug` of the team, **not** its name. Each team already **has** to have access to the repository.
 
 `restrictions` is only available for organization-owned repositories.


### PR DESCRIPTION
Adds support for assigning 'apps' in branch protection rules.

Note that this requires changes from upstream vendor (google/go-github) to be vendor'd in.

See upstream vendor PR here: https://github.com/google/go-github/pull/1337

Note: From the comments in the above PR, it looks like this PR is the one that's actually going to land (same functionality) https://github.com/google/go-github/pull/1283