### PR TITLE
Fix getTeamAndUserFromURL function

### DIFF
--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -145,7 +145,7 @@ func getTeamAndUserFromURL(url *string) (string, string) {
 
 	urlSlice := strings.Split(*url, "/")
 	for v := range urlSlice {
-		if urlSlice[v] == "teams" {
+		if urlSlice[v] == "teams" || urlSlice[v] == "team" {
 			team = urlSlice[v+1]
 		}
 		if urlSlice[v] == "memberships" {


### PR DESCRIPTION
The github api started returning a different url format, this handles both the old and new string, just in case they change it back.

