### PR TITLE
Fix Typo For Actions Page

### DIFF
--- a/website/github.erb
+++ b/website/github.erb
@@ -44,7 +44,7 @@
         <a href="#">Resources</a>
         <ul class="nav nav-visible">
           <li>
-            <a href="/docs/providers/github/r/github_actions_secret.html">github_actions_secret</a>
+            <a href="/docs/providers/github/r/actions_secret.html">github_actions_secret</a>
           </li>
           <li>
             <a href="/docs/providers/github/r/branch_protection.html">github_branch_protection</a>


### PR DESCRIPTION
Fixes a typo that is causing CI failures and a broken link to documentation.

/cc https://github.com/terraform-providers/terraform-provider-github/issues/271