### PR TITLE
go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/terraform-providers/terraform-provider-github
 
 require (
+	github.com/google/go-github/v25 v25.1.3
 	github.com/hashicorp/terraform v0.12.7
-	github.com/google/go-github/v28 v28.0.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/terraform-providers/terraform-provider-tls v1.2.0
 	golang.org/x/oauth2 v0.0.0-20190604054615-0f29369cfe45


### PR DESCRIPTION
The update was made [by the renovate bot](https://github.com/terraform-providers/terraform-provider-github/pull/274), but in reality that version was never used, because no import paths were updated.

I turned off the renovate bot for that reason, to prevent similar messy upgrades in the future. We can turn it back on at some point, but someone will need to investigate configuration and whether it's even possible for the bot to update import paths.