### PR TITLE
Fix github_repository_file import documentation

### DIFF
--- a/website/docs/r/repository_file.html.markdown
+++ b/website/docs/r/repository_file.html.markdown
@@ -54,11 +54,11 @@ The following additional attributes are exported:
 Repository files can be imported using a combination of the `repo` and `file`, e.g.
 
 ```
-$ terraform import github_repository.gitignore example/.gitignore
+$ terraform import github_repository_file.gitignore example/.gitignore
 ```
 
 To import a file from a branch other than master, append `:` and the branch name, e.g.
 
 ```
-$ terraform import github_repository.gitignore example/.gitignore:dev
+$ terraform import github_repository_file.gitignore example/.gitignore:dev
 ```


### PR DESCRIPTION
Attach missing `_file` suffix

Without `_file` suffix, below error message is occurred.

```sh
$ terraform import github_repository.gitignore example/.gitignore 
Error: resource address "github_repository.gitignore" does not exist in the configuration.

Before importing this resource, please create its configuration in the root module. For example:

resource "github_repository" "gitignore" {
  # (resource arguments)
}
```

After fixing

```sh
$ terraform import github_repository_file.gitignore example/.gitignore
github_repository_file.gitignore: Importing from ID "example/.gitignore"...
github_repository_file.gitignore: Import prepared!
  Prepared github_repository_file for import
github_repository_file.gitignore: Refreshing state... [id=example/.gitignore]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```