### PR TITLE
Update CHANGELOG.md to include #309

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 2.2.2 (Unreleased)
+## 2.3.0 (Unreleased)
+
+ENHANCEMENTS:
+
+* `resource/repository`:  Added functionality to generate a new repository from a Template Repository ([#309](https://github.com/terraform-providers/terraform-provider-github/issues/309))
+
 ## 2.2.1 (September 04, 2019)
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 
-* `resource/repository`:  Added functionality to generate a new repository from a Template Repository ([#309](https://github.com/terraform-providers/terraform-provider-github/issues/309))
+* `resource/repository`: Added functionality to generate a new repository from a Template Repository ([GH-309])
 
 ## 2.2.1 (September 04, 2019)
 


### PR DESCRIPTION
This updates the CHANGELOG with a new enhancement that merged.  The version has bumped from `2.2.1` to `2.3.0` according to our [versioning scheme](https://www.hashicorp.com/blog/hashicorp-terraform-provider-versioning/).

cc https://github.com/terraform-providers/terraform-provider-github/issues/309