### PR TITLE
Refactor: clean up buildTwoPartID

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -178,7 +178,7 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	d.SetId(buildTwoPartID(&repoName, &branch))
+	d.SetId(buildTwoPartID(repoName, branch))
 
 	if err = requireSignedCommitsUpdate(d, meta); err != nil {
 		return err
@@ -300,7 +300,7 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	d.SetId(buildTwoPartID(&repoName, &branch))
+	d.SetId(buildTwoPartID(repoName, branch))
 
 	if err = requireSignedCommitsUpdate(d, meta); err != nil {
 		return err

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -129,7 +129,7 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interfa
 		}
 	}
 
-	d.SetId(buildTwoPartID(&repoName, &name))
+	d.SetId(buildTwoPartID(repoName, name))
 
 	return resourceGithubIssueLabelRead(d, meta)
 }

--- a/github/resource_github_issue_label_test.go
+++ b/github/resource_github_issue_label_test.go
@@ -186,7 +186,7 @@ func testAccGithubIssueLabelDestroy(s *terraform.State) error {
 			orgName, repoName, name)
 		if err == nil {
 			if label != nil &&
-				buildTwoPartID(label.Name, label.Color) == rs.Primary.ID {
+				buildTwoPartID(*label.Name, *label.Color) == rs.Primary.ID {
 				return fmt.Errorf("Issue label still exists")
 			}
 		}

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -68,7 +68,7 @@ func resourceGithubMembershipCreateOrUpdate(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	d.SetId(buildTwoPartID(membership.Organization.Login, membership.User.Login))
+	d.SetId(buildTwoPartID(*membership.Organization.Login, *membership.User.Login))
 
 	return resourceGithubMembershipRead(d, meta)
 }

--- a/github/resource_github_membership_test.go
+++ b/github/resource_github_membership_test.go
@@ -99,7 +99,7 @@ func testAccCheckGithubMembershipDestroy(s *terraform.State) error {
 
 		if err == nil {
 			if membership != nil &&
-				buildTwoPartID(membership.Organization.Login, membership.User.Login) == rs.Primary.ID {
+				buildTwoPartID(*membership.Organization.Login, *membership.User.Login) == rs.Primary.ID {
 				return fmt.Errorf("Organization membership %q still exists", rs.Primary.ID)
 			}
 		}

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -74,7 +74,7 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta int
 		return err
 	}
 
-	d.SetId(buildTwoPartID(&repoName, &username))
+	d.SetId(buildTwoPartID(repoName, username))
 
 	return resourceGithubRepositoryCollaboratorRead(d, meta)
 }

--- a/github/resource_github_repository_deploy_key.go
+++ b/github/resource_github_repository_deploy_key.go
@@ -79,9 +79,7 @@ func resourceGithubRepositoryDeployKeyCreate(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	id := strconv.FormatInt(*resultKey.ID, 10)
-
-	d.SetId(buildTwoPartID(&repoName, &id))
+	d.SetId(buildTwoPartID(repoName, strconv.FormatInt(*resultKey.ID, 10)))
 
 	return resourceGithubRepositoryDeployKeyRead(d, meta)
 }

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -73,7 +73,7 @@ func resourceGithubTeamMembershipCreateOrUpdate(d *schema.ResourceData, meta int
 		return err
 	}
 
-	d.SetId(buildTwoPartID(&teamIdString, &username))
+	d.SetId(buildTwoPartID(teamIdString, username))
 
 	return resourceGithubTeamMembershipRead(d, meta)
 }

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -79,7 +79,7 @@ func resourceGithubTeamRepositoryCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	d.SetId(buildTwoPartID(&teamIdString, &repoName))
+	d.SetId(buildTwoPartID(teamIdString, repoName))
 
 	return resourceGithubTeamRepositoryRead(d, meta)
 }
@@ -171,7 +171,7 @@ func resourceGithubTeamRepositoryUpdate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	d.SetId(buildTwoPartID(&teamIdString, &repoName))
+	d.SetId(buildTwoPartID(teamIdString, repoName))
 
 	return resourceGithubTeamRepositoryRead(d, meta)
 }

--- a/github/resource_github_team_repository_test.go
+++ b/github/resource_github_team_repository_test.go
@@ -147,7 +147,7 @@ func testAccCheckGithubTeamRepositoryDestroy(s *terraform.State) error {
 
 		if err == nil {
 			if repo != nil &&
-				buildTwoPartID(&teamIdString, repo.Name) == rs.Primary.ID {
+				buildTwoPartID(teamIdString, *repo.Name) == rs.Primary.ID {
 				return fmt.Errorf("Team repository still exists")
 			}
 		}

--- a/github/util.go
+++ b/github/util.go
@@ -56,8 +56,8 @@ func parseTwoPartID(id string) (string, string, error) {
 }
 
 // format the strings into an id `a:b`
-func buildTwoPartID(a, b *string) string {
-	return fmt.Sprintf("%s:%s", *a, *b)
+func buildTwoPartID(a, b string) string {
+	return fmt.Sprintf("%s:%s", a, b)
 }
 
 func expandStringList(configured []interface{}) []string {

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -69,7 +69,7 @@ func TestAccGithubUtilRole_validation(t *testing.T) {
 func TestAccGithubUtilTwoPartID(t *testing.T) {
 	partOne, partTwo := "foo", "bar"
 
-	id := buildTwoPartID(&partOne, &partTwo)
+	id := buildTwoPartID(partOne, partTwo)
 
 	if id != "foo:bar" {
 		t.Fatalf("Expected two part id to be foo:bar, actual: %s", id)


### PR DESCRIPTION
The parameters to buildTwoPartID are not optional,
so they should be passed by-value and not by-pointer.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>