### PR TITLE
Fixed : insecure_ssl parameter behaviour in webhook creation

### DIFF
--- a/github/resource_github_organization_webhook_test.go
+++ b/github/resource_github_organization_webhook_test.go
@@ -32,7 +32,7 @@ func TestAccGithubOrganizationWebhook_basic(t *testing.T) {
 						Configuration: map[string]interface{}{
 							"url":          "https://google.de/webhook",
 							"content_type": "json",
-							"insecure_ssl": "true",
+							"insecure_ssl": true,
 						},
 						Active: true,
 					}),
@@ -47,7 +47,7 @@ func TestAccGithubOrganizationWebhook_basic(t *testing.T) {
 						Configuration: map[string]interface{}{
 							"url":          "https://google.de/webhooks",
 							"content_type": "form",
-							"insecure_ssl": "false",
+							"insecure_ssl": false,
 						},
 						Active: false,
 					}),

--- a/github/resource_github_repository_webhook_test.go
+++ b/github/resource_github_repository_webhook_test.go
@@ -33,7 +33,7 @@ func TestAccGithubRepositoryWebhook_basic(t *testing.T) {
 						Configuration: map[string]interface{}{
 							"url":          "https://google.de/webhook",
 							"content_type": "json",
-							"insecure_ssl": "true",
+							"insecure_ssl": true,
 						},
 						Active: true,
 					}),
@@ -48,7 +48,7 @@ func TestAccGithubRepositoryWebhook_basic(t *testing.T) {
 						Configuration: map[string]interface{}{
 							"url":          "https://google.de/webhooks",
 							"content_type": "form",
-							"insecure_ssl": "false",
+							"insecure_ssl": false,
 						},
 						Active: false,
 					}),
@@ -84,7 +84,7 @@ func TestAccGithubRepositoryWebhook_secret(t *testing.T) {
 							"url":          "https://www.terraform.io/webhook",
 							"content_type": "json",
 							"secret":       "********",
-							"insecure_ssl": "false",
+							"insecure_ssl": false,
 						},
 						Active: true,
 					}),

--- a/github/schema_webhook_configuration.go
+++ b/github/schema_webhook_configuration.go
@@ -25,7 +25,7 @@ func webhookConfigurationSchema() *schema.Schema {
 					Sensitive: true,
 				},
 				"insecure_ssl": {
-					Type:     schema.TypeString,
+					Type:     schema.TypeBool,
 					Optional: true,
 				},
 			},


### PR DESCRIPTION
insecure_ssl parameter is not working while creating webhook for org/repo
This PR fixes this behaviour 
#352 