### PR TITLE
Remove Test Step To Verify Importing Invitation

### DIFF
--- a/github/resource_github_user_invitation_accepter_test.go
+++ b/github/resource_github_user_invitation_accepter_test.go
@@ -35,11 +35,6 @@ func TestAccGithubUserInvitationAccepter_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(rn, "invitation_id", regexp.MustCompile(`^[0-9]+$`)),
 				),
 			},
-			{
-				ResourceName:      rn,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }


### PR DESCRIPTION
There is no `Importer` currently defined for `GithubUserInvitationAccepter` which causes this test to fail.

cc https://github.com/terraform-providers/terraform-provider-github/issues/350#issuecomment-594946337