### PR TITLE
Refactor: simplify API result handling

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"strings"
 
 	"github.com/google/go-github/v28/github"
@@ -208,49 +207,43 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] Reading branch protection: %s/%s (%s)",
 		orgName, repoName, branch)
-	githubProtection, resp, err := client.Repositories.GetBranchProtection(ctx,
-		orgName, repoName, branch)
-	if err != nil {
-		if ghErr, ok := err.(*github.ErrorResponse); ok {
-			if ghErr.Response.StatusCode == http.StatusNotModified {
-				if err := requireSignedCommitsRead(d, meta); err != nil {
-					return fmt.Errorf("Error setting signed commit restriction: %v", err)
-				}
-				return nil
-			}
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing branch protection %s/%s (%s) from state because it no longer exists in GitHub",
-					orgName, repoName, branch)
-				d.SetId("")
-				return nil
-			}
+	githubProtection, resp, err := client.Repositories.GetBranchProtection(ctx, orgName, repoName, branch)
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		if err := requireSignedCommitsRead(d, meta); err != nil {
+			return fmt.Errorf("Error setting signed commit restriction: %v", err)
+		}
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing branch protection %s/%s (%s) from state because it no longer exists in GitHub", orgName, repoName, branch)
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		d.Set("etag", resp.Header.Get("ETag"))
+		d.Set("repository", repoName)
+		d.Set("branch", branch)
+		d.Set("enforce_admins", githubProtection.EnforceAdmins.Enabled)
+
+		if err := flattenAndSetRequiredStatusChecks(d, githubProtection); err != nil {
+			return fmt.Errorf("Error setting required_status_checks: %v", err)
 		}
 
-		return err
+		if err := flattenAndSetRequiredPullRequestReviews(d, githubProtection); err != nil {
+			return fmt.Errorf("Error setting required_pull_request_reviews: %v", err)
+		}
+
+		if err := flattenAndSetRestrictions(d, githubProtection); err != nil {
+			return fmt.Errorf("Error setting restrictions: %v", err)
+		}
+
+		if err := requireSignedCommitsRead(d, meta); err != nil {
+			return fmt.Errorf("Error setting signed commit restriction: %v", err)
+		}
+
+		return nil
 	}
-
-	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("repository", repoName)
-	d.Set("branch", branch)
-	d.Set("enforce_admins", githubProtection.EnforceAdmins.Enabled)
-
-	if err := flattenAndSetRequiredStatusChecks(d, githubProtection); err != nil {
-		return fmt.Errorf("Error setting required_status_checks: %v", err)
-	}
-
-	if err := flattenAndSetRequiredPullRequestReviews(d, githubProtection); err != nil {
-		return fmt.Errorf("Error setting required_pull_request_reviews: %v", err)
-	}
-
-	if err := flattenAndSetRestrictions(d, githubProtection); err != nil {
-		return fmt.Errorf("Error setting restrictions: %v", err)
-	}
-
-	if err := requireSignedCommitsRead(d, meta); err != nil {
-		return fmt.Errorf("Error setting signed commit restriction: %v", err)
-	}
-
-	return nil
 }
 
 func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_organization_project.go
+++ b/github/resource_github_organization_project.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 
 	"github.com/google/go-github/v28/github"
@@ -90,28 +89,23 @@ func resourceGithubOrganizationProjectRead(d *schema.ResourceData, meta interfac
 
 	log.Printf("[DEBUG] Reading organization project: %s (%s)", d.Id(), orgName)
 	project, resp, err := client.Projects.GetProject(ctx, projectID)
-	if err != nil {
-		if ghErr, ok := err.(*github.ErrorResponse); ok {
-			if ghErr.Response.StatusCode == http.StatusNotModified {
-				return nil
-			}
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing organization project %s/%s from state because it no longer exists in GitHub",
-					orgName, d.Id())
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing organization project %s/%s from state because it no longer exists in GitHub", orgName, d.Id())
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		d.Set("etag", resp.Header.Get("ETag"))
+		d.Set("name", project.GetName())
+		d.Set("body", project.GetBody())
+		d.Set("url", fmt.Sprintf("https://github.com/orgs/%s/projects/%d", orgName, project.GetNumber()))
+
+		return nil
 	}
-
-	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("name", project.GetName())
-	d.Set("body", project.GetBody())
-	d.Set("url", fmt.Sprintf("https://github.com/orgs/%s/projects/%d",
-		orgName, project.GetNumber()))
-
-	return nil
 }
 
 func resourceGithubOrganizationProjectUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_project_column.go
+++ b/github/resource_github_project_column.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"log"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -85,24 +84,25 @@ func resourceGithubProjectColumnRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[DEBUG] Reading project column: %s", d.Id())
-	column, _, err := client.Projects.GetProjectColumn(ctx, columnID)
-	if err != nil {
-		if err, ok := err.(*github.ErrorResponse); ok {
-			if err.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing project column %s from state because it no longer exists in GitHub", d.Id())
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
+	column, resp, err := client.Projects.GetProjectColumn(ctx, columnID)
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing project column %s from state because it no longer exists in GitHub", d.Id())
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		projectURL := column.GetProjectURL()
+		projectID := strings.TrimPrefix(projectURL, client.BaseURL.String()+`projects/`)
+
+		d.Set("name", column.GetName())
+		d.Set("project_id", projectID)
+
+		return nil
 	}
-
-	projectURL := column.GetProjectURL()
-	projectID := strings.TrimPrefix(projectURL, client.BaseURL.String()+`projects/`)
-
-	d.Set("name", column.GetName())
-	d.Set("project_id", projectID)
-	return nil
 }
 
 func resourceGithubProjectColumnUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"regexp"
 
 	"github.com/google/go-github/v28/github"
@@ -268,55 +267,51 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	repo, resp, err := client.Repositories.Get(ctx, orgName, repoName)
-	if err != nil {
-		if ghErr, ok := err.(*github.ErrorResponse); ok {
-			if ghErr.Response.StatusCode == http.StatusNotModified {
-				return nil
-			}
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing repository %s/%s from state because it no longer exists in GitHub",
-					orgName, repoName)
-				d.SetId("")
-				return nil
-			}
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing repository %s/%s from state because it no longer exists in GitHub", orgName, repoName)
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		d.Set("etag", resp.Header.Get("ETag"))
+		d.Set("name", repoName)
+		d.Set("description", repo.Description)
+		d.Set("homepage_url", repo.Homepage)
+		d.Set("private", repo.Private)
+		d.Set("has_issues", repo.HasIssues)
+		d.Set("has_projects", repo.HasProjects)
+		d.Set("has_wiki", repo.HasWiki)
+		d.Set("allow_merge_commit", repo.AllowMergeCommit)
+		d.Set("allow_squash_merge", repo.AllowSquashMerge)
+		d.Set("allow_rebase_merge", repo.AllowRebaseMerge)
+		d.Set("has_downloads", repo.HasDownloads)
+		d.Set("full_name", repo.FullName)
+		d.Set("default_branch", repo.DefaultBranch)
+		d.Set("html_url", repo.HTMLURL)
+		d.Set("ssh_clone_url", repo.SSHURL)
+		d.Set("svn_url", repo.SVNURL)
+		d.Set("git_clone_url", repo.GitURL)
+		d.Set("http_clone_url", repo.CloneURL)
+		d.Set("archived", repo.Archived)
+		d.Set("topics", flattenStringList(repo.Topics))
+
+		if repo.TemplateRepository != nil {
+			d.Set("template", []interface{}{
+				map[string]interface{}{
+					"owner":      repo.TemplateRepository.Owner.Login,
+					"repository": repo.TemplateRepository.Name,
+				},
+			})
+		} else {
+			d.Set("template", []interface{}{})
 		}
-		return err
+
+		return nil
 	}
-
-	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("name", repoName)
-	d.Set("description", repo.Description)
-	d.Set("homepage_url", repo.Homepage)
-	d.Set("private", repo.Private)
-	d.Set("has_issues", repo.HasIssues)
-	d.Set("has_projects", repo.HasProjects)
-	d.Set("has_wiki", repo.HasWiki)
-	d.Set("allow_merge_commit", repo.AllowMergeCommit)
-	d.Set("allow_squash_merge", repo.AllowSquashMerge)
-	d.Set("allow_rebase_merge", repo.AllowRebaseMerge)
-	d.Set("has_downloads", repo.HasDownloads)
-	d.Set("full_name", repo.FullName)
-	d.Set("default_branch", repo.DefaultBranch)
-	d.Set("html_url", repo.HTMLURL)
-	d.Set("ssh_clone_url", repo.SSHURL)
-	d.Set("svn_url", repo.SVNURL)
-	d.Set("git_clone_url", repo.GitURL)
-	d.Set("http_clone_url", repo.CloneURL)
-	d.Set("archived", repo.Archived)
-	d.Set("topics", flattenStringList(repo.Topics))
-
-	if repo.TemplateRepository != nil {
-		d.Set("template", []interface{}{
-			map[string]interface{}{
-				"owner":      repo.TemplateRepository.Owner.Login,
-				"repository": repo.TemplateRepository.Name,
-			},
-		})
-	} else {
-		d.Set("template", []interface{}{})
-	}
-
-	return nil
 }
 
 func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_repository_project.go
+++ b/github/resource_github_repository_project.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -106,28 +105,23 @@ func resourceGithubRepositoryProjectRead(d *schema.ResourceData, meta interface{
 
 	log.Printf("[DEBUG] Reading repository project: %s", d.Id())
 	project, resp, err := client.Projects.GetProject(ctx, projectID)
-	if err != nil {
-		if ghErr, ok := err.(*github.ErrorResponse); ok {
-			if ghErr.Response.StatusCode == http.StatusNotModified {
-				return nil
-			}
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing repository project %s from state because it no longer exists in GitHub",
-					d.Id())
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing repository project %s from state because it no longer exists in GitHub", d.Id())
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		d.Set("etag", resp.Header.Get("ETag"))
+		d.Set("name", project.GetName())
+		d.Set("body", project.GetBody())
+		d.Set("url", fmt.Sprintf("https://github.com/%s/%s/projects/%d", orgName, d.Get("repository"), project.GetNumber()))
+
+		return nil
 	}
-
-	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("name", project.GetName())
-	d.Set("body", project.GetBody())
-	d.Set("url", fmt.Sprintf("https://github.com/%s/%s/projects/%d",
-		orgName, d.Get("repository"), project.GetNumber()))
-
-	return nil
 }
 
 func resourceGithubRepositoryProjectUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -142,40 +141,37 @@ func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{
 	}
 
 	log.Printf("[DEBUG] Reading repository webhook: %s (%s/%s)", d.Id(), orgName, repoName)
-	hook, _, err := client.Repositories.GetHook(ctx, orgName, repoName, hookID)
-	if err != nil {
-		if ghErr, ok := err.(*github.ErrorResponse); ok {
-			if ghErr.Response.StatusCode == http.StatusNotModified {
-				return nil
-			}
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing repository webhook %s from state because it no longer exists in GitHub",
-					d.Id())
-				d.SetId("")
-				return nil
+	hook, resp, err := client.Repositories.GetHook(ctx, orgName, repoName, hookID)
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing repository webhook %s from state because it no longer exists in GitHub", d.Id())
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		d.Set("url", hook.URL)
+		d.Set("active", hook.Active)
+		d.Set("events", hook.Events)
+
+		// GitHub returns the secret as a string of 8 asterisks "********"
+		// We would prefer to store the real secret in state, so we'll
+		// write the configuration secret in state from what we get from
+		// ResourceData
+		if len(d.Get("configuration").([]interface{})) > 0 {
+			currentSecret := d.Get("configuration").([]interface{})[0].(map[string]interface{})["secret"]
+
+			if hook.Config["secret"] != nil {
+				hook.Config["secret"] = currentSecret
 			}
 		}
-		return err
+
+		d.Set("configuration", []interface{}{hook.Config})
+
+		return nil
 	}
-	d.Set("url", hook.URL)
-	d.Set("active", hook.Active)
-	d.Set("events", hook.Events)
-
-	// GitHub returns the secret as a string of 8 astrisks "********"
-	// We would prefer to store the real secret in state, so we'll
-	// write the configuration secret in state from what we get from
-	// ResourceData
-	if len(d.Get("configuration").([]interface{})) > 0 {
-		currentSecret := d.Get("configuration").([]interface{})[0].(map[string]interface{})["secret"]
-
-		if hook.Config["secret"] != nil {
-			hook.Config["secret"] = currentSecret
-		}
-	}
-
-	d.Set("configuration", []interface{}{hook.Config})
-
-	return nil
 }
 
 func resourceGithubRepositoryWebhookUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"log"
-	"net/http"
 	"strconv"
 
 	"github.com/google/go-github/v28/github"
@@ -102,27 +101,22 @@ func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	log.Printf("[DEBUG] Reading team membership: %s/%s", teamIdString, username)
-	membership, resp, err := client.Teams.GetTeamMembership(ctx,
-		teamId, username)
-	if err != nil {
-		if ghErr, ok := err.(*github.ErrorResponse); ok {
-			if ghErr.Response.StatusCode == http.StatusNotModified {
-				return nil
-			}
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing team membership %s from state because it no longer exists in GitHub",
-					d.Id())
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
+	membership, resp, err := client.Teams.GetTeamMembership(ctx, teamId, username)
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing team membership %s from state because it no longer exists in GitHub", d.Id())
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		d.Set("etag", resp.Header.Get("ETag"))
+		d.Set("role", membership.Role)
+
+		return nil
 	}
-
-	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("role", membership.Role)
-
-	return nil
 }
 
 func resourceGithubTeamMembershipDelete(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"log"
-	"net/http"
 	"strconv"
 
 	"github.com/google/go-github/v28/github"
@@ -108,34 +107,30 @@ func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	log.Printf("[DEBUG] Reading team repository association: %s (%s/%s)", teamIdString, orgName, repoName)
-	repo, resp, repoErr := client.Teams.IsTeamRepo(ctx, teamId, orgName, repoName)
-	if repoErr != nil {
-		if ghErr, ok := repoErr.(*github.ErrorResponse); ok {
-			if ghErr.Response.StatusCode == http.StatusNotModified {
-				return nil
-			}
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing team repository association %s from state because it no longer exists in GitHub",
-					d.Id())
-				d.SetId("")
-				return nil
-			}
+	repo, resp, err := client.Teams.IsTeamRepo(ctx, teamId, orgName, repoName)
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing team repository association %s from state because it no longer exists in GitHub", d.Id())
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		d.Set("etag", resp.Header.Get("ETag"))
+		d.Set("team_id", teamIdString)
+		d.Set("repository", repo.Name)
+
+		permName, permErr := getRepoPermission(repo.Permissions)
+		if permErr != nil {
+			return permErr
 		}
-		return err
+
+		d.Set("permission", permName)
+
+		return nil
 	}
-
-	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("team_id", teamIdString)
-	d.Set("repository", repo.Name)
-
-	permName, permErr := getRepoPermission(repo.Permissions)
-	if permErr != nil {
-		return permErr
-	}
-
-	d.Set("permission", permName)
-
-	return nil
 }
 
 func resourceGithubTeamRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_user_gpg_key.go
+++ b/github/resource_github_user_gpg_key.go
@@ -3,10 +3,8 @@ package github
 import (
 	"context"
 	"log"
-	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v28/github"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -64,25 +62,21 @@ func resourceGithubUserGpgKeyRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Reading user GPG key: %s", d.Id())
-	key, _, err := client.Users.GetGPGKey(ctx, id)
-	if err != nil {
-		if ghErr, ok := err.(*github.ErrorResponse); ok {
-			if ghErr.Response.StatusCode == http.StatusNotModified {
-				return nil
-			}
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing user GPG key %s from state because it no longer exists in GitHub",
-					d.Id())
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
+	key, resp, err := client.Users.GetGPGKey(ctx, id)
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing user GPG key %s from state because it no longer exists in GitHub", d.Id())
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		d.Set("key_id", key.KeyID)
+
+		return nil
 	}
-
-	d.Set("key_id", key.KeyID)
-
-	return nil
 }
 
 func resourceGithubUserGpgKeyDelete(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_user_ssh_key.go
+++ b/github/resource_github_user_ssh_key.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"log"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -82,26 +81,23 @@ func resourceGithubUserSshKeyRead(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Reading user SSH key: %s", d.Id())
 	key, resp, err := client.Users.GetKey(ctx, id)
-	if err != nil {
-		if ghErr, ok := err.(*github.ErrorResponse); ok {
-			if ghErr.Response.StatusCode == http.StatusNotModified {
-				return nil
-			}
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing user SSH key %s from state because it no longer exists in GitHub",
-					d.Id())
-				d.SetId("")
-				return nil
-			}
-		}
+	switch apires, apierr := apiResult(resp, err); apires {
+	case APINotModified:
+		return nil
+	case APINotFound:
+		log.Printf("[WARN] Removing user SSH key %s from state because it no longer exists in GitHub", d.Id())
+		d.SetId("")
+		return nil
+	case APIError:
+		return apierr
+	default:
+		d.Set("etag", resp.Header.Get("ETag"))
+		d.Set("title", key.Title)
+		d.Set("key", key.Key)
+		d.Set("url", key.URL)
+
+		return nil
 	}
-
-	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("title", key.Title)
-	d.Set("key", key.Key)
-	d.Set("url", key.URL)
-
-	return nil
 }
 
 func resourceGithubUserSshKeyDelete(d *schema.ResourceData, meta interface{}) error {

--- a/github/util.go
+++ b/github/util.go
@@ -2,9 +2,11 @@ package github
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/google/go-github/v28/github"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -104,4 +106,29 @@ func validateTeamIDFunc(v interface{}, keyName string) (we []string, errors []er
 	}
 
 	return
+}
+
+type APIResult int
+
+const (
+	APISuccess APIResult = iota
+	APIError
+	APINotFound
+	APINotModified
+)
+
+func apiResult(resp *github.Response, err error) (APIResult, error) {
+	if err != nil {
+		if resp.StatusCode == http.StatusNotModified {
+			return APINotModified, nil
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return APINotFound, nil
+		}
+
+		return APIError, err
+	}
+
+	return APISuccess, nil
 }


### PR DESCRIPTION
Every resource `Read` function has to process the results
of its primary GitHub API call, and there are a number of
possible results and actions to be taken.

This patch adds a function to parse the API results and return
an enum indicating the type of result the API returned; this
allows the calling code to use a `switch` statement to handle
each possible case, making the code more readable.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>