### PR TITLE
Fix YAML front matter separator

### DIFF
--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -3,7 +3,7 @@ layout: "github"
 page_title: "GitHub: github_ip_ranges"
 description: |-
   Get information on GitHub's IP addresses.
--------------------------------------------
+---
 
 # github_ip_ranges
 

--- a/website/docs/d/membership.html.markdown
+++ b/website/docs/d/membership.html.markdown
@@ -3,7 +3,7 @@ layout: "github"
 page_title: "GitHub: github_membership"
 description: |-
   Get information on user membership in an organization.
--------------------------------------------
+---
 
 # github_membership
 


### PR DESCRIPTION
This fixes those two broken pages:

- https://www.terraform.io/docs/providers/github/d/ip_ranges.html
- https://www.terraform.io/docs/providers/github/d/membership.html