### PR TITLE
Fix problem with pr #303, adding "maintain" and "triage" for repo collaborators

### DIFF
--- a/github/util_permissions.go
+++ b/github/util_permissions.go
@@ -48,6 +48,10 @@ func getInvitationPermission(i *github.RepositoryInvitation) (string, error) {
 		return pushPermission, nil
 	} else if *i.Permissions == adminPermission {
 		return adminPermission, nil
+	} else if *i.Permissions == maintainPermission {
+		return maintainPermission, nil
+	} else if *i.Permissions == triagePermission {
+		return triagePermission, nil
 	}
 
 	return "", fmt.Errorf("unexpected permission value: %v", *i.Permissions)

--- a/website/docs/r/repository_collaborator.html.markdown
+++ b/website/docs/r/repository_collaborator.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `repository` - (Required) The GitHub repository
 * `username` - (Required) The user to add to the repository as a collaborator.
 * `permission` - (Optional) The permission of the outside collaborator for the repository.
-            Must be one of `pull`, `push`, or `admin`. Defaults to `push`.
+            Must be one of `pull`, `push`, `maintain`, `triage` or `admin`. Defaults to `push`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Due to type validation in previous PR #303 did not enable new roles for **collaborators** (only for teams) as per https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator collaborators can also be "maintain" and "triage":

```
Error: unexpected permission value: maintain
Error: unexpected permission value: maintain
```

This PR updates role validation and also updates documentation for repository_collaborator.

More info: https://github.com/terraform-providers/terraform-provider-github/pull/303#issuecomment-610409485

(my first contribution!)