### PR TITLE
Correct timestamp for oauth2 module in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,7 @@ require (
 	github.com/hashicorp/terraform v0.12.7
 	github.com/kylelemons/godebug v1.1.0
 	github.com/terraform-providers/terraform-provider-tls v1.2.0
-	golang.org/x/oauth2 v0.0.0-20190604054615-0f29369cfe45
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604054615-0f29369cfe45 h1:7WTIev2se641DAZGtJcRvZBxQ1TvY+9GTffZHngkGHY=
 golang.org/x/oauth2 v0.0.0-20190604054615-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=


### PR DESCRIPTION
The timestamp in go.mod does not match the timestamp in the
oauth2 repository, and thus all of the golang tools complain about
it. This patch corrects go.mod and go.sum to match the timestamp.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>