### PR TITLE
Skip team_sync_mapping test for non-enterprise accounts

### DIFF
--- a/github/resource_github_team_sync_group_mapping_test.go
+++ b/github/resource_github_team_sync_group_mapping_test.go
@@ -46,6 +46,9 @@ func TestAccGithubTeamSyncGroupMapping_basic(t *testing.T) {
 }
 
 func TestAccGithubTeamSyncGroupMapping_disappears(t *testing.T) {
+	if isEnterprise != "true" {
+		t.Skip("Skipping because `ENTERPRISE_ACCOUNT` is not set or set to false")
+	}
 	teamName := acctest.RandomWithPrefix("tf-acc-test-%s")
 	rn := "github_team_sync_group_mapping.test_mapping"
 


### PR DESCRIPTION
* Prevents `TestAccGithubTeamSyncGroupMapping_disappears` from running by default when an enterprise cloud account is not in use, resulting in test failure with `403 This team is not externally managed`