### PR TITLE
Add triage and maintain repo permissions

### DIFF
--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -37,7 +37,7 @@ func resourceGithubRepositoryCollaborator() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "push",
-				ValidateFunc: validateValueFunc([]string{"pull", "push", "admin"}),
+				ValidateFunc: validateValueFunc([]string{"pull", "triage", "push", "maintain", "admin"}),
 			},
 			"invitation_id": {
 				Type:     schema.TypeString,

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -36,7 +36,7 @@ func resourceGithubTeamRepository() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "pull",
-				ValidateFunc: validateValueFunc([]string{"pull", "push", "admin"}),
+				ValidateFunc: validateValueFunc([]string{"pull", "triage", "push", "maintain", "admin"}),
 			},
 			"etag": {
 				Type:     schema.TypeString,

--- a/github/resource_github_team_repository_test.go
+++ b/github/resource_github_team_repository_test.go
@@ -48,19 +48,31 @@ func TestAccGithubTeamRepository_basic(t *testing.T) {
 }
 
 func TestAccCheckGetPermissions(t *testing.T) {
-	pullMap := map[string]bool{"pull": true, "push": false, "admin": false}
-	pushMap := map[string]bool{"pull": true, "push": true, "admin": false}
-	adminMap := map[string]bool{"pull": true, "push": true, "admin": true}
-	errorMap := map[string]bool{"pull": false, "push": false, "admin": false}
+	pullMap := map[string]bool{"pull": true, "triage": false, "push": false, "maintain": false, "admin": false}
+	triageMap := map[string]bool{"pull": false, "triage": true, "push": false, "maintain": false, "admin": false}
+	pushMap := map[string]bool{"pull": true, "triage": false, "push": true, "maintain": false, "admin": false}
+	maintainMap := map[string]bool{"pull": false, "triage": false, "push": false, "maintain": true, "admin": false}
+	adminMap := map[string]bool{"pull": true, "triage": false, "push": true, "maintain": false, "admin": true}
+	errorMap := map[string]bool{"pull": false, "triage": false, "push": false, "maintain": false, "admin": false}
 
 	pull, _ := getRepoPermission(&pullMap)
 	if pull != "pull" {
 		t.Fatalf("Expected pull permission, actual: %s", pull)
 	}
 
+	triage, _ := getRepoPermission(&triageMap)
+	if triage != "triage" {
+		t.Fatalf("Expected triage permission, actual: %s", triage)
+	}
+
 	push, _ := getRepoPermission(&pushMap)
 	if push != "push" {
 		t.Fatalf("Expected push permission, actual: %s", push)
+	}
+
+	maintain, _ := getRepoPermission(&maintainMap)
+	if maintain != "maintain" {
+		t.Fatalf("Expected maintain permission, actual: %s", maintain)
 	}
 
 	admin, _ := getRepoPermission(&adminMap)

--- a/github/util_permissions.go
+++ b/github/util_permissions.go
@@ -8,12 +8,13 @@ import (
 )
 
 const (
-	pullPermission  string = "pull"
-	pushPermission  string = "push"
-	adminPermission string = "admin"
-
-	writePermission string = "write"
-	readPermission  string = "read"
+	pullPermission     string = "pull"
+	triagePermission   string = "triage"
+	pushPermission     string = "push"
+	maintainPermission string = "maintain"
+	adminPermission    string = "admin"
+	writePermission    string = "write"
+	readPermission     string = "read"
 )
 
 func getRepoPermission(p *map[string]bool) (string, error) {
@@ -23,8 +24,12 @@ func getRepoPermission(p *map[string]bool) (string, error) {
 	// permission, the map will be: {"pull": true, "push": true, "admin": false}
 	if (*p)[adminPermission] {
 		return adminPermission, nil
+	} else if (*p)[maintainPermission] {
+		return maintainPermission, nil
 	} else if (*p)[pushPermission] {
 		return pushPermission, nil
+	} else if (*p)[triagePermission] {
+		return triagePermission, nil
 	} else {
 		if (*p)[pullPermission] {
 			return pullPermission, nil

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,7 @@ require (
 	github.com/hashicorp/terraform v0.12.7
 	github.com/kylelemons/godebug v1.1.0
 	github.com/terraform-providers/terraform-provider-tls v1.2.0
-	golang.org/x/oauth2 v0.0.0-20190604054615-0f29369cfe45
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,3 @@ require (
 	github.com/terraform-providers/terraform-provider-tls v1.2.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 )
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604054615-0f29369cfe45 h1:7WTIev2se641DAZGtJcRvZBxQ1TvY+9GTffZHngkGHY=
 golang.org/x/oauth2 v0.0.0-20190604054615-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=


### PR DESCRIPTION
Closes #279 

This PR makes the `triage` and `maintain` repository permissions available. See https://github.blog/2019-10-03-delegate-responsibilities-with-expanded-repository-permissions/