### PR TITLE
[fix] Example's template block fixed

### DIFF
--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -24,7 +24,7 @@ resource "github_repository" "example" {
 
   template {
     owner = "github"
-    repo = "terraform-module-template"
+    repository = "terraform-module-template"
   }
 }
 ```


### PR DESCRIPTION
`repo` is not supported by this module