### PR TITLE
Fixes team membership bug

### DIFF
--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/google/go-github/v28/github"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -113,12 +112,10 @@ func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	team, user := getTeamAndUserFromURL(membership.URL)
-
 	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("username", user)
+	d.Set("username", username)
 	d.Set("role", membership.Role)
-	d.Set("team_id", team)
+	d.Set("team_id", teamId)
 
 	return nil
 }
@@ -138,19 +135,4 @@ func resourceGithubTeamMembershipDelete(d *schema.ResourceData, meta interface{}
 	_, err = client.Teams.RemoveTeamMembership(ctx, teamId, username)
 
 	return err
-}
-
-func getTeamAndUserFromURL(url *string) (string, string) {
-	var team, user string
-
-	urlSlice := strings.Split(*url, "/")
-	for v := range urlSlice {
-		if urlSlice[v] == "teams" {
-			team = urlSlice[v+1]
-		}
-		if urlSlice[v] == "memberships" {
-			user = urlSlice[v+1]
-		}
-	}
-	return team, user
 }

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -89,6 +89,13 @@ func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return unconvertibleIdErr(teamIdString, err)
 	}
+
+	// We intentionally set these early to allow reconciliation
+	// from an upstream bug which emptied team_id in state
+	// See https://github.com/terraform-providers/terraform-provider-github/issues/323
+	d.Set("team_id", teamIdString)
+	d.Set("username", username)
+
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
@@ -113,9 +120,7 @@ func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("username", username)
 	d.Set("role", membership.Role)
-	d.Set("team_id", teamId)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #323
Closes #326

The current code parses username and team_id from the returned URL with code
that expects the URL to be constructed in a certain fashion. Today that changed,
in the form of "teams/id" to "team/id", making team_id go missing.

Since the upstream API is only meant for obtaining membership status/type, with
the URL being an opaque reference back to itself, we shouldn't depend on that URL
being anything in particular. So this sets our data, if the API responds, to the
username and team_id we already had to make the call.