### PR TITLE
GH-144 - New Data Source: Github release

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ In the organization you are using above, create the following test repositories:
   * Create a `test-branch` branch
 * `test-repo-template`
   * Configure the repository to be a [Template repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-template-repository)
+  * Create a release on the repository with `tag = v1.0`
 
 ### GitHub users
 Export your github username (the one you used to create the personal access token above) as `GITHUB_TEST_USER`. You will need to export a
@@ -107,3 +108,5 @@ the acceptance tests do real things (and will trigger some notifications for thi
 
 Additionally the user exported as `GITHUB_TEST_USER` should have a public email address configured in their profile; this should be exported
 as `GITHUB_TEST_USER_EMAIL` and the Github name exported as `GITHUB_TEST_USER_NAME` (this could be different to your GitHub login).
+
+Finally, export the ID of the release created in the template repository as `GITHUB_TEMPLATE_REPOSITORY_RELEASE_ID`

--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform/helper/validation"
 	"log"
 	"strconv"
 	"strings"
@@ -27,6 +28,11 @@ func dataSourceGithubRelease() *schema.Resource {
 			"retrieve_by": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"latest",
+					"id",
+					"tag",
+				}, false),
 			},
 			"release_tag": {
 				Type:     schema.TypeString,

--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -2,9 +2,12 @@ package github
 
 import (
 	"context"
+	"errors"
 	"log"
 	"strconv"
+	"strings"
 
+	"github.com/google/go-github/v28/github"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -21,9 +24,17 @@ func dataSourceGithubRelease() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"retrieve_by": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"release_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"release_id": {
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
 			},
 			"url": {
 				Type:     schema.TypeString,
@@ -36,13 +47,37 @@ func dataSourceGithubRelease() *schema.Resource {
 func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error {
 	repository := d.Get("repository").(string)
 	owner := d.Get("owner").(string)
-	releaseID := int64(d.Get("release_id").(int))
-	log.Printf("[INFO] Refreshing GitHub release %s from repository %s", releaseID, repository)
 
 	client := meta.(*Organization).client
 	ctx := context.Background()
 
-	release, _, err := client.Repositories.GetRelease(ctx, owner, repository, releaseID)
+	var err error
+	var release *github.RepositoryRelease
+
+	switch retrieveBy := strings.ToLower(d.Get("retrieve_by").(string)); retrieveBy {
+	case "latest":
+		log.Printf("[INFO] Refreshing GitHub latest release from repository %s", repository)
+		release, _, err = client.Repositories.GetLatestRelease(ctx, owner, repository)
+	case "id":
+		releaseID := int64(d.Get("release_id").(int))
+		if releaseID == 0 {
+			return errors.New("'release_id' must be set when 'retrieve_by' = 'id'")
+		}
+
+		log.Printf("[INFO] Refreshing GitHub release by id %s from repository %s", releaseID, repository)
+		release, _, err = client.Repositories.GetRelease(ctx, owner, repository, releaseID)
+	case "tag":
+		tag := d.Get("release_tag").(string)
+		if tag == "" {
+			return errors.New("'release_tag' must be set when 'retrieve_by' = 'tag'")
+		}
+
+		log.Printf("[INFO] Refreshing GitHub release by tag %s from repository %s", tag, repository)
+		release, _, err = client.Repositories.GetReleaseByTag(ctx, owner, repository, tag)
+	default:
+		return errors.New("One of: 'latest', 'id', 'tag' must be set for 'retrieve_by'")
+	}
+
 	if err != nil {
 		return err
 	}

--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -36,7 +36,55 @@ func dataSourceGithubRelease() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"taget_commitish": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"body": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"draft": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"prerelease": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"published_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"html_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"asserts_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"upload_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"zipball_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tarball_url": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -83,7 +131,20 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.SetId(strconv.FormatInt(release.GetID(), 10))
+	d.Set("release_tag", release.GetTagName())
+	d.Set("taget_commitish", release.GetTargetCommitish())
+	d.Set("name", release.GetName())
+	d.Set("body", release.GetBody())
+	d.Set("draft", release.GetDraft())
+	d.Set("prerelease", release.GetPrerelease())
+	d.Set("created_at", release.GetCreatedAt())
+	d.Set("published_at", release.GetPublishedAt())
 	d.Set("url", release.GetURL())
+	d.Set("html_url", release.GetHTMLURL())
+	d.Set("asserts_url", release.GetAssetsURL())
+	d.Set("upload_url", release.GetUploadURL())
+	d.Set("zipball_url", release.GetZipballURL())
+	d.Set("tarball_url", release.GetTarballURL())
 
 	return nil
 }

--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -112,7 +112,7 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 			return errors.New("'release_id' must be set when 'retrieve_by' = 'id'")
 		}
 
-		log.Printf("[INFO] Refreshing GitHub release by id %s from repository %s", releaseID, repository)
+		log.Printf("[INFO] Refreshing GitHub release by id %d from repository %s", releaseID, repository)
 		release, _, err = client.Repositories.GetRelease(ctx, owner, repository, releaseID)
 	case "tag":
 		tag := d.Get("release_tag").(string)

--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -2,7 +2,7 @@ package github
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -36,7 +36,7 @@ func dataSourceGithubRelease() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"taget_commitish": {
+			"target_commitish": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -109,7 +109,7 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 	case "id":
 		releaseID := int64(d.Get("release_id").(int))
 		if releaseID == 0 {
-			return errors.New("'release_id' must be set when 'retrieve_by' = 'id'")
+			return fmt.Errorf("`release_id` must be set when `retrieve_by` = `id`")
 		}
 
 		log.Printf("[INFO] Refreshing GitHub release by id %d from repository %s", releaseID, repository)
@@ -117,13 +117,13 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 	case "tag":
 		tag := d.Get("release_tag").(string)
 		if tag == "" {
-			return errors.New("'release_tag' must be set when 'retrieve_by' = 'tag'")
+			return fmt.Errorf("`release_tag` must be set when `retrieve_by` = `tag`")
 		}
 
 		log.Printf("[INFO] Refreshing GitHub release by tag %s from repository %s", tag, repository)
 		release, _, err = client.Repositories.GetReleaseByTag(ctx, owner, repository, tag)
 	default:
-		return errors.New("One of: 'latest', 'id', 'tag' must be set for 'retrieve_by'")
+		return fmt.Errorf("one of: `latest`, `id`, `tag` must be set for `retrieve_by`")
 	}
 
 	if err != nil {
@@ -132,7 +132,7 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(strconv.FormatInt(release.GetID(), 10))
 	d.Set("release_tag", release.GetTagName())
-	d.Set("taget_commitish", release.GetTargetCommitish())
+	d.Set("target_commitish", release.GetTargetCommitish())
 	d.Set("name", release.GetName())
 	d.Set("body", release.GetBody())
 	d.Set("draft", release.GetDraft())

--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -1,0 +1,54 @@
+package github
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGithubRelease() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubReleaseRead,
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"release_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error {
+	repository := d.Get("repository").(string)
+	owner := d.Get("owner").(string)
+	releaseID := int64(d.Get("release_id").(int))
+	log.Printf("[INFO] Refreshing GitHub release %s from repository %s", releaseID, repository)
+
+	client := meta.(*Organization).client
+	ctx := context.Background()
+
+	release, _, err := client.Repositories.GetRelease(ctx, owner, repository, releaseID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(release.GetID(), 10))
+	d.Set("url", release.GetURL())
+
+	return nil
+}

--- a/github/data_source_github_release_test.go
+++ b/github/data_source_github_release_test.go
@@ -3,13 +3,14 @@ package github
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccGithubReleaseDataSource_fetchByLatestNoReleaseReturnsError(t *testing.T) {
-	repo := "nonExistantRepo"
+	repo := "nonExistentRepo"
 	owner := "no-user"
 	retrieveBy := "latest"
 	resource.ParallelTest(t, resource.TestCase{
@@ -19,43 +20,141 @@ func TestAccGithubReleaseDataSource_fetchByLatestNoReleaseReturnsError(t *testin
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy),
+				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", 0),
 				ExpectError: regexp.MustCompile(`Not Found`),
 			},
 		},
 	})
 }
 
-// func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
+func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
+	repo := "terraform"
+	owner := "hashicorp"
+	retrieveBy := "latest"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", 0),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.github_release.test", "url", regexp.MustCompile(`hashicorp/terraform`)),
+					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", regexp.MustCompile(`hashicorp/terraform/tarball`)),
+				),
+			},
+		},
+	})
 
-// }
+}
 
-// func TestAccGithubReleaseDataSource_fetchByIdWithNoIdReturnsError(t *testing.T) {
+func TestAccGithubReleaseDataSource_fetchByIdWithNoIdReturnsError(t *testing.T) {
+	retrieveBy := "id"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckGithubReleaseDataSourceConfig("", "", retrieveBy, "", 0),
+				ExpectError: regexp.MustCompile("release_id` must be set when `retrieve_by` = `id`"),
+			},
+		},
+	})
+}
 
-// }
+func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
+	repo := "terraform"
+	owner := "hashicorp"
+	retrieveBy := "id"
+	id := int64(23055013)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", id),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.github_release.test", "release_id", strconv.FormatInt(id, 10)),
+					resource.TestMatchResourceAttr("data.github_release.test", "url", regexp.MustCompile(`hashicorp/terraform`)),
+					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", regexp.MustCompile(`hashicorp/terraform/tarball`)),
+				),
+			},
+		},
+	})
+}
 
-// func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
+func TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError(t *testing.T) {
+	repo := "terraform"
+	owner := "hashicorp"
+	retrieveBy := "tag"
+	id := int64(23055013)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", id),
+				ExpectError: regexp.MustCompile("`release_tag` must be set when `retrieve_by` = `tag`"),
+			},
+		},
+	})
+}
 
-// }
+func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
+	repo := "terraform"
+	owner := "hashicorp"
+	retrieveBy := "tag"
+	tag := "v0.12.20"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, tag, 0),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.github_release.test", "release_tag", tag),
+					resource.TestMatchResourceAttr("data.github_release.test", "url", regexp.MustCompile(`hashicorp/terraform`)),
+					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", regexp.MustCompile(`hashicorp/terraform/tarball`)),
+				),
+			},
+		},
+	})
+}
 
-// func TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError(t *testing.T) {
+func TestAccGithubReleaseDataSource_invalidRetrieveMethodReturnsError(t *testing.T) {
+	retrieveBy := "not valid"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckGithubReleaseDataSourceConfig("", "", retrieveBy, "", 0),
+				ExpectError: regexp.MustCompile("one of: `latest`, `id`, `tag` must be set for `retrieve_by`"),
+			},
+		},
+	})
 
-// }
+}
 
-// func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
-
-// }
-
-// func TestAccGithubReleaseDataSource_invalidRetrieveMethodReturnsError(t *testing.T) {
-
-// }
-
-func testAccCheckGithubReleaseDataSourceConfig(repo string, owner string, retrieveBy string) string {
+func testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, tag string, id int64) string {
 	return fmt.Sprintf(`
 data "github_release" "test" {
 	repository = "%s"
 	owner = "%s"
 	retrieve_by = "%s"
+	release_tag = "%s"
+	release_id = %d
 }
-`, repo, owner, retrieveBy)
+`, repo, owner, retrieveBy, tag , id)
 }

--- a/github/data_source_github_release_test.go
+++ b/github/data_source_github_release_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -28,9 +29,11 @@ func TestAccGithubReleaseDataSource_fetchByLatestNoReleaseReturnsError(t *testin
 }
 
 func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
-	repo := "terraform"
-	owner := "hashicorp"
+	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
+	owner := os.Getenv("GITHUB_TEST_USER")
 	retrieveBy := "latest"
+	urlResponse := regexp.MustCompile(`hashicorp/terraform`)
+	tarballResponse := regexp.MustCompile(`hashicorp/terraform/tarball`)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -40,13 +43,12 @@ func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
 			{
 				Config: testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", 0),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.github_release.test", "url", regexp.MustCompile(`hashicorp/terraform`)),
-					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", regexp.MustCompile(`hashicorp/terraform/tarball`)),
+					resource.TestMatchResourceAttr("data.github_release.test", "url", urlResponse),
+					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", tarballResponse),
 				),
 			},
 		},
 	})
-
 }
 
 func TestAccGithubReleaseDataSource_fetchByIdWithNoIdReturnsError(t *testing.T) {
@@ -59,17 +61,17 @@ func TestAccGithubReleaseDataSource_fetchByIdWithNoIdReturnsError(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckGithubReleaseDataSourceConfig("", "", retrieveBy, "", 0),
-				ExpectError: regexp.MustCompile("release_id` must be set when `retrieve_by` = `id`"),
+				ExpectError: regexp.MustCompile("`release_id` must be set when `retrieve_by` = `id`"),
 			},
 		},
 	})
 }
 
 func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
-	repo := "terraform"
-	owner := "hashicorp"
+	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
+	owner := os.Getenv("GITHUB_TEST_USER")
 	retrieveBy := "id"
-	id := int64(23055013)
+	id, _ := strconv.ParseInt(os.Getenv("GITHUB_TEMPLATE_REPOSITORY_RELEASE_ID"), 10, 64)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -89,10 +91,10 @@ func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
 }
 
 func TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError(t *testing.T) {
-	repo := "terraform"
-	owner := "hashicorp"
+	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
+	owner := os.Getenv("GITHUB_TEST_USER")
 	retrieveBy := "tag"
-	id := int64(23055013)
+	id := int64(0)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -108,10 +110,12 @@ func TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError(t *testing.T) {
 }
 
 func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
-	repo := "terraform"
-	owner := "hashicorp"
+	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
+	owner := os.Getenv("GITHUB_TEST_USER")
 	retrieveBy := "tag"
-	tag := "v0.12.20"
+	tag := "v1.0"
+	urlResponse := regexp.MustCompile(`hashicorp/terraform`)
+	tarballResponse := regexp.MustCompile(`hashicorp/terraform/tarball`)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -122,8 +126,8 @@ func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
 				Config: testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, tag, 0),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.github_release.test", "release_tag", tag),
-					resource.TestMatchResourceAttr("data.github_release.test", "url", regexp.MustCompile(`hashicorp/terraform`)),
-					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", regexp.MustCompile(`hashicorp/terraform/tarball`)),
+					resource.TestMatchResourceAttr("data.github_release.test", "url", urlResponse),
+					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", tarballResponse),
 				),
 			},
 		},

--- a/github/data_source_github_release_test.go
+++ b/github/data_source_github_release_test.go
@@ -146,7 +146,7 @@ func TestAccGithubReleaseDataSource_invalidRetrieveMethodReturnsError(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckGithubReleaseDataSourceConfig("", "", retrieveBy, "", 0),
-				ExpectError: regexp.MustCompile("expected retrieve_by to be one of \\[latest id tag]"),
+				ExpectError: regexp.MustCompile(`expected retrieve_by to be one of \[latest id tag]`),
 			},
 		},
 	})

--- a/github/data_source_github_release_test.go
+++ b/github/data_source_github_release_test.go
@@ -30,10 +30,10 @@ func TestAccGithubReleaseDataSource_fetchByLatestNoReleaseReturnsError(t *testin
 
 func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
-	owner := os.Getenv("GITHUB_TEST_USER")
+	owner := os.Getenv("GITHUB_ORGANIZATION")
 	retrieveBy := "latest"
-	urlResponse := regexp.MustCompile(`hashicorp/terraform`)
-	tarballResponse := regexp.MustCompile(`hashicorp/terraform/tarball`)
+	expectedUrl := regexp.MustCompile(fmt.Sprintf("%s/%s", owner, repo))
+	expectedTarball := regexp.MustCompile(fmt.Sprintf("%s/%s/tarball", owner, repo))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -43,8 +43,8 @@ func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
 			{
 				Config: testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", 0),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.github_release.test", "url", urlResponse),
-					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", tarballResponse),
+					resource.TestMatchResourceAttr("data.github_release.test", "url", expectedUrl),
+					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", expectedTarball),
 				),
 			},
 		},
@@ -69,8 +69,10 @@ func TestAccGithubReleaseDataSource_fetchByIdWithNoIdReturnsError(t *testing.T) 
 
 func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
-	owner := os.Getenv("GITHUB_TEST_USER")
+	owner := os.Getenv("GITHUB_ORGANIZATION")
 	retrieveBy := "id"
+	expectedUrl := regexp.MustCompile(fmt.Sprintf("%s/%s", owner, repo))
+	expectedTarball := regexp.MustCompile(fmt.Sprintf("%s/%s/tarball", owner, repo))
 	id, _ := strconv.ParseInt(os.Getenv("GITHUB_TEMPLATE_REPOSITORY_RELEASE_ID"), 10, 64)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -82,8 +84,8 @@ func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
 				Config: testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", id),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.github_release.test", "release_id", strconv.FormatInt(id, 10)),
-					resource.TestMatchResourceAttr("data.github_release.test", "url", regexp.MustCompile(`hashicorp/terraform`)),
-					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", regexp.MustCompile(`hashicorp/terraform/tarball`)),
+					resource.TestMatchResourceAttr("data.github_release.test", "url", expectedUrl),
+					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", expectedTarball),
 				),
 			},
 		},
@@ -92,7 +94,7 @@ func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
 
 func TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError(t *testing.T) {
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
-	owner := os.Getenv("GITHUB_TEST_USER")
+	owner := os.Getenv("GITHUB_ORGANIZATION")
 	retrieveBy := "tag"
 	id := int64(0)
 	resource.ParallelTest(t, resource.TestCase{
@@ -111,11 +113,11 @@ func TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError(t *testing.T) {
 
 func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
-	owner := os.Getenv("GITHUB_TEST_USER")
+	owner := os.Getenv("GITHUB_ORGANIZATION")
 	retrieveBy := "tag"
 	tag := "v1.0"
-	urlResponse := regexp.MustCompile(`hashicorp/terraform`)
-	tarballResponse := regexp.MustCompile(`hashicorp/terraform/tarball`)
+	expectedUrl := regexp.MustCompile(fmt.Sprintf("%s/%s", owner, repo))
+	expectedTarball := regexp.MustCompile(fmt.Sprintf("%s/%s/tarball", owner, repo))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -126,8 +128,8 @@ func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
 				Config: testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, tag, 0),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.github_release.test", "release_tag", tag),
-					resource.TestMatchResourceAttr("data.github_release.test", "url", urlResponse),
-					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", tarballResponse),
+					resource.TestMatchResourceAttr("data.github_release.test", "url", expectedUrl),
+					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", expectedTarball),
 				),
 			},
 		},
@@ -144,7 +146,7 @@ func TestAccGithubReleaseDataSource_invalidRetrieveMethodReturnsError(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckGithubReleaseDataSourceConfig("", "", retrieveBy, "", 0),
-				ExpectError: regexp.MustCompile("one of: `latest`, `id`, `tag` must be set for `retrieve_by`"),
+				ExpectError: regexp.MustCompile("expected retrieve_by to be one of \\[latest id tag]"),
 			},
 		},
 	})

--- a/github/data_source_github_release_test.go
+++ b/github/data_source_github_release_test.go
@@ -38,7 +38,7 @@ func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", 0),
+				Config: testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", 0),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.github_release.test", "url", regexp.MustCompile(`hashicorp/terraform`)),
 					resource.TestMatchResourceAttr("data.github_release.test", "tarball_url", regexp.MustCompile(`hashicorp/terraform/tarball`)),
@@ -77,7 +77,7 @@ func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", id),
+				Config: testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, "", id),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.github_release.test", "release_id", strconv.FormatInt(id, 10)),
 					resource.TestMatchResourceAttr("data.github_release.test", "url", regexp.MustCompile(`hashicorp/terraform`)),
@@ -119,7 +119,7 @@ func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, tag, 0),
+				Config: testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy, tag, 0),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.github_release.test", "release_tag", tag),
 					resource.TestMatchResourceAttr("data.github_release.test", "url", regexp.MustCompile(`hashicorp/terraform`)),
@@ -156,5 +156,5 @@ data "github_release" "test" {
 	release_tag = "%s"
 	release_id = %d
 }
-`, repo, owner, retrieveBy, tag , id)
+`, repo, owner, retrieveBy, tag, id)
 }

--- a/github/data_source_github_release_test.go
+++ b/github/data_source_github_release_test.go
@@ -1,0 +1,61 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccGithubReleaseDataSource_fetchByLatestNoReleaseReturnsError(t *testing.T) {
+	repo := "nonExistantRepo"
+	owner := "no-user"
+	retrieveBy := "latest"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckGithubReleaseDataSourceConfig(repo, owner, retrieveBy),
+				ExpectError: regexp.MustCompile(`Not Found`),
+			},
+		},
+	})
+}
+
+// func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
+
+// }
+
+// func TestAccGithubReleaseDataSource_fetchByIdWithNoIdReturnsError(t *testing.T) {
+
+// }
+
+// func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
+
+// }
+
+// func TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError(t *testing.T) {
+
+// }
+
+// func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
+
+// }
+
+// func TestAccGithubReleaseDataSource_invalidRetrieveMethodReturnsError(t *testing.T) {
+
+// }
+
+func testAccCheckGithubReleaseDataSourceConfig(repo string, owner string, retrieveBy string) string {
+	return fmt.Sprintf(`
+data "github_release" "test" {
+	repository = "%s"
+	owner = "%s"
+	retrieve_by = "%s"
+}
+`, repo, owner, retrieveBy)
+}

--- a/github/provider.go
+++ b/github/provider.go
@@ -70,6 +70,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"github_collaborators": dataSourceGithubCollaborators(),
 			"github_ip_ranges":     dataSourceGithubIpRanges(),
+			"github_release":       dataSourceGithubRelease(),
 			"github_repositories":  dataSourceGithubRepositories(),
 			"github_repository":    dataSourceGithubRepository(),
 			"github_team":          dataSourceGithubTeam(),

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -67,6 +67,9 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("GITHUB_TEMPLATE_REPOSITORY"); v == "" {
 		t.Fatal("GITHUB_TEMPLATE_REPOSITORY must be set for acceptance tests")
 	}
+	if v := os.Getenv("GITHUB_TEMPLATE_REPOSITORY_RELEASE_ID"); v == "" {
+		t.Fatal("GITHUB_TEMPLATE_REPOSITORY_RELEASE_ID must be set for acceptance tests")
+	}
 }
 
 func TestProvider_individual(t *testing.T) {

--- a/website/docs/d/release.html.markdown
+++ b/website/docs/d/release.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "github"
+page_title: "GitHub: github_release"
+description: |-
+  Get information on a GitHub release.
+---
+
+# github\_user
+
+Use this data source to retrieve information about a GitHub release in a specified repository.
+
+## Example Usage
+To retrieve the latest release that is present in a repository:
+```hcl
+data "github_release" "example" {
+    repository  = "example-repository"
+    owner       = "example-owner"
+    retrieve_by = "latest"
+}
+```
+To retrieve a specific release from a repository based on it's ID:
+```hcl
+data "github_release" "example" {
+    repository  = "example-repository"
+    owner       = "example-owner"
+    retrieve_by = "id"
+    id          = 12345
+}
+```
+Finally, to retrieve a release based on it's tag: 
+```hcl
+data "github_release" "example" {
+    repository  = "example-repository"
+    owner       = "example-owner"
+    retrieve_by = "tag"
+    release_tag = "v1.0.0"
+}
+```
+
+## Argument Reference
+
+ *  `repository`  -  (Required) Name of the repository to retrieve the release from.
+ 
+ *  `owner`  -  (Required) Owner of the repository.
+ 
+ *  `retrieve_by`  -  (Required) Describes how to fetch the release. Valid values are `id`, `tag`, `latest`.
+ 
+ *  `release_id`  -  (Optional) ID of the release to retrieve. Must be specified when `retrieve_by` = `id`.
+ 
+ *  `release_tag`  -  (Optional) Tag of the release to retrieve. Must be specified when `retrieve_by` = `tag`.
+ 
+
+## Attributes Reference
+
+ * `release_tag` - Tag of release
+ * `release_id` - ID of release
+ * `target_commitish` - Commitish value that determines where the Git release is created from
+ * `name` - Name of release
+ * `body` - Contents of the description (body) of a release
+ * `draft` - (`Boolean`) indicates whether the release is a draft
+ * `prerelease` - (`Boolean`) indicates whether the release is a prerelease
+ * `created_at` - Date of release creation
+ * `published_at` - Date of release publishing
+ * `url` - Base URL of the release
+ * `html_url` - URL directing to detailed information on the release
+ * `asserts_url` - URL of any associated assets with the release
+ * `upload_url` - URL that can be used to upload Assets to the release
+ * `zipball_url` - Download URL of a specific release in `zip` format
+ * `tarball_url` - Download URL of a specific release in `tar.gz` format


### PR DESCRIPTION
This PR covers functionality described in GH-144.

The following functionality has been provided by this new data source:
- [Get a single release by ID](https://developer.github.com/v3/repos/releases/#get-a-single-release)
- [Get the latest release for a repo](https://developer.github.com/v3/repos/releases/#get-the-latest-release)
- [Get a release by tag](https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name)

Things not covered by this data source:
- [Github release Assets](https://developer.github.com/v3/repos/releases/#list-assets-for-a-release)
- Managing (CRUD) Releases

The following constraints apply to this data source:

Required properties:
- `repository`    : Name of the repository to retrieve the release from
- `owner`          : Owner of the repository (can be org / user)
- `retrieve_by`  : Describes how to fetch the release. Valid values are `id`, `tag`, `latest`
- `release_id`    : ID of the release to retrieve. Must be specified when `retrieve_by` = `id`
- `release_tag`  : Tag of the release to retrieve. Must be specified when `retrieve_by` = `tag`

I would like to say that this is my first real foray with Go, so any styling / syntax / best practice tips would be appreciated!