### PR TITLE
Add missing sidebar items

### DIFF
--- a/website/docs/d/release.html.markdown
+++ b/website/docs/d/release.html.markdown
@@ -5,12 +5,13 @@ description: |-
   Get information on a GitHub release.
 ---
 
-# github\_user
+# github\_release
 
 Use this data source to retrieve information about a GitHub release in a specified repository.
 
 ## Example Usage
 To retrieve the latest release that is present in a repository:
+
 ```hcl
 data "github_release" "example" {
     repository  = "example-repository"
@@ -18,7 +19,9 @@ data "github_release" "example" {
     retrieve_by = "latest"
 }
 ```
+
 To retrieve a specific release from a repository based on it's ID:
+
 ```hcl
 data "github_release" "example" {
     repository  = "example-repository"
@@ -27,7 +30,9 @@ data "github_release" "example" {
     id          = 12345
 }
 ```
-Finally, to retrieve a release based on it's tag: 
+
+Finally, to retrieve a release based on it's tag:
+
 ```hcl
 data "github_release" "example" {
     repository  = "example-repository"

--- a/website/docs/r/user_ssh_key.html.markdown
+++ b/website/docs/r/user_ssh_key.html.markdown
@@ -36,7 +36,7 @@ The following attributes are exported:
 
 ## Import
 
-SSH keys can be imported using the their ID e.g.
+SSH keys can be imported using their ID e.g.
 
 ```
 $ terraform import github_user_ssh_key.example 1234567

--- a/website/github.erb
+++ b/website/github.erb
@@ -71,6 +71,9 @@
             <a href="/docs/providers/github/r/repository_deploy_key.html">github_repository_deploy_key</a>
           </li>
           <li>
+            <a href="/docs/providers/github/r/repository_file.html">github_repository_file</a>
+          </li>
+          <li>
             <a href="/docs/providers/github/r/repository_project.html">github_repository_project</a>
           </li>
           <li>

--- a/website/github.erb
+++ b/website/github.erb
@@ -20,6 +20,9 @@
               <a href="/docs/providers/github/d/ip_ranges.html">github_ip_ranges</a>
             </li>
             <li>
+              <a href="/docs/providers/github/d/release.html">github_release</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/d/repositories.html">github_repositories</a>
             </li>
             <li>

--- a/website/github.erb
+++ b/website/github.erb
@@ -29,10 +29,10 @@
               <a href="/docs/providers/github/d/repository.html">github_repository</a>
             </li>
             <li>
-              <a href="/docs/providers/github/d/user.html">github_user</a>
+              <a href="/docs/providers/github/d/team.html">github_team</a>
             </li>
             <li>
-              <a href="/docs/providers/github/d/team.html">github_team</a>
+              <a href="/docs/providers/github/d/user.html">github_user</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Hello 👋

This adds two missing items to the sidebar (`github_release` and `github_repository_file`) and updates the Markdown for `github_release`.