### PR TITLE
Fix README to include envvar for acceptance tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ In the organization you are using above, create the following test repositories:
 
 Export an environment variable corresponding to `GITHUB_TEMPLATE_REPOSITORY=test-repo-template`.
 
-
 ### GitHub users
 Export your github username (the one you used to create the personal access token above) as `GITHUB_TEST_USER`. You will need to export a
 different github username as `GITHUB_TEST_COLLABORATOR`. Please note that these usernames cannot be the same as each other, and both of them

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ In the organization you are using above, create the following test repositories:
 * `test-repo-template`
   * Configure the repository to be a [Template repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-template-repository)
 
+Export an environment variable corresponding to GITHUB_TEMPLATE_REPOSITORY=test-repo-template.
+
+
 ### GitHub users
 Export your github username (the one you used to create the personal access token above) as `GITHUB_TEST_USER`. You will need to export a
 different github username as `GITHUB_TEST_COLLABORATOR`. Please note that these usernames cannot be the same as each other, and both of them

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In the organization you are using above, create the following test repositories:
 * `test-repo-template`
   * Configure the repository to be a [Template repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-template-repository)
 
-Export an environment variable corresponding to GITHUB_TEMPLATE_REPOSITORY=test-repo-template.
+Export an environment variable corresponding to `GITHUB_TEMPLATE_REPOSITORY=test-repo-template`.
 
 
 ### GitHub users


### PR DESCRIPTION
Updated README to include `GITHUB_TEMPLATE_REPOSITORY`, which is needed in order to run acceptance tests.