### PR TITLE
Fix incorrect argument name

### DIFF
--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `allow_rebase_merge` - (Optional) Set to `false` to disable rebase merges on the repository.
 
-* `auto_delete_head_branch` - (Optional) Automatically delete head branch after a pull request is merged. Defaults to `false`.
+* `delete_branch_on_merge` - (Optional) Automatically delete head branch after a pull request is merged. Defaults to `false`.
 
 * `has_downloads` - (Optional) Set to `true` to enable the (deprecated) downloads features on the repository.
 


### PR DESCRIPTION
Looks like the docs weren't updated correctly when this new feature landed in 2.6.0