### PR TITLE
Updating docs to include triage and maintain permissions, as per PR #303

### DIFF
--- a/website/docs/r/team_repository.html.markdown
+++ b/website/docs/r/team_repository.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `team_id` - (Required) The GitHub team id
 * `repository` - (Required) The repository to add to the team.
 * `permission` - (Optional) The permissions of team members regarding the repository.
-  Must be one of `pull`, `push`, or `admin`. Defaults to `pull`.
+  Must be one of `pull`, `triage`, `push`, `maintain`, or `admin`. Defaults to `pull`.
 
 
 ## Import


### PR DESCRIPTION
I spent a little bit of time last week digging around until I discovered that triage and maintain permissions had been added in #303 so I tweaked the docs to include mention of them.