### PR TITLE
Docs: Correct Repository_Collaborator Permission Levels

### DIFF
--- a/website/docs/r/repository_collaborator.html.markdown
+++ b/website/docs/r/repository_collaborator.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `repository` - (Required) The GitHub repository
 * `username` - (Required) The user to add to the repository as a collaborator.
 * `permission` - (Optional) The permission of the outside collaborator for the repository.
-            Must be one of `pull`, `push`, or `admin`. Defaults to `push`.
+            Must be one of `pull`, `triage`, `push`, `maintain`, or `admin`. Defaults to `push`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Looking at https://github.com/terraform-providers/terraform-provider-github/blob/master/github/resource_github_repository_collaborator.go#L41, "triage" and "maintain" are supported. Update the docs to reflect it.