### PR TITLE
Prevent a panic when trying to use DismissalRestrictions

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -433,17 +433,18 @@ func requireSignedCommitsUpdate(d *schema.ResourceData, meta interface{}) (err e
 func flattenAndSetRequiredPullRequestReviews(d *schema.ResourceData, protection *github.Protection) error {
 	rprr := protection.RequiredPullRequestReviews
 	if rprr != nil {
-		users := make([]interface{}, 0, len(rprr.DismissalRestrictions.Users))
-		for _, u := range rprr.DismissalRestrictions.Users {
-			if u.Login != nil {
-				users = append(users, *u.Login)
+		var users, teams []interface{}
+		if rprr.DismissalRestrictions != nil {
+			for _, u := range rprr.DismissalRestrictions.Users {
+				if u.Login != nil {
+					users = append(users, *u.Login)
+				}
 			}
-		}
 
-		teams := make([]interface{}, 0, len(rprr.DismissalRestrictions.Teams))
-		for _, t := range rprr.DismissalRestrictions.Teams {
-			if t.Slug != nil {
-				teams = append(teams, *t.Slug)
+			for _, t := range rprr.DismissalRestrictions.Teams {
+				if t.Slug != nil {
+					teams = append(teams, *t.Slug)
+				}
 			}
 		}
 

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -305,18 +305,21 @@ func testAccCheckGithubBranchProtectionPullRequestReviews(protection *github.Pro
 			return fmt.Errorf("Expected `dismiss_state_reviews` to be %t, got %t", expectedStale, reviews.DismissStaleReviews)
 		}
 
-		users := []string{}
-		for _, u := range reviews.DismissalRestrictions.Users {
-			users = append(users, *u.Login)
+		var users, teams []string
+		if reviews.DismissalRestrictions != nil {
+			for _, u := range reviews.DismissalRestrictions.Users {
+				users = append(users, *u.Login)
+			}
+
+			for _, t := range reviews.DismissalRestrictions.Teams {
+				teams = append(teams, *t.Slug)
+			}
 		}
+
 		if diff := pretty.Compare(users, expectedUsers); diff != "" {
 			return fmt.Errorf("diff %q: (-got +want)\n%s", "required_pull_request_reviews.dismissal_users", diff)
 		}
 
-		teams := []string{}
-		for _, t := range reviews.DismissalRestrictions.Teams {
-			teams = append(teams, *t.Slug)
-		}
 		sort.Strings(teams)
 		sort.Strings(expectedTeams)
 		if diff := pretty.Compare(teams, expectedTeams); diff != "" {


### PR DESCRIPTION
The recently updated `go-github` package updated the protections struct
a little by converting the `DismissalRestrictions` field from a struct
to a pointer to a struct. Hence this can now be `nil` which in turn
causes a panic when trying to use it as a value.

This PR added the change to the `go-github` package: https://github.com/google/go-github/pull/1288

Relevant crash info:

```
panic: runtime error: invalid memory address or nil pointer dereference
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xe0e67c]
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: goroutine 95 [running]:
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: github.com/terraform-providers/terraform-provider-github/github.flattenAndSetRequiredPullRequestReviews(0xc0002724d0, 0xc00022cce0, 0x0, 0x0)
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-github/github/resource_github_branch_protection.go:431 +0x4c
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: github.com/terraform-providers/terraform-provider-github/github.resourceGithubBranchProtectionRead(0xc0002724d0, 0xec62c0, 0xc00016e630, 0xc0002724d0, 0x0)
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-github/github/resource_github_branch_protection.go:241 +0x9a7
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: github.com/hashicorp/terraform/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000116b80, 0xc00009a820, 0xec62c0, 0xc00016e630, 0xc0001362a0, 0x0, 0x0)
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:455 +0x11c
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: github.com/hashicorp/terraform/helper/plugin.(*GRPCProviderServer).ReadResource(0xc00000ca90, 0x12b5f20, 0xc00065b2c0, 0xc000250000, 0xc00000ca90, 0xc00065b230, 0xf74120)
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/helper/plugin/grpc_provider.go:525 +0x3a8
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: github.com/hashicorp/terraform/internal/tfplugin5._Provider_ReadResource_Handler(0x10a07c0, 0xc00000ca90, 0x12b5f20, 0xc00065b2c0, 0xc00009bf90, 0x0, 0x0, 0x0, 0xc00025d040, 0x195)
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-github/vendor/github.com/hashicorp/terraform/internal/tfplugin5/tfplugin5.pb.go:3181 +0x23e
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: google.golang.org/grpc.(*Server).processUnaryRPC(0xc000144780, 0x12bc280, 0xc000145200, 0xc0005fb000, 0xc0001263c0, 0x1af6c50, 0x0, 0x0, 0x0)
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-github/vendor/google.golang.org/grpc/server.go:971 +0x4a2
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: google.golang.org/grpc.(*Server).handleStream(0xc000144780, 0x12bc280, 0xc000145200, 0xc0005fb000, 0x0)
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-github/vendor/google.golang.org/grpc/server.go:1250 +0xd61
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000034510, 0xc000144780, 0x12bc280, 0xc000145200, 0xc0005fb000)
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-github/vendor/google.golang.org/grpc/server.go:690 +0x9f
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: created by google.golang.org/grpc.(*Server).serveStreams.func1
2020-03-13T11:26:01.255Z [DEBUG] plugin.terraform-provider-github_v2.4.1_x4: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-github/vendor/google.golang.org/grpc/server.go:688 +0xa1
2020-03-13T11:26:01.256Z [DEBUG] plugin: plugin process exited: path=/terraform/.terraform/plugins/linux_amd64/terraform-provider-github_v2.4.1_x4 pid=1664 error="exit status 2"
```