### PR TITLE
Add visibility parameter to data source and resource

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -37,6 +37,10 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"visibility": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"has_issues": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -138,6 +142,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("description", repo.GetDescription())
 	d.Set("homepage_url", repo.GetHomepage())
 	d.Set("private", repo.GetPrivate())
+	d.Set("visibility", repo.GetVisibility())
 	d.Set("has_issues", repo.GetHasIssues())
 	d.Set("has_wiki", repo.GetHasWiki())
 	d.Set("allow_merge_commit", repo.GetAllowMergeCommit())

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -81,6 +81,7 @@ func testRepoCheck() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr("data.github_repository.test", "id", "test-repo"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "name", "test-repo"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "private", "false"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "visibility", "public"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "description", "Test description, used in GitHub Terraform provider acceptance test."),
 		resource.TestCheckResourceAttr("data.github_repository.test", "homepage_url", "http://www.example.com"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "has_issues", "true"),

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -41,8 +41,17 @@ func resourceGithubRepository() *schema.Resource {
 				Optional: true,
 			},
 			"private": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:          schema.TypeBool,
+				Computed:      true, // is affected by "visibility"
+				Optional:      true,
+				ConflictsWith: []string{"visibility"},
+				Deprecated:    "use visibility instead",
+			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true, // is affected by "private"
+				ValidateFunc: validation.StringInSlice([]string{"public", "private", "internal"}, false),
 			},
 			"has_issues": {
 				Type:     schema.TypeBool,
@@ -178,6 +187,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 		Description:         github.String(d.Get("description").(string)),
 		Homepage:            github.String(d.Get("homepage_url").(string)),
 		Private:             github.Bool(d.Get("private").(bool)),
+		Visibility:          github.String(d.Get("visibility").(string)),
 		HasDownloads:        github.Bool(d.Get("has_downloads").(bool)),
 		HasIssues:           github.Bool(d.Get("has_issues").(bool)),
 		HasProjects:         github.Bool(d.Get("has_projects").(bool)),
@@ -204,6 +214,12 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 
 	repoReq := resourceGithubRepositoryObject(d)
 	owner := meta.(*Owner).name
+
+	// Auth issues (403 You need admin access to the organization before adding a repository to it.)
+	// are encountered when the resources is created with the visibility parameter. As
+	// resourceGithubRepositoryUpdate is called immediately after, this is subsequently corrected.
+	repoReq.Visibility = nil
+
 	repoName := repoReq.GetName()
 	ctx := context.Background()
 
@@ -300,6 +316,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("description", repo.GetDescription())
 	d.Set("homepage_url", repo.GetHomepage())
 	d.Set("private", repo.GetPrivate())
+	d.Set("visibility", repo.GetVisibility())
 	d.Set("has_issues", repo.GetHasIssues())
 	d.Set("has_projects", repo.GetHasProjects())
 	d.Set("has_wiki", repo.GetHasWiki())
@@ -338,6 +355,12 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 	client := meta.(*Owner).v3client
 
 	repoReq := resourceGithubRepositoryObject(d)
+
+	// The endpoint will throw an error if trying to PATCH with a visibility value that is the same
+	if !d.HasChange("visibility") {
+		repoReq.Visibility = nil
+	}
+
 	// Can only set `default_branch` on an already created repository with the target branches ref already in-place
 	if v, ok := d.GetOk("default_branch"); ok {
 		branch := v.(string)

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -82,6 +82,7 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						HasProjects:         false,
 						DefaultBranch:       "master",
 						Archived:            false,
+						Visibility:          "public",
 					}),
 				),
 			},
@@ -100,6 +101,7 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						DefaultBranch:    "master",
 						HasProjects:      false,
 						Archived:         false,
+						Visibility:       "public",
 					}),
 				),
 			},
@@ -144,6 +146,7 @@ func TestAccGithubRepository_archive(t *testing.T) {
 						HasDownloads:     true,
 						DefaultBranch:    "master",
 						Archived:         true,
+						Visibility:       "public",
 					}),
 				),
 			},
@@ -188,6 +191,7 @@ func TestAccGithubRepository_archiveUpdate(t *testing.T) {
 						HasDownloads:     true,
 						DefaultBranch:    "master",
 						Archived:         false,
+						Visibility:       "public",
 					}),
 				),
 			},
@@ -207,6 +211,7 @@ func TestAccGithubRepository_archiveUpdate(t *testing.T) {
 						HasDownloads:     true,
 						DefaultBranch:    "master",
 						Archived:         true,
+						Visibility:       "public",
 					}),
 				),
 			},
@@ -273,6 +278,7 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 						HasDownloads:     true,
 						DefaultBranch:    "master",
 						Archived:         false,
+						Visibility:       "public",
 					}),
 				),
 			},
@@ -298,6 +304,7 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 						HasDownloads:     true,
 						DefaultBranch:    "foo",
 						Archived:         false,
+						Visibility:       "public",
 					}),
 				),
 			},
@@ -345,6 +352,7 @@ func TestAccGithubRepository_templates(t *testing.T) {
 						LicenseTemplate:   "ms-pl",
 						GitignoreTemplate: "C++",
 						Archived:          false,
+						Visibility:        "public",
 					}),
 				),
 			},
@@ -397,6 +405,7 @@ func TestAccGithubRepository_topics(t *testing.T) {
 
 						// non-zero defaults
 						DefaultBranch:    "master",
+						Visibility:       "public",
 						AllowMergeCommit: true,
 						AllowSquashMerge: true,
 						AllowRebaseMerge: true,
@@ -415,6 +424,7 @@ func TestAccGithubRepository_topics(t *testing.T) {
 
 						// non-zero defaults
 						DefaultBranch:    "master",
+						Visibility:       "public",
 						AllowMergeCommit: true,
 						AllowSquashMerge: true,
 						AllowRebaseMerge: true,
@@ -433,6 +443,7 @@ func TestAccGithubRepository_topics(t *testing.T) {
 
 						// non-zero defaults
 						DefaultBranch:    "master",
+						Visibility:       "public",
 						AllowMergeCommit: true,
 						AllowSquashMerge: true,
 						AllowRebaseMerge: true,
@@ -520,6 +531,7 @@ type testAccGithubRepositoryExpectedAttributes struct {
 	Description         string
 	Homepage            string
 	Private             bool
+	Visibility          string
 	HasDownloads        bool
 	HasIssues           bool
 	HasProjects         bool
@@ -551,6 +563,9 @@ func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testA
 		}
 		if private := repo.GetPrivate(); private != want.Private {
 			return fmt.Errorf("got private %#v; want %#v", private, want.Private)
+		}
+		if visibility := repo.GetVisibility(); visibility != want.Visibility {
+			return fmt.Errorf("got visibility %#v; want %#v", visibility, want.Visibility)
 		}
 		if hasIssues := repo.GetHasIssues(); hasIssues != want.HasIssues {
 			return fmt.Errorf("got has issues %#v; want %#v", hasIssues, want.HasIssues)
@@ -714,7 +729,7 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -746,7 +761,7 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  visibility = "public"
 
   has_issues         = false
   has_wiki           = false
@@ -768,7 +783,7 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -790,7 +805,7 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -813,7 +828,7 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -836,7 +851,7 @@ resource "github_repository" "foo" {
 
   # So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true
@@ -867,7 +882,7 @@ resource "github_repository" "foo" {
 
 	# So that acceptance tests can be run in a github organization
   # with no billing
-  private = false
+  visibility = "public"
 
   has_issues         = true
   has_wiki           = true

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -33,6 +33,8 @@ The following arguments are supported:
 
 * `private` - Whether the repository is private.
 
+* `visibility` - Whether the repository is public, private or internal.
+
 * `has_issues` - Whether the repository has GitHub Issues enabled.
 
 * `has_projects` - Whether the repository has the GitHub Projects enabled.

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 * `private` - (Optional) Set to `true` to create a private repository.
   Repositories are created as public (e.g. open source) by default.
+  
+* `visibility` - (Optional) Can be `public` or `private`. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be `internal`. The `visibility` parameter overrides the `private` parameter.
 
 * `has_issues` - (Optional) Set to `true` to enable the GitHub Issues features
   on the repository.


### PR DESCRIPTION
Adds the additional visibility parameter allowing for enterprise
accounts to set the repository to be only internally visible.

Fixes issues within #441 
* Removes default being set
* Removes inclusion of the parameter within unit tests as it will have a nil value

Resolves #304 