### PR TITLE
website: Fix typo in github_actions_secret nav link

### DIFF
--- a/website/github.erb
+++ b/website/github.erb
@@ -44,7 +44,7 @@
         <a href="#">Resources</a>
         <ul class="nav nav-visible">
           <li>
-            <a href="/docs/providers/github/r/github_actions_secret.html">github_actions_secret</a>
+            <a href="/docs/providers/github/r/actions_secret.html">github_actions_secret</a>
           </li>
           <li>
             <a href="/docs/providers/github/r/branch_protection.html">github_branch_protection</a>


### PR DESCRIPTION
Hello! There's a broken nav link that makes this resource's docs unreachable. (Unless you edit the URL by hand.) 

Once this is merged, please cherry-pick it to the `stable-website` branch, so it'll stop causing broken link alerts for the website. 

Thank you! 