### PR TITLE
only enable dismissal restrictions if users or teams provided

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -544,9 +544,13 @@ func expandRequiredPullRequestReviews(d *schema.ResourceData) (*github.PullReque
 			m := v.(map[string]interface{})
 
 			users := expandNestedSet(m, "dismissal_users")
-			drr.Users = &users
+			if len(users) > 0 {
+				drr.Users = &users
+			}
 			teams := expandNestedSet(m, "dismissal_teams")
-			drr.Teams = &teams
+			if len(teams) > 0 {
+				drr.Teams = &teams
+			}
 
 			rprr.DismissalRestrictionsRequest = drr
 			rprr.DismissStaleReviews = m["dismiss_stale_reviews"].(bool)

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -221,8 +221,7 @@ func TestAccGithubBranchProtection_emptyItems(t *testing.T) {
 func TestAccGithubBranchProtection_emptyDismissalRestrictions(t *testing.T) {
 	var protection github.Protection
 	rn := "github_branch_protection.master"
-	rString := acctest.RandString(5)
-	repoName := fmt.Sprintf("tf-acc-test-branch-prot-%s", rString)
+	repoName := acctest.RandomWithPrefix("tf-acc-test-branch-prot-")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -240,6 +239,11 @@ func TestAccGithubBranchProtection_emptyDismissalRestrictions(t *testing.T) {
 					resource.TestCheckResourceAttr(rn, "required_pull_request_reviews.0.dismissal_users.#", "0"),
 					resource.TestCheckResourceAttr(rn, "required_pull_request_reviews.0.dismissal_teams.#", "0"),
 				),
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -234,8 +234,11 @@ func TestAccGithubBranchProtection_emptyDismissalRestrictions(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubProtectedBranchExists("github_branch_protection.master", repoName+":master", &protection),
 					testAccCheckGithubBranchProtectionPullRequestReviews(&protection, true, []string{}, []string{}, true),
-					resource.TestCheckResourceAttr(rn, "dismissal_restrictions_users.%", "0"),
-					resource.TestCheckResourceAttr(rn, "dismissal_restrictions_teams.%", "0"),
+					resource.TestCheckResourceAttr(rn, "required_pull_request_reviews.#", "1"),
+					resource.TestCheckResourceAttr(rn, "required_pull_request_reviews.0.dismiss_stale_reviews", "true"),
+					resource.TestCheckResourceAttr(rn, "required_pull_request_reviews.0.require_code_owner_reviews", "true"),
+					resource.TestCheckResourceAttr(rn, "required_pull_request_reviews.0.dismissal_users.#", "0"),
+					resource.TestCheckResourceAttr(rn, "required_pull_request_reviews.0.dismissal_teams.#", "0"),
 				),
 			},
 		},
@@ -411,28 +414,6 @@ func testAccGithubBranchProtectionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccGithubBranchProtectionEmptyDismissalsConfig(repoName string) string {
-	return fmt.Sprintf(`
-
-resource "github_repository" "test" {
-	name        = "%s"
-	description = "Terraform Acceptance Test %s"
-	auto_init   = true
-}
-
-resource "github_branch_protection" "master" {
-	repository     = "${github_repository.test.name}"
-	branch         = "master"
-	enforce_admins = true
-
-	required_pull_request_reviews {
-		dismiss_stale_reviews = true
-		require_code_owner_reviews = true
-	}
-}
-`, repoName, repoName)
-}
-
 func testAccGithubBranchProtectionConfig(repoName string) string {
 	return fmt.Sprintf(`
 resource "github_repository" "test" {
@@ -577,4 +558,26 @@ resource "github_branch_protection" "master" {
   }
 }
 `, repoName, repoName, user)
+}
+
+func testAccGithubBranchProtectionEmptyDismissalsConfig(repoName string) string {
+	return fmt.Sprintf(`
+
+resource "github_repository" "test" {
+	name        = "%s"
+	description = "Terraform Acceptance Test %s"
+	auto_init   = true
+}
+
+resource "github_branch_protection" "master" {
+	repository     = "${github_repository.test.name}"
+	branch         = "master"
+	enforce_admins = true
+
+	required_pull_request_reviews {
+		dismiss_stale_reviews = true
+		require_code_owner_reviews = true
+	}
+}
+`, repoName, repoName)
 }


### PR DESCRIPTION
* Relates to #267

Output of acceptance tests:
```
--- PASS: TestAccGithubBranchProtection_users (12.96s)
--- PASS: TestAccGithubBranchProtection_emptyDismissalRestrictions (19.08s)
--- PASS: TestAccGithubBranchProtection_emptyItems (19.16s)
--- PASS: TestAccGithubBranchProtection_basic (35.05s)
--- PASS: TestAccGithubBranchProtection_teams (56.88s)
```