### PR TITLE
resource/github_repository: Introduce option to manage `Delete Branch on Merge`

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -75,6 +75,11 @@ func resourceGithubRepository() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"delete_branch_on_merge": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"auto_init": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -162,22 +167,23 @@ func resourceGithubRepository() *schema.Resource {
 
 func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 	return &github.Repository{
-		Name:              github.String(d.Get("name").(string)),
-		Description:       github.String(d.Get("description").(string)),
-		Homepage:          github.String(d.Get("homepage_url").(string)),
-		Private:           github.Bool(d.Get("private").(bool)),
-		HasDownloads:      github.Bool(d.Get("has_downloads").(bool)),
-		HasIssues:         github.Bool(d.Get("has_issues").(bool)),
-		HasProjects:       github.Bool(d.Get("has_projects").(bool)),
-		HasWiki:           github.Bool(d.Get("has_wiki").(bool)),
-		AllowMergeCommit:  github.Bool(d.Get("allow_merge_commit").(bool)),
-		AllowSquashMerge:  github.Bool(d.Get("allow_squash_merge").(bool)),
-		AllowRebaseMerge:  github.Bool(d.Get("allow_rebase_merge").(bool)),
-		AutoInit:          github.Bool(d.Get("auto_init").(bool)),
-		LicenseTemplate:   github.String(d.Get("license_template").(string)),
-		GitignoreTemplate: github.String(d.Get("gitignore_template").(string)),
-		Archived:          github.Bool(d.Get("archived").(bool)),
-		Topics:            expandStringList(d.Get("topics").(*schema.Set).List()),
+		Name:                github.String(d.Get("name").(string)),
+		Description:         github.String(d.Get("description").(string)),
+		Homepage:            github.String(d.Get("homepage_url").(string)),
+		Private:             github.Bool(d.Get("private").(bool)),
+		HasDownloads:        github.Bool(d.Get("has_downloads").(bool)),
+		HasIssues:           github.Bool(d.Get("has_issues").(bool)),
+		HasProjects:         github.Bool(d.Get("has_projects").(bool)),
+		HasWiki:             github.Bool(d.Get("has_wiki").(bool)),
+		AllowMergeCommit:    github.Bool(d.Get("allow_merge_commit").(bool)),
+		AllowSquashMerge:    github.Bool(d.Get("allow_squash_merge").(bool)),
+		AllowRebaseMerge:    github.Bool(d.Get("allow_rebase_merge").(bool)),
+		DeleteBranchOnMerge: github.Bool(d.Get("delete_branch_on_merge").(bool)),
+		AutoInit:            github.Bool(d.Get("auto_init").(bool)),
+		LicenseTemplate:     github.String(d.Get("license_template").(string)),
+		GitignoreTemplate:   github.String(d.Get("gitignore_template").(string)),
+		Archived:            github.Bool(d.Get("archived").(bool)),
+		Topics:              expandStringList(d.Get("topics").(*schema.Set).List()),
 	}
 }
 
@@ -294,6 +300,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("allow_merge_commit", repo.AllowMergeCommit)
 	d.Set("allow_squash_merge", repo.AllowSquashMerge)
 	d.Set("allow_rebase_merge", repo.AllowRebaseMerge)
+	d.Set("delete_branch_on_merge", repo.DeleteBranchOnMerge)
 	d.Set("has_downloads", repo.HasDownloads)
 	d.Set("full_name", repo.FullName)
 	d.Set("default_branch", repo.DefaultBranch)

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -68,18 +68,19 @@ func TestAccGithubRepository_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubRepositoryExists(rn, &repo),
 					testAccCheckGithubRepositoryAttributes(&repo, &testAccGithubRepositoryExpectedAttributes{
-						Name:             name,
-						Description:      description,
-						Homepage:         "http://example.com/",
-						HasIssues:        true,
-						HasWiki:          true,
-						AllowMergeCommit: true,
-						AllowSquashMerge: false,
-						AllowRebaseMerge: false,
-						HasDownloads:     true,
-						HasProjects:      false,
-						DefaultBranch:    "master",
-						Archived:         false,
+						Name:                name,
+						Description:         description,
+						Homepage:            "http://example.com/",
+						HasIssues:           true,
+						HasWiki:             true,
+						AllowMergeCommit:    true,
+						AllowSquashMerge:    false,
+						AllowRebaseMerge:    false,
+						DeleteBranchOnMerge: false,
+						HasDownloads:        true,
+						HasProjects:         false,
+						DefaultBranch:       "master",
+						Archived:            false,
 					}),
 				),
 			},
@@ -555,23 +556,24 @@ func testAccCheckGithubRepositoryTemplateRepoAttribute(n string, repo *github.Re
 }
 
 type testAccGithubRepositoryExpectedAttributes struct {
-	Name              string
-	Description       string
-	Homepage          string
-	Private           bool
-	HasDownloads      bool
-	HasIssues         bool
-	HasProjects       bool
-	HasWiki           bool
-	AllowMergeCommit  bool
-	AllowSquashMerge  bool
-	AllowRebaseMerge  bool
-	AutoInit          bool
-	DefaultBranch     string
-	LicenseTemplate   string
-	GitignoreTemplate string
-	Archived          bool
-	Topics            []string
+	Name                string
+	Description         string
+	Homepage            string
+	Private             bool
+	HasDownloads        bool
+	HasIssues           bool
+	HasProjects         bool
+	HasWiki             bool
+	AllowMergeCommit    bool
+	AllowSquashMerge    bool
+	AllowRebaseMerge    bool
+	DeleteBranchOnMerge bool
+	AutoInit            bool
+	DefaultBranch       string
+	LicenseTemplate     string
+	GitignoreTemplate   string
+	Archived            bool
+	Topics              []string
 }
 
 func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testAccGithubRepositoryExpectedAttributes) resource.TestCheckFunc {

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -56,6 +56,8 @@ The following arguments are supported:
 
 * `allow_rebase_merge` - (Optional) Set to `false` to disable rebase merges on the repository.
 
+* `auto_delete_head_branch` - (Optional) Automatically delete head branch after a pull request is merged. Defaults to `false`.
+
 * `has_downloads` - (Optional) Set to `true` to enable the (deprecated) downloads features on the repository.
 
 * `auto_init` - (Optional) Set to `true` to produce an initial commit in the repository.


### PR DESCRIPTION
Since [this commit](https://github.com/google/go-github/pull/1388/) it
is possible to manage if the project should close branches automatically
after a PR is merged.

The current version on this project already supports this new config.

This commit introduces the new option, using the same default as the
GitHub API uses.

Fix #264
Closes #265

Better reviewed with `?w=1` on the url to hide whitespace introduced by gofmt