### PR TITLE
Refactor: cleanup usage of parseTwoPartID

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -195,7 +195,7 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 
 	client := meta.(*Organization).client
 
-	repoName, branch, err := parseTwoPartID(d.Id())
+	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 	}
 
 	client := meta.(*Organization).client
-	repoName, branch, err := parseTwoPartID(d.Id())
+	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ func resourceGithubBranchProtectionDelete(d *schema.ResourceData, meta interface
 	}
 
 	client := meta.(*Organization).client
-	repoName, branch, err := parseTwoPartID(d.Id())
+	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func flattenAndSetRequiredStatusChecks(d *schema.ResourceData, protection *githu
 func requireSignedCommitsRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Organization).client
 
-	repoName, branch, err := parseTwoPartID(d.Id())
+	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
 	}
@@ -404,7 +404,7 @@ func requireSignedCommitsUpdate(d *schema.ResourceData, meta interface{}) (err e
 	requiredSignedCommit := d.Get("require_signed_commits").(bool)
 	client := meta.(*Organization).client
 
-	repoName, branch, err := parseTwoPartID(d.Id())
+	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -238,7 +238,7 @@ func testAccCheckGithubProtectedBranchExists(n, id string, protection *github.Pr
 
 		conn := testAccProvider.Meta().(*Organization).client
 		o := testAccProvider.Meta().(*Organization).name
-		r, b, err := parseTwoPartID(rs.Primary.ID)
+		r, b, err := parseTwoPartID(rs.Primary.ID, "repository", "branch")
 		if err != nil {
 			return err
 		}
@@ -368,7 +368,7 @@ func testAccGithubBranchProtectionDestroy(s *terraform.State) error {
 		}
 
 		o := testAccProvider.Meta().(*Organization).name
-		r, b, err := parseTwoPartID(rs.Primary.ID)
+		r, b, err := parseTwoPartID(rs.Primary.ID, "repository", "branch")
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -101,7 +101,7 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interfa
 			originalName = name
 		} else {
 			var err error
-			_, originalName, err = parseTwoPartID(d.Id())
+			_, originalName, err = parseTwoPartID(d.Id(), "repository", "name")
 			if err != nil {
 				return err
 			}
@@ -141,7 +141,7 @@ func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	client := meta.(*Organization).client
-	repoName, name, err := parseTwoPartID(d.Id())
+	repoName, name, err := parseTwoPartID(d.Id(), "repository", "name")
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_issue_label_test.go
+++ b/github/resource_github_issue_label_test.go
@@ -138,7 +138,7 @@ func testAccCheckGithubIssueLabelExists(n string, label *github.Label) resource.
 
 		conn := testAccProvider.Meta().(*Organization).client
 		orgName := testAccProvider.Meta().(*Organization).name
-		repoName, name, err := parseTwoPartID(rs.Primary.ID)
+		repoName, name, err := parseTwoPartID(rs.Primary.ID, "repository", "name")
 		if err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ func testAccGithubIssueLabelDestroy(s *terraform.State) error {
 		}
 
 		orgName := testAccProvider.Meta().(*Organization).name
-		repoName, name, err := parseTwoPartID(rs.Primary.ID)
+		repoName, name, err := parseTwoPartID(rs.Primary.ID, "repository", "name")
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -82,7 +82,7 @@ func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) erro
 	client := meta.(*Organization).client
 
 	orgName := meta.(*Organization).name
-	_, username, err := parseTwoPartID(d.Id())
+	_, username, err := parseTwoPartID(d.Id(), "organization", "username")
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_membership_test.go
+++ b/github/resource_github_membership_test.go
@@ -90,7 +90,7 @@ func testAccCheckGithubMembershipDestroy(s *terraform.State) error {
 		if rs.Type != "github_membership" {
 			continue
 		}
-		orgName, username, err := parseTwoPartID(rs.Primary.ID)
+		orgName, username, err := parseTwoPartID(rs.Primary.ID, "organization", "username")
 		if err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ func testAccCheckGithubMembershipExists(n string, membership *github.Membership)
 		}
 
 		conn := testAccProvider.Meta().(*Organization).client
-		orgName, username, err := parseTwoPartID(rs.Primary.ID)
+		orgName, username, err := parseTwoPartID(rs.Primary.ID, "organization", "username")
 		if err != nil {
 			return err
 		}
@@ -149,7 +149,7 @@ func testAccCheckGithubMembershipRoleState(n string, membership *github.Membersh
 		}
 
 		conn := testAccProvider.Meta().(*Organization).client
-		orgName, username, err := parseTwoPartID(rs.Primary.ID)
+		orgName, username, err := parseTwoPartID(rs.Primary.ID, "organization", "username")
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -88,7 +88,7 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 	client := meta.(*Organization).client
 
 	orgName := meta.(*Organization).name
-	repoName, username, err := parseTwoPartID(d.Id())
+	repoName, username, err := parseTwoPartID(d.Id(), "repository", "username")
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_repository_collaborator_test.go
+++ b/github/resource_github_repository_collaborator_test.go
@@ -101,7 +101,7 @@ func testAccCheckGithubRepositoryCollaboratorDestroy(s *terraform.State) error {
 		}
 
 		o := testAccProvider.Meta().(*Organization).name
-		r, u, err := parseTwoPartID(rs.Primary.ID)
+		r, u, err := parseTwoPartID(rs.Primary.ID, "repository", "username")
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ func testAccCheckGithubRepositoryCollaboratorExists(n string) resource.TestCheck
 
 		conn := testAccProvider.Meta().(*Organization).client
 		orgName := testAccProvider.Meta().(*Organization).name
-		repoName, username, err := parseTwoPartID(rs.Primary.ID)
+		repoName, username, err := parseTwoPartID(rs.Primary.ID, "repository", "username")
 		if err != nil {
 			return err
 		}
@@ -175,7 +175,7 @@ func testAccCheckGithubRepositoryCollaboratorPermission(n string) resource.TestC
 
 		conn := testAccProvider.Meta().(*Organization).client
 		orgName := testAccProvider.Meta().(*Organization).name
-		repoName, username, err := parseTwoPartID(rs.Primary.ID)
+		repoName, username, err := parseTwoPartID(rs.Primary.ID, "repository", "username")
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_repository_deploy_key.go
+++ b/github/resource_github_repository_deploy_key.go
@@ -95,7 +95,7 @@ func resourceGithubRepositoryDeployKeyRead(d *schema.ResourceData, meta interfac
 	client := meta.(*Organization).client
 
 	owner := meta.(*Organization).name
-	repoName, idString, err := parseTwoPartID(d.Id())
+	repoName, idString, err := parseTwoPartID(d.Id(), "repository", "ID")
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func resourceGithubRepositoryDeployKeyDelete(d *schema.ResourceData, meta interf
 	client := meta.(*Organization).client
 
 	owner := meta.(*Organization).name
-	repoName, idString, err := parseTwoPartID(d.Id())
+	repoName, idString, err := parseTwoPartID(d.Id(), "repository", "ID")
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_repository_deploy_key_test.go
+++ b/github/resource_github_repository_deploy_key_test.go
@@ -89,7 +89,7 @@ func testAccCheckGithubRepositoryDeployKeyDestroy(s *terraform.State) error {
 		}
 
 		orgName := testAccProvider.Meta().(*Organization).name
-		repoName, idString, err := parseTwoPartID(rs.Primary.ID)
+		repoName, idString, err := parseTwoPartID(rs.Primary.ID, "repository", "ID")
 		if err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ func testAccCheckGithubRepositoryDeployKeyExists(n string) resource.TestCheckFun
 
 		conn := testAccProvider.Meta().(*Organization).client
 		orgName := testAccProvider.Meta().(*Organization).name
-		repoName, idString, err := parseTwoPartID(rs.Primary.ID)
+		repoName, idString, err := parseTwoPartID(rs.Primary.ID, "repository", "ID")
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -80,7 +80,7 @@ func resourceGithubTeamMembershipCreateOrUpdate(d *schema.ResourceData, meta int
 
 func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Organization).client
-	teamIdString, username, err := parseTwoPartID(d.Id())
+	teamIdString, username, err := parseTwoPartID(d.Id(), "team_id", "username")
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -103,7 +103,7 @@ func testAccCheckGithubTeamMembershipDestroy(s *terraform.State) error {
 			continue
 		}
 
-		teamIdString, username, err := parseTwoPartID(rs.Primary.ID)
+		teamIdString, username, err := parseTwoPartID(rs.Primary.ID, "team_id", "username")
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func testAccCheckGithubTeamMembershipExists(n string, membership *github.Members
 		}
 
 		conn := testAccProvider.Meta().(*Organization).client
-		teamIdString, username, err := parseTwoPartID(rs.Primary.ID)
+		teamIdString, username, err := parseTwoPartID(rs.Primary.ID, "team_id", "username")
 		if err != nil {
 			return err
 		}
@@ -172,7 +172,7 @@ func testAccCheckGithubTeamMembershipRoleState(n, expected string, membership *g
 		}
 
 		conn := testAccProvider.Meta().(*Organization).client
-		teamIdString, username, err := parseTwoPartID(rs.Primary.ID)
+		teamIdString, username, err := parseTwoPartID(rs.Primary.ID, "team_id", "username")
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -92,7 +92,7 @@ func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) 
 
 	client := meta.(*Organization).client
 
-	teamIdString, repoName, err := parseTwoPartID(d.Id())
+	teamIdString, repoName, err := parseTwoPartID(d.Id(), "team_id", "repository")
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_team_repository_test.go
+++ b/github/resource_github_team_repository_test.go
@@ -101,7 +101,7 @@ func testAccCheckGithubTeamRepositoryExists(n string, repository *github.Reposit
 
 		conn := testAccProvider.Meta().(*Organization).client
 
-		teamIdString, repoName, err := parseTwoPartID(rs.Primary.ID)
+		teamIdString, repoName, err := parseTwoPartID(rs.Primary.ID, "team_id", "repository")
 		if err != nil {
 			return err
 		}
@@ -131,7 +131,7 @@ func testAccCheckGithubTeamRepositoryDestroy(s *terraform.State) error {
 			continue
 		}
 
-		teamIdString, repoName, err := parseTwoPartID(rs.Primary.ID)
+		teamIdString, repoName, err := parseTwoPartID(rs.Primary.ID, "team_id", "repository")
 		if err != nil {
 			return err
 		}

--- a/github/util.go
+++ b/github/util.go
@@ -45,7 +45,7 @@ func validateValueFunc(values []string) schema.SchemaValidateFunc {
 	}
 }
 
-// return the pieces of id `a:b` as a, b
+// return the pieces of id `left:right` as left, right
 func parseTwoPartID(id, left, right string) (string, string, error) {
 	parts := strings.SplitN(id, ":", 2)
 	if len(parts) != 2 {

--- a/github/util.go
+++ b/github/util.go
@@ -46,10 +46,10 @@ func validateValueFunc(values []string) schema.SchemaValidateFunc {
 }
 
 // return the pieces of id `a:b` as a, b
-func parseTwoPartID(id string) (string, string, error) {
+func parseTwoPartID(id, left, right string) (string, string, error) {
 	parts := strings.SplitN(id, ":", 2)
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Unexpected ID format (%q). Expected organization:name", id)
+		return "", "", fmt.Errorf("Unexpected ID format (%q). Expected %s:%s", id, left, right)
 	}
 
 	return parts[0], parts[1], nil

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -75,7 +75,7 @@ func TestAccGithubUtilTwoPartID(t *testing.T) {
 		t.Fatalf("Expected two part id to be foo:bar, actual: %s", id)
 	}
 
-	parsedPartOne, parsedPartTwo, err := parseTwoPartID(id)
+	parsedPartOne, parsedPartTwo, err := parseTwoPartID(id, "left", "right")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This function is used in many resources to parse colon-separated
two-part identifier strings, and it emits an error message when
the string does not match the expected format. The error message
indicates that the format was expected to be "organization:name"
but this is only true for some resources, not all of them. As a
result users may get an error while attempting to import a resource
which gives them incorrect information about the identitier format.

This patch improves the function to accept a pair of label strings,
and it uses them when constructing the error message, so the message
will be tailored to the call site's desired format for the string.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>