### PR TITLE
Compute node ids for repo, user and team resources & data sources

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -98,6 +98,10 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -153,6 +157,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("git_clone_url", repo.GitURL)
 	d.Set("http_clone_url", repo.CloneURL)
 	d.Set("archived", repo.Archived)
+	d.Set("node_id", repo.GetNodeID())
 
 	err = d.Set("topics", flattenStringList(repo.Topics))
 	if err != nil {

--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -40,6 +40,10 @@ func dataSourceGithubTeam() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -72,6 +76,7 @@ func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", team.GetDescription())
 	d.Set("privacy", team.GetPrivacy())
 	d.Set("permission", team.GetPermission())
+	d.Set("node_id", team.GetNodeID())
 
 	return nil
 }

--- a/github/data_source_github_user.go
+++ b/github/data_source_github_user.go
@@ -91,6 +91,10 @@ func dataSourceGithubUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -145,6 +149,7 @@ func dataSourceGithubUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("following", user.GetFollowing())
 	d.Set("created_at", user.GetCreatedAt())
 	d.Set("updated_at", user.GetUpdatedAt())
+	d.Set("node_id", user.GetNodeID())
 
 	return nil
 }

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -156,6 +156,10 @@ func resourceGithubRepository() *schema.Resource {
 					},
 				},
 			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -304,6 +308,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("http_clone_url", repo.CloneURL)
 	d.Set("archived", repo.Archived)
 	d.Set("topics", flattenStringList(repo.Topics))
+	d.Set("node_id", repo.GetNodeID())
 
 	if repo.TemplateRepository != nil {
 		d.Set("template", []interface{}{

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -51,6 +51,10 @@ func resourceGithubTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -137,6 +141,7 @@ func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("ldap_dn", team.GetLDAPDN())
 	d.Set("slug", team.GetSlug())
+	d.Set("node_id", team.GetNodeID())
 
 	return nil
 }


### PR DESCRIPTION
Output of node ids will assist in integration with the v4 provider which
uses global ids for both input and state.