### PR TITLE
Fix issues with auto_init destroying repositories

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -87,7 +87,6 @@ func resourceGithubRepository() *schema.Resource {
 			"auto_init": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: false,
 			},
 			"default_branch": {
 				Type:        schema.TypeString,

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -87,7 +87,7 @@ func resourceGithubRepository() *schema.Resource {
 			"auto_init": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 			},
 			"default_branch": {
 				Type:        schema.TypeString,

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -451,48 +451,6 @@ func TestAccGithubRepository_topics(t *testing.T) {
 	})
 }
 
-func TestAccGithubRepository_autoInitForceNew(t *testing.T) {
-	var repo github.Repository
-
-	rn := "github_repository.foo"
-	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	name := fmt.Sprintf("tf-acc-test-%s", randString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGithubRepositoryDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGithubRepositoryConfigAutoInitForceNew(randString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGithubRepositoryExists(rn, &repo),
-					resource.TestCheckResourceAttr(rn, "name", name),
-					resource.TestCheckResourceAttr(rn, "auto_init", "false"),
-				),
-			},
-			{
-				Config: testAccGithubRepositoryConfigAutoInitForceNewUpdate(randString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGithubRepositoryExists(rn, &repo),
-					resource.TestCheckResourceAttr(rn, "name", name),
-					resource.TestCheckResourceAttr(rn, "auto_init", "true"),
-					resource.TestCheckResourceAttr(rn, "license_template", "mpl-2.0"),
-					resource.TestCheckResourceAttr(rn, "gitignore_template", "Go"),
-				),
-			},
-			{
-				ResourceName:      rn,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"auto_init", "license_template", "gitignore_template",
-				},
-			},
-		},
-	})
-}
-
 func TestAccGithubRepository_createFromTemplate(t *testing.T) {
 	var repo github.Repository
 
@@ -939,29 +897,4 @@ resource "github_repository" "foo" {
   topics = [%s]
 }
 `, randString, randString, topicList)
-}
-
-func testAccGithubRepositoryConfigAutoInitForceNew(randString string) string {
-	return fmt.Sprintf(`
-resource "github_repository" "foo" {
-  name      = "tf-acc-test-%s"
-  auto_init = false
-}
-`, randString)
-}
-
-func testAccGithubRepositoryConfigAutoInitForceNewUpdate(randString string) string {
-	return fmt.Sprintf(`
-resource "github_repository" "foo" {
-  name               = "tf-acc-test-%s"
-  auto_init          = true
-  license_template   = "mpl-2.0"
-  gitignore_template = "Go"
-}
-
-resource "github_branch_protection" "repo_name_master" {
-  repository = "${github_repository.foo.name}"
-  branch     = "master"
-}
-`, randString)
 }


### PR DESCRIPTION
From github API perspective setting or modifying `auto_init` only makes sense in the context of creating a new repository. Changing it after is ignored by the github API which is the behavior we should (and use to) match. The only scenario where this makes sense to assume that changing this intends on a destructive action (blowing up a github repo is not something that should be easy accidentally) is when you use the `terraform taint` command but for very different reasons. This change is related to several PRs and issues that subverts the communities expectations with no real or perceived value.

For further context please see #155 #154 https://github.com/sous-chefs/terraform-github-org/pull/111 #135 

fixes #155 

Signed-off-by: Ben Abrams <me@benabrams.it>