### PR TITLE
Handle pagination when listing commits in github_repository_file

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -320,12 +320,26 @@ func checkRepositoryFileExists(client *github.Client, org, repo, file, branch st
 
 func getFileCommit(client *github.Client, org, repo, file, branch string) (*github.RepositoryCommit, error) {
 	ctx := context.WithValue(context.Background(), ctxId, fmt.Sprintf("%s/%s", repo, file))
-	commits, _, err := client.Repositories.ListCommits(ctx, org, repo, &github.CommitsListOptions{SHA: branch})
-	if err != nil {
-		return nil, err
+	opts := &github.CommitsListOptions{
+		SHA: branch,
+	}
+	allCommits := []*github.RepositoryCommit{}
+	for {
+		commits, resp, err := client.Repositories.ListCommits(ctx, org, repo, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		allCommits = append(allCommits, commits...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+
+		opts.Page = resp.NextPage
 	}
 
-	for _, c := range commits {
+	for _, c := range allCommits {
 		sha := c.GetSHA()
 
 		// Skip merge commits


### PR DESCRIPTION
Hey @jcudit, @kpfleming,

When using `github_repository_file`, the resource attempts to lookup the file's commit info which involves listing all commits in a branch and looping backwards until it finds a commit containing the file.

Alas I didn't cover pagination when listing these commits for a branch which will cause a problem when the file's commit was too far in the past, users would see something like this:

```hcl
Error: Cannot find file .github/workflows/tfsec.yml in repo <org/repo>
```

This PR fixes this by adding missing support for pagination - couldn't write a test for this but have fixed the issue we found in one of our repos.