### PR TITLE
Support "maintain" and "triage" for repository collaborators

### DIFF
--- a/github/util_permissions.go
+++ b/github/util_permissions.go
@@ -48,6 +48,10 @@ func getInvitationPermission(i *github.RepositoryInvitation) (string, error) {
 		return pushPermission, nil
 	} else if *i.Permissions == adminPermission {
 		return adminPermission, nil
+	} else if *i.Permissions == maintainPermission {
+		return maintainPermission, nil
+	} else if *i.Permissions == triagePermission {
+		return triagePermission, nil
 	}
 
 	return "", fmt.Errorf("unexpected permission value: %v", *i.Permissions)

--- a/website/docs/r/repository_collaborator.html.markdown
+++ b/website/docs/r/repository_collaborator.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `repository` - (Required) The GitHub repository
 * `username` - (Required) The user to add to the repository as a collaborator.
 * `permission` - (Optional) The permission of the outside collaborator for the repository.
-            Must be one of `pull`, `push`, or `admin`. Defaults to `push`.
+            Must be one of `pull`, `push`, `maintain`, `triage` or `admin`. Defaults to `push`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
This follows on from the work done by @romaninsh in #421 and adds the test coverage suggested by @anGie44. 

More info: #303 (comment)

Output from Acceptance Tests:
```
--- PASS: TestAccGithubRepositoryCollaborator_caseInsensitive (16.45s)
--- PASS: TestAccGithubRepositoryCollaborator_basic (31.27s)
```