### PR TITLE
update docs to reflect resource and data schemas

### DIFF
--- a/github/data_source_github_actions_public_key.go
+++ b/github/data_source_github_actions_public_key.go
@@ -2,8 +2,9 @@ package github
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func dataSourceGithubActionsPublicKey() *schema.Resource {
@@ -17,11 +18,11 @@ func dataSourceGithubActionsPublicKey() *schema.Resource {
 			},
 			"key_id": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 			"key": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 		},
 	}

--- a/website/docs/d/actions_public_key.html.markdown
+++ b/website/docs/d/actions_public_key.html.markdown
@@ -14,14 +14,12 @@ Note that the provider `token` must have admin rights to a repository to retriev
 
 ```hcl
 data "github_secrets_public_key" "example" {
-  owner      = "example_owner"
   repository = "example_repo"
 }
 ```
 
 ## Argument Reference
 
- * `owner`      - (Required) Owner of the repository.
  * `repository` - (Required) Name of the repository to get public key from.
 
 ## Attributes Reference

--- a/website/docs/r/actions_secret.html.markdown
+++ b/website/docs/r/actions_secret.html.markdown
@@ -23,7 +23,6 @@ in your code. See below for an example of this abstraction.
 
 ```hcl
 data "github_actions_public_key" "example_public_key" {
-  owner      = "example_owner"
   repository = "example_repository"
 }
 
@@ -31,8 +30,6 @@ resource "github_actions_secret" "example_secret" {
   repository       = "example_repository"
   secret_name      = "example_secret_name"
   plaintext_value  = var.some_secret_string
-  key_id           = github_actions_public_key.example_public_key.key_id
-  public_key       = github_actions_public_key.example_public_key.key
 }
 ```
 
@@ -43,5 +40,8 @@ The following arguments are supported:
 * `repository`      - (Required) Name of the repository
 * `secret_name`     - (Required) Name of the secret
 * `plaintext_value` - (Required) Plaintext value of the secret to be encrypted
-* `key_id`          - (Required) ID if the key used for encryption
-* `public_key`      - (Required) Public key of the repository to be used in encryption of the `plaintext_value`
+
+## Attributes Reference
+
+* `created_at`      - Date of actions_secret creation.
+* `updated_at`      - Date of actions_secret update.


### PR DESCRIPTION
Changes to address discrepancies observed in `github_actions_public_key` data source schema definition and `github_actions_secret` resource website docs