### PR TITLE
typo in actions_secret URL

### DIFF
--- a/website/github.erb
+++ b/website/github.erb
@@ -44,7 +44,7 @@
         <a href="#">Resources</a>
         <ul class="nav nav-visible">
           <li>
-            <a href="/docs/providers/github/r/github_actions_secret.html">github_actions_secret</a>
+            <a href="/docs/providers/github/r/actions_secret.html">github_actions_secret</a>
           </li>
           <li>
             <a href="/docs/providers/github/r/branch_protection.html">github_branch_protection</a>


### PR DESCRIPTION
The `github_actions_secret` link from the index 404s:

![image](https://user-images.githubusercontent.com/4310271/78119167-fa0c6000-7442-11ea-86f1-865e9e5cc4af.png)
