### PR TITLE
Visibility

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -37,6 +37,10 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"visibility": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"has_issues": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -143,6 +147,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("description", repo.GetDescription())
 	d.Set("homepage_url", repo.GetHomepage())
 	d.Set("private", repo.GetPrivate())
+	d.Set("visibility", repo.GetVisibility())
 	d.Set("has_issues", repo.GetHasIssues())
 	d.Set("has_wiki", repo.GetHasWiki())
 	d.Set("allow_merge_commit", repo.GetAllowMergeCommit())

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -77,6 +77,7 @@ func testRepoCheck() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr("data.github_repository.test", "id", "test-repo"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "name", "test-repo"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "private", "false"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "visibility", "public"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "description", "Test description, used in GitHub Terraform provider acceptance test."),
 		resource.TestCheckResourceAttr("data.github_repository.test", "homepage_url", "http://www.example.com"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "has_issues", "true"),

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -44,6 +44,12 @@ func resourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "public",
+				ValidateFunc: validation.StringInSlice([]string{"public", "private", "internal"}, false),
+			},
 			"has_issues": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -179,6 +185,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 		Description:         github.String(d.Get("description").(string)),
 		Homepage:            github.String(d.Get("homepage_url").(string)),
 		Private:             github.Bool(d.Get("private").(bool)),
+		Visibility:          github.String(d.Get("visibility").(string)),
 		HasDownloads:        github.Bool(d.Get("has_downloads").(bool)),
 		HasIssues:           github.Bool(d.Get("has_issues").(bool)),
 		HasProjects:         github.Bool(d.Get("has_projects").(bool)),
@@ -303,6 +310,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("description", repo.GetDescription())
 	d.Set("homepage_url", repo.GetHomepage())
 	d.Set("private", repo.GetPrivate())
+	d.Set("visibility", repo.GetVisibility())
 	d.Set("has_issues", repo.GetHasIssues())
 	d.Set("has_projects", repo.GetHasProjects())
 	d.Set("has_wiki", repo.GetHasWiki())

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -71,6 +71,7 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						Name:                name,
 						Description:         description,
 						Homepage:            "http://example.com/",
+						Visibility:          "public",
 						HasIssues:           true,
 						HasWiki:             true,
 						IsTemplate:          false,
@@ -93,6 +94,7 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						Name:             name,
 						Description:      "Updated " + description,
 						Homepage:         "http://example.com/",
+						Visibility:       "public",
 						AllowMergeCommit: false,
 						AllowSquashMerge: true,
 						AllowRebaseMerge: true,
@@ -136,6 +138,7 @@ func TestAccGithubRepository_archive(t *testing.T) {
 						Name:             name,
 						Description:      description,
 						Homepage:         "http://example.com/",
+						Visibility:       "public",
 						HasIssues:        true,
 						HasWiki:          true,
 						AllowMergeCommit: true,
@@ -180,6 +183,7 @@ func TestAccGithubRepository_archiveUpdate(t *testing.T) {
 						Name:             name,
 						Description:      description,
 						Homepage:         "http://example.com/",
+						Visibility:       "public",
 						HasIssues:        true,
 						HasWiki:          true,
 						AllowMergeCommit: true,
@@ -199,6 +203,7 @@ func TestAccGithubRepository_archiveUpdate(t *testing.T) {
 						Name:             name,
 						Description:      description,
 						Homepage:         "http://example.com/",
+						Visibility:       "public",
 						HasIssues:        true,
 						HasWiki:          true,
 						AllowMergeCommit: true,
@@ -264,6 +269,7 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 						Name:             name,
 						Description:      description,
 						Homepage:         "http://example.com/",
+						Visibility:       "public",
 						HasIssues:        true,
 						HasWiki:          true,
 						AllowMergeCommit: true,
@@ -289,6 +295,7 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 						Name:             name,
 						Description:      "Updated " + description,
 						Homepage:         "http://example.com/",
+						Visibility:       "public",
 						AutoInit:         true,
 						HasIssues:        true,
 						HasWiki:          true,
@@ -334,6 +341,7 @@ func TestAccGithubRepository_templates(t *testing.T) {
 						Name:              name,
 						Description:       description,
 						Homepage:          "http://example.com/",
+						Visibility:        "public",
 						HasIssues:         true,
 						HasWiki:           true,
 						AllowMergeCommit:  true,
@@ -393,6 +401,7 @@ func TestAccGithubRepository_topics(t *testing.T) {
 						Name:        name,
 						Description: description,
 						Homepage:    "http://example.com/",
+						Visibility:  "public",
 						Topics:      []string{"topic2", "topic1"},
 
 						// non-zero defaults
@@ -411,6 +420,7 @@ func TestAccGithubRepository_topics(t *testing.T) {
 						Name:        name,
 						Description: description,
 						Homepage:    "http://example.com/",
+						Visibility:  "public",
 						Topics:      []string{"topic1", "topic2", "topic3"},
 
 						// non-zero defaults
@@ -429,6 +439,7 @@ func TestAccGithubRepository_topics(t *testing.T) {
 						Name:        name,
 						Description: description,
 						Homepage:    "http://example.com/",
+						Visibility:  "public",
 						Topics:      []string{},
 
 						// non-zero defaults
@@ -562,6 +573,7 @@ type testAccGithubRepositoryExpectedAttributes struct {
 	Description         string
 	Homepage            string
 	Private             bool
+	Visibility          string
 	HasDownloads        bool
 	HasIssues           bool
 	HasProjects         bool
@@ -593,6 +605,9 @@ func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testA
 		}
 		if private := repo.GetPrivate(); private != want.Private {
 			return fmt.Errorf("got private %#v; want %#v", private, want.Private)
+		}
+		if visibility := repo.GetVisibility(); visibility != want.Visibility {
+			return fmt.Errorf("got visibility %#v; want %#v", visibility, want.Visibility)
 		}
 		if hasIssues := repo.GetHasIssues(); hasIssues != want.HasIssues {
 			return fmt.Errorf("got has issues %#v; want %#v", hasIssues, want.HasIssues)
@@ -757,7 +772,8 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  private    = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -789,7 +805,8 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  private    = false
+  visibility = "public"
 
   has_issues         = false
   has_wiki           = false
@@ -811,7 +828,8 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  private    = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -833,7 +851,8 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  private    = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -856,7 +875,8 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  private    = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -879,7 +899,8 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  private    = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -912,7 +933,8 @@ resource "github_repository" "foo" {
 
 	# So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  private    = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -934,7 +956,8 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  private    = false
+  visibility = "public"
 
   topics = [%s]
 }

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -33,6 +33,8 @@ The following arguments are supported:
 
 * `private` - Whether the repository is private.
 
+* `visibility` - Whether the repository is public, private or internal.
+
 * `has_issues` - Whether the repository has GitHub Issues enabled.
 
 * `has_projects` - Whether the repository has the GitHub Projects enabled.

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -41,6 +41,10 @@ The following arguments are supported:
 
 * `private` - (Optional) Set to `true` to create a private repository.
   Repositories are created as public (e.g. open source) by default.
+  
+* `visibility` - (Optional) Can be `public` or `private`. If your organization is associated with an enterprise account 
+using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be `internal`. The `visibility` 
+parameter overrides the `private` parameter.
 
 * `has_issues` - (Optional) Set to `true` to enable the GitHub Issues features
   on the repository.


### PR DESCRIPTION
Adds the additional visibility parameter allowing for enterprise
accounts to set the repository to be only internally visible.

**NOTE: This is dependant on #424 and should be rebased on master once this has been merged.**