### PR TITLE
Add missing repository_file link

### DIFF
--- a/website/github.erb
+++ b/website/github.erb
@@ -68,6 +68,9 @@
             <a href="/docs/providers/github/r/repository_deploy_key.html">github_repository_deploy_key</a>
           </li>
           <li>
+            <a href="/docs/providers/github/r/repository_file.html">github_repository_file</a>
+          </li>
+          <li>
             <a href="/docs/providers/github/r/repository_project.html">github_repository_project</a>
           </li>
           <li>


### PR DESCRIPTION
Not sure if these are autogenerated or what, but the new `github_repository_file` resource in the latest release doesn't have a link in the docs sidebar. The doc page does exist though: https://www.terraform.io/docs/providers/github/r/repository_file.html