### PR TITLE
github/provider: introduce owner  

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           RUN_FILTER: ${{ env.RUN_FILTER }}
           GITHUB_BASE_URL: "https://api.github.com/"
-          GITHUB_ORGANIZATION: terraformtesting
+          GITHUB_OWNER: terraformtesting
           GITHUB_TEST_USER: github-terraform-test-user
           GITHUB_TEST_USER_NAME: "Test User"
           GITHUB_TEST_USER_EMAIL: 60107403+github-terraform-test-user@users.noreply.github.com

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Once the token has been created, it must be exported in your environment as `GIT
 
 ### GitHub organization
 If you do not have an organization already that you are comfortable running tests against, you will need to [create one](https://help.github.com/en/articles/creating-a-new-organization-from-scratch). The free "Team for Open Source" org type is fine for these tests. The name of the
-organization must then be exported in your environment as `GITHUB_ORGANIZATION`. If you are interested in using and/or testing Github's [Team synchronization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/synchronizing-teams-between-your-identity-provider-and-github) feature, you will need to have an organization that uses Github Enterprise Cloud in addition to the requirements defined in the Github docs and set the environment variable `ENTERPRISE_ACCOUNT` to `true`. 
+organization must then be exported in your environment as `GITHUB_OWNER`. If you are interested in using and/or testing Github's [Team synchronization](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/synchronizing-teams-between-your-identity-provider-and-github) feature, you will need to have an organization that uses Github Enterprise Cloud in addition to the requirements defined in the Github docs and set the environment variable `ENTERPRISE_ACCOUNT` to `true`. 
 
 ### Test repositories
 In the organization you are using above, create the following test repositories:

--- a/github/config.go
+++ b/github/config.go
@@ -69,7 +69,14 @@ func (c *Config) Clients() (interface{}, error) {
 	owner.v4client = v4client
 
 	owner.name = c.Owner
-	if owner.name != "" {
+	if owner.name == "" {
+		// Discover authenticated user
+		user, _, err := owner.v3client.Users.Get(ctx, "")
+		if err != nil {
+			return nil, err
+		}
+		owner.name = user.GetLogin()
+	} else {
 		remoteOrg, _, err := owner.v3client.Organizations.Get(ctx, owner.name)
 		if err == nil {
 			if remoteOrg != nil {

--- a/github/data_source_github_actions_public_key.go
+++ b/github/data_source_github_actions_public_key.go
@@ -35,10 +35,10 @@ func dataSourceGithubActionsPublicKeyRead(d *schema.ResourceData, meta interface
 	}
 
 	repository := d.Get("repository").(string)
-	owner := meta.(*Organization).name
+	owner := meta.(*Owner).name
 	log.Printf("[INFO] Refreshing GitHub Actions Public Key from: %s/%s", owner, repository)
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	ctx := context.Background()
 
 	publicKey, _, err := client.Actions.GetPublicKey(ctx, owner, repository)

--- a/github/data_source_github_actions_public_key_test.go
+++ b/github/data_source_github_actions_public_key_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccGithubActionsPublicKeyDataSource_noMatchReturnsError(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	repo := "non-existent"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -26,6 +30,10 @@ func TestAccGithubActionsPublicKeyDataSource_noMatchReturnsError(t *testing.T) {
 }
 
 func TestAccCheckGithubActionsPublicKeyDataSource_existing(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/github/data_source_github_branch.go
+++ b/github/data_source_github_branch.go
@@ -45,8 +45,8 @@ func dataSourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	branchName := d.Get("branch").(string)
 	branchRefName := "refs/heads/" + branchName

--- a/github/data_source_github_branch_test.go
+++ b/github/data_source_github_branch_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestAccGithubBranchDataSource_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
 
 	var (
 		name = "main"

--- a/github/data_source_github_collaborators.go
+++ b/github/data_source_github_collaborators.go
@@ -110,7 +110,7 @@ func dataSourceGithubCollaborators() *schema.Resource {
 
 func dataSourceGithubCollaboratorsRead(d *schema.ResourceData, meta interface{}) error {
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	ctx := context.Background()
 
 	owner := d.Get("owner").(string)

--- a/github/data_source_github_collaborators_test.go
+++ b/github/data_source_github_collaborators_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccGithubCollaboratorsDataSource_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	dsn := "data.github_collaborators.test"
 	repoName := fmt.Sprintf("tf-acc-test-collab-%s", acctest.RandString(5))
 
@@ -39,5 +43,5 @@ data "github_collaborators" "test" {
   owner      = "%s"
   repository = "${github_repository.test.name}"
 }
-`, repo, testOrganization)
+`, repo, testOwner)
 }

--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -34,9 +34,9 @@ func dataSourceGithubIpRanges() *schema.Resource {
 }
 
 func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta interface{}) error {
-	owner := meta.(*Owner)
+	org := meta.(*Owner)
 
-	api, _, err := owner.v3client.APIMeta(owner.StopContext)
+	api, _, err := org.v3client.APIMeta(org.StopContext)
 	if err != nil {
 		return err
 	}

--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -34,9 +34,9 @@ func dataSourceGithubIpRanges() *schema.Resource {
 }
 
 func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta interface{}) error {
-	org := meta.(*Organization)
+	owner := meta.(*Owner)
 
-	api, _, err := org.v3client.APIMeta(org.StopContext)
+	api, _, err := owner.v3client.APIMeta(owner.StopContext)
 	if err != nil {
 		return err
 	}

--- a/github/data_source_github_membership.go
+++ b/github/data_source_github_membership.go
@@ -32,8 +32,8 @@ func dataSourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) er
 	username := d.Get("username").(string)
 	log.Printf("[INFO] Refreshing GitHub membership: %s", username)
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 
 	ctx := context.Background()
 

--- a/github/data_source_github_membership_test.go
+++ b/github/data_source_github_membership_test.go
@@ -28,6 +28,10 @@ func TestAccGithubMembershipDataSource_existing(t *testing.T) {
 	if testUser == "" {
 		t.Skip("This test requires you to set the test user (set it by exporting GITHUB_TEST_USER)")
 	}
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/github/data_source_github_organization_team_sync_groups.go
+++ b/github/data_source_github_organization_team_sync_groups.go
@@ -41,10 +41,10 @@ func dataSourceGithubOrganizationTeamSyncGroups() *schema.Resource {
 func dataSourceGithubOrganizationTeamSyncGroupsRead(d *schema.ResourceData, meta interface{}) error {
 	log.Print("[INFO] Refreshing GitHub Organization Team-Sync Groups")
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	ctx := context.Background()
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	options := &github.ListCursorOptions{PerPage: maxPerPage}
 
 	groups := make([]interface{}, 0)

--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -102,7 +102,7 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 	repository := d.Get("repository").(string)
 	owner := d.Get("owner").(string)
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	ctx := context.Background()
 
 	var err error

--- a/github/data_source_github_release_test.go
+++ b/github/data_source_github_release_test.go
@@ -29,6 +29,10 @@ func TestAccGithubReleaseDataSource_fetchByLatestNoReleaseReturnsError(t *testin
 }
 
 func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
 	owner := os.Getenv("GITHUB_ORGANIZATION")
 	retrieveBy := "latest"
@@ -68,6 +72,10 @@ func TestAccGithubReleaseDataSource_fetchByIdWithNoIdReturnsError(t *testing.T) 
 }
 
 func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
 	owner := os.Getenv("GITHUB_ORGANIZATION")
 	retrieveBy := "id"
@@ -112,6 +120,10 @@ func TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError(t *testing.T) {
 }
 
 func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
 	owner := os.Getenv("GITHUB_ORGANIZATION")
 	retrieveBy := "tag"

--- a/github/data_source_github_release_test.go
+++ b/github/data_source_github_release_test.go
@@ -34,7 +34,7 @@ func TestAccGithubReleaseDataSource_latestExisting(t *testing.T) {
 	}
 
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
-	owner := os.Getenv("GITHUB_ORGANIZATION")
+	owner := os.Getenv("GITHUB_OWNER")
 	retrieveBy := "latest"
 	expectedUrl := regexp.MustCompile(fmt.Sprintf("%s/%s", owner, repo))
 	expectedTarball := regexp.MustCompile(fmt.Sprintf("%s/%s/tarball", owner, repo))
@@ -77,7 +77,7 @@ func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
 	}
 
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
-	owner := os.Getenv("GITHUB_ORGANIZATION")
+	owner := os.Getenv("GITHUB_OWNER")
 	retrieveBy := "id"
 	expectedUrl := regexp.MustCompile(fmt.Sprintf("%s/%s", owner, repo))
 	expectedTarball := regexp.MustCompile(fmt.Sprintf("%s/%s/tarball", owner, repo))
@@ -102,7 +102,7 @@ func TestAccGithubReleaseDataSource_fetchByIdExisting(t *testing.T) {
 
 func TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError(t *testing.T) {
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
-	owner := os.Getenv("GITHUB_ORGANIZATION")
+	owner := os.Getenv("GITHUB_OWNER")
 	retrieveBy := "tag"
 	id := int64(0)
 	resource.ParallelTest(t, resource.TestCase{
@@ -125,7 +125,7 @@ func TestAccGithubReleaseDataSource_fetchByTagExisting(t *testing.T) {
 	}
 
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
-	owner := os.Getenv("GITHUB_ORGANIZATION")
+	owner := os.Getenv("GITHUB_OWNER")
 	retrieveBy := "tag"
 	tag := "v1.0"
 	expectedUrl := regexp.MustCompile(fmt.Sprintf("%s/%s", owner, repo))

--- a/github/data_source_github_repositories.go
+++ b/github/data_source_github_repositories.go
@@ -48,7 +48,7 @@ func dataSourceGithubRepositoriesRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	query := d.Get("query").(string)
 	opt := &github.SearchOptions{

--- a/github/data_source_github_repositories_test.go
+++ b/github/data_source_github_repositories_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccGithubRepositoriesDataSource_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	query := "org:hashicorp repository:terraform"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -28,6 +32,10 @@ func TestAccGithubRepositoriesDataSource_basic(t *testing.T) {
 	})
 }
 func TestAccGithubRepositoriesDataSource_Sort(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -55,6 +63,10 @@ func TestAccGithubRepositoriesDataSource_Sort(t *testing.T) {
 }
 
 func TestAccGithubRepositoriesDataSource_noMatch(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	query := "klsafj_23434_doesnt_exist"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -112,8 +112,8 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	var repoName string
 
 	if fullName, ok := d.GetOk("full_name"); ok {

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccGithubRepositoryDataSource_fullName_noMatchReturnsError(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	fullName := "klsafj_23434_doesnt_exist/not-exists"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -25,6 +29,10 @@ func TestAccGithubRepositoryDataSource_fullName_noMatchReturnsError(t *testing.T
 }
 
 func TestAccGithubRepositoryDataSource_name_noMatchReturnsError(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	name := "not-exists"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -41,7 +49,11 @@ func TestAccGithubRepositoryDataSource_name_noMatchReturnsError(t *testing.T) {
 }
 
 func TestAccGithubRepositoryDataSource_fullName_existing(t *testing.T) {
-	fullName := testOrganization + "/test-repo"
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
+	fullName := testOwner + "/test-repo"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -57,6 +69,10 @@ func TestAccGithubRepositoryDataSource_fullName_existing(t *testing.T) {
 }
 
 func TestAccGithubRepositoryDataSource_name_existing(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	name := "test-repo"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -85,13 +101,13 @@ func testRepoCheck() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr("data.github_repository.test", "allow_squash_merge", "true"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "allow_rebase_merge", "true"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "has_downloads", "true"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "full_name", testOrganization+"/test-repo"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "full_name", testOwner+"/test-repo"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "default_branch", "master"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "html_url", "https://github.com/"+testOrganization+"/test-repo"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "ssh_clone_url", "git@github.com:"+testOrganization+"/test-repo.git"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "svn_url", "https://github.com/"+testOrganization+"/test-repo"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "git_clone_url", "git://github.com/"+testOrganization+"/test-repo.git"),
-		resource.TestCheckResourceAttr("data.github_repository.test", "http_clone_url", "https://github.com/"+testOrganization+"/test-repo.git"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "html_url", "https://github.com/"+testOwner+"/test-repo"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "ssh_clone_url", "git@github.com:"+testOwner+"/test-repo.git"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "svn_url", "https://github.com/"+testOwner+"/test-repo"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "git_clone_url", "git://github.com/"+testOwner+"/test-repo.git"),
+		resource.TestCheckResourceAttr("data.github_repository.test", "http_clone_url", "https://github.com/"+testOwner+"/test-repo.git"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "archived", "false"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "topics.#", "2"),
 		resource.TestCheckResourceAttr("data.github_repository.test", "topics.0", "second-test-topic"),

--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -52,11 +52,11 @@ func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	slug := d.Get("slug").(string)
 	log.Printf("[INFO] Refreshing GitHub Team: %s", slug)
 
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 	ctx := context.Background()
 
-	team, err := getGithubTeamBySlug(ctx, client, meta.(*Organization).name, slug)
+	team, err := getGithubTeamBySlug(ctx, client, meta.(*Owner).name, slug)
 	if err != nil {
 		return err
 	}

--- a/github/data_source_github_team_test.go
+++ b/github/data_source_github_team_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccGithubTeamDataSource_noMatchReturnsError(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	slug := "non-existing"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/github/data_source_github_user.go
+++ b/github/data_source_github_user.go
@@ -103,7 +103,7 @@ func dataSourceGithubUserRead(d *schema.ResourceData, meta interface{}) error {
 	username := d.Get("username").(string)
 	log.Printf("[INFO] Refreshing GitHub User: %s", username)
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	ctx := context.Background()
 
 	user, _, err := client.Users.Get(ctx, username)

--- a/github/provider.go
+++ b/github/provider.go
@@ -89,7 +89,7 @@ func init() {
 
 		"owner": "The GitHub owner name to manage.",
 
-		"organization": "The GitHub owner name to manage.",
+		"organization": "(Deprecated) The GitHub organization name to manage.",
 
 		"base_url": "The GitHub Base API URL",
 	}

--- a/github/resource_github_actions_secret.go
+++ b/github/resource_github_actions_secret.go
@@ -51,8 +51,8 @@ func resourceGithubActionsSecretCreateOrUpdate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	owner := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
 	ctx := context.Background()
 
 	repo := d.Get("repository").(string)
@@ -91,8 +91,8 @@ func resourceGithubActionsSecretRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	owner := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
 	ctx := context.Background()
 
 	repoName, secretName, err := parseTwoPartID(d.Id(), "repository", "secret_name")
@@ -126,8 +126,8 @@ func resourceGithubActionsSecretDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	repoName, secretName, err := parseTwoPartID(d.Id(), "repository", "secret_name")
@@ -142,7 +142,7 @@ func resourceGithubActionsSecretDelete(d *schema.ResourceData, meta interface{})
 }
 
 func getPublicKeyDetails(owner, repository string, meta interface{}) (keyId, pkValue string, err error) {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	ctx := context.Background()
 
 	publicKey, _, err := client.Actions.GetPublicKey(ctx, owner, repository)

--- a/github/resource_github_actions_secret_test.go
+++ b/github/resource_github_actions_secret_test.go
@@ -122,8 +122,8 @@ func testAccCheckGithubActionsSecretDisappears(resourceName string) resource.Tes
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
-		conn := testAccProvider.Meta().(*Organization).v3client
-		owner := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		owner := testAccProvider.Meta().(*Owner).name
 		repoName, secretName, err := parseTwoPartID(rs.Primary.ID, "repository", "secret_name")
 		if err != nil {
 			return err

--- a/github/resource_github_actions_secret_test.go
+++ b/github/resource_github_actions_secret_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestAccGithubActionsSecret_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	repo := acctest.RandomWithPrefix("tf-acc-test")
 
 	secretResourceName := "github_actions_secret.test_secret"
@@ -100,7 +104,7 @@ func testAccCheckGithubActionsSecretExists(resourceName, secretName string, t *t
 			return fmt.Errorf("no repo name is set")
 		}
 
-		org := testAccProvider.Meta().(*Organization)
+		org := testAccProvider.Meta().(*Owner)
 		conn := org.v3client
 		_, _, err := conn.Actions.GetSecret(context.TODO(), org.name, repoName, secretName)
 		if err != nil {
@@ -130,13 +134,13 @@ func testAccCheckGithubActionsSecretDisappears(resourceName string) resource.Tes
 }
 
 func testAccCheckGithubActionsSecretDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*Organization).v3client
+	client := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_actions_secret" {
 			continue
 		}
-		owner := testAccProvider.Meta().(*Organization).name
+		owner := testAccProvider.Meta().(*Owner).name
 		repoName := rs.Primary.Attributes["repository"]
 		secretName := rs.Primary.Attributes["secret_name"]
 

--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -70,8 +70,8 @@ func resourceGithubBranchCreate(d *schema.ResourceData, meta interface{}) error 
 		ctx = context.WithValue(ctx, ctxId, d.Id())
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	branchName := d.Get("branch").(string)
 	branchRefName := "refs/heads/" + branchName
@@ -117,8 +117,8 @@ func resourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error {
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	repoName, branchName, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
@@ -162,8 +162,8 @@ func resourceGithubBranchDelete(d *schema.ResourceData, meta interface{}) error 
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	repoName, branchName, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -155,9 +155,9 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	branch := d.Get("branch").(string)
 
@@ -198,13 +198,13 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
 	}
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {
@@ -264,7 +264,7 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
@@ -275,7 +275,7 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	log.Printf("[DEBUG] Updating branch protection: %s/%s (%s)",
@@ -320,13 +320,13 @@ func resourceGithubBranchProtectionDelete(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
 	}
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	log.Printf("[DEBUG] Deleting branch protection: %s/%s (%s)", orgName, repoName, branch)
@@ -381,13 +381,13 @@ func flattenAndSetRequiredStatusChecks(d *schema.ResourceData, protection *githu
 }
 
 func requireSignedCommitsRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
 	}
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {
@@ -407,13 +407,13 @@ func requireSignedCommitsRead(d *schema.ResourceData, meta interface{}) error {
 
 func requireSignedCommitsUpdate(d *schema.ResourceData, meta interface{}) (err error) {
 	requiredSignedCommit := d.Get("require_signed_commits").(bool)
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
 	if err != nil {
 		return err
 	}
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestAccGithubBranchProtection_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var protection github.Protection
 
 	rn := "github_branch_protection.master"
@@ -73,6 +77,10 @@ func TestAccGithubBranchProtection_basic(t *testing.T) {
 }
 
 func TestAccGithubBranchProtection_users(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	rn := "github_branch_protection.master"
 	rString := acctest.RandString(5)
 	repoName := fmt.Sprintf("tf-acc-test-branch-prot-%s", rString)
@@ -105,6 +113,10 @@ func TestAccGithubBranchProtection_users(t *testing.T) {
 }
 
 func TestAccGithubBranchProtection_teams(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var firstP, secondP, thirdP github.Protection
 
 	rn := "github_branch_protection.master"
@@ -185,6 +197,10 @@ func TestAccGithubBranchProtection_teams(t *testing.T) {
 
 // See https://github.com/terraform-providers/terraform-provider-github/issues/8
 func TestAccGithubBranchProtection_emptyItems(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var protection github.Protection
 
 	rn := "github_branch_protection.master"
@@ -219,6 +235,10 @@ func TestAccGithubBranchProtection_emptyItems(t *testing.T) {
 }
 
 func TestAccGithubBranchProtection_emptyDismissalRestrictions(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var protection github.Protection
 	rn := "github_branch_protection.master"
 	repoName := acctest.RandomWithPrefix("tf-acc-test-branch-prot-")
@@ -260,8 +280,8 @@ func testAccCheckGithubProtectedBranchExists(n, id string, protection *github.Pr
 			return fmt.Errorf("Expected ID to be %v, got %v", id, rs.Primary.ID)
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		o := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		o := testAccProvider.Meta().(*Owner).name
 		r, b, err := parseTwoPartID(rs.Primary.ID, "repository", "branch")
 		if err != nil {
 			return err
@@ -390,14 +410,14 @@ func testAccCheckGithubBranchProtectionNoPullRequestReviewsExist(protection *git
 }
 
 func testAccGithubBranchProtectionDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_branch_protection" {
 			continue
 		}
 
-		o := testAccProvider.Meta().(*Organization).name
+		o := testAccProvider.Meta().(*Owner).name
 		r, b, err := parseTwoPartID(rs.Primary.ID, "repository", "branch")
 		if err != nil {
 			return err

--- a/github/resource_github_branch_test.go
+++ b/github/resource_github_branch_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestAccGithubBranch_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
 
 	var (
 		reference github.Reference
@@ -68,6 +71,9 @@ func TestAccGithubBranch_basic(t *testing.T) {
 	})
 }
 func TestAccGithubBranch_withSourceBranch(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
 
 	var (
 		reference github.Reference
@@ -150,8 +156,8 @@ func testAccCheckGithubBranchDestroy(s *terraform.State) error {
 			continue
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgName := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgName := testAccProvider.Meta().(*Owner).name
 		repoName, branchName, err := parseTwoPartID(rs.Primary.ID, "repository", "branch")
 		if err != nil {
 			return err
@@ -184,8 +190,8 @@ func testAccCheckGithubBranchExists(n, id string, reference *github.Reference) r
 			return fmt.Errorf("Expected ID to be %v, got %v", id, rs.Primary.ID)
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgName := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgName := testAccProvider.Meta().(*Owner).name
 		repoName, branchName, err := parseTwoPartID(rs.Primary.ID, "repository", "branch")
 		if err != nil {
 			return err

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -65,8 +65,8 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	name := d.Get("name").(string)
 	color := d.Get("color").(string)
@@ -153,13 +153,13 @@ func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	repoName, name, err := parseTwoPartID(d.Id(), "repository", "name")
 	if err != nil {
 		return err
 	}
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
@@ -199,9 +199,9 @@ func resourceGithubIssueLabelDelete(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	name := d.Get("name").(string)
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())

--- a/github/resource_github_issue_label_test.go
+++ b/github/resource_github_issue_label_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestAccGithubIssueLabel_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var label, updatedLabel github.Label
 
 	rn := "github_issue_label.test"
@@ -48,6 +52,10 @@ func TestAccGithubIssueLabel_basic(t *testing.T) {
 }
 
 func TestAccGithubIssueLabel_existingLabel(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var label github.Label
 
 	rn := "github_issue_label.test"
@@ -76,6 +84,10 @@ func TestAccGithubIssueLabel_existingLabel(t *testing.T) {
 }
 
 func TestAccGithubIssueLabel_description(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var label github.Label
 
 	rn := "github_issue_label.test"
@@ -137,8 +149,8 @@ func testAccCheckGithubIssueLabelExists(n string, label *github.Label) resource.
 			return fmt.Errorf("No issue label ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgName := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgName := testAccProvider.Meta().(*Owner).name
 		repoName, name, err := parseTwoPartID(rs.Primary.ID, "repository", "name")
 		if err != nil {
 			return err
@@ -179,14 +191,14 @@ func testAccCheckGithubIssueLabelIDUnchanged(label, updatedLabel *github.Label) 
 }
 
 func testAccGithubIssueLabelDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_issue_label" {
 			continue
 		}
 
-		orgName := testAccProvider.Meta().(*Organization).name
+		orgName := testAccProvider.Meta().(*Owner).name
 		repoName, name, err := parseTwoPartID(rs.Primary.ID, "repository", "name")
 		if err != nil {
 			return err

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -46,9 +46,9 @@ func resourceGithubMembershipCreateOrUpdate(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	username := d.Get("username").(string)
 	roleName := d.Get("role").(string)
 	ctx := context.Background()
@@ -79,9 +79,9 @@ func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	_, username, err := parseTwoPartID(d.Id(), "organization", "username")
 	if err != nil {
 		return err
@@ -122,8 +122,8 @@ func resourceGithubMembershipDelete(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	log.Printf("[DEBUG] Deleting membership: %s", d.Id())

--- a/github/resource_github_membership_test.go
+++ b/github/resource_github_membership_test.go
@@ -15,9 +15,11 @@ func TestAccGithubMembership_basic(t *testing.T) {
 	if testCollaborator == "" {
 		t.Skip("Skipping because `GITHUB_TEST_COLLABORATOR` is not set")
 	}
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
 
 	var membership github.Membership
-
 	rn := "github_membership.test_org_membership"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -44,6 +46,9 @@ func TestAccGithubMembership_basic(t *testing.T) {
 func TestAccGithubMembership_caseInsensitive(t *testing.T) {
 	if testCollaborator == "" {
 		t.Skip("Skipping because `GITHUB_TEST_COLLABORATOR` is not set")
+	}
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
 	}
 
 	var membership github.Membership
@@ -84,7 +89,7 @@ func TestAccGithubMembership_caseInsensitive(t *testing.T) {
 }
 
 func testAccCheckGithubMembershipDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_membership" {
@@ -122,7 +127,7 @@ func testAccCheckGithubMembershipExists(n string, membership *github.Membership)
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
+		conn := testAccProvider.Meta().(*Owner).v3client
 		orgName, username, err := parseTwoPartID(rs.Primary.ID, "organization", "username")
 		if err != nil {
 			return err
@@ -148,7 +153,7 @@ func testAccCheckGithubMembershipRoleState(n string, membership *github.Membersh
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
+		conn := testAccProvider.Meta().(*Owner).v3client
 		orgName, username, err := parseTwoPartID(rs.Primary.ID, "organization", "username")
 		if err != nil {
 			return err

--- a/github/resource_github_organization_project.go
+++ b/github/resource_github_organization_project.go
@@ -48,8 +48,8 @@ func resourceGithubOrganizationProjectCreate(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	name := d.Get("name").(string)
 	body := d.Get("body").(string)
 	ctx := context.Background()
@@ -76,8 +76,8 @@ func resourceGithubOrganizationProjectRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 
 	projectID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -120,8 +120,8 @@ func resourceGithubOrganizationProjectUpdate(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 
 	name := d.Get("name").(string)
 	body := d.Get("body").(string)
@@ -151,8 +151,8 @@ func resourceGithubOrganizationProjectDelete(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	projectID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return err

--- a/github/resource_github_organization_project_test.go
+++ b/github/resource_github_organization_project_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestAccGithubOrganizationProject_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var project github.Project
 
 	rn := "github_organization_project.test"
@@ -42,7 +46,7 @@ func TestAccGithubOrganizationProject_basic(t *testing.T) {
 }
 
 func testAccGithubOrganizationProjectDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_organization_project" {
@@ -81,7 +85,7 @@ func testAccCheckGithubOrganizationProjectExists(n string, project *github.Proje
 			return err
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
+		conn := testAccProvider.Meta().(*Owner).v3client
 		gotProject, _, err := conn.Projects.GetProject(context.TODO(), projectID)
 		if err != nil {
 			return err

--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -78,9 +78,9 @@ func resourceGithubOrganizationWebhookCreate(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	webhookObj := resourceGithubOrganizationWebhookObject(d)
 	ctx := context.Background()
 
@@ -109,9 +109,9 @@ func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return unconvertibleIdErr(d.Id(), err)
@@ -166,9 +166,9 @@ func resourceGithubOrganizationWebhookUpdate(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	webhookObj := resourceGithubOrganizationWebhookObject(d)
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -193,9 +193,9 @@ func resourceGithubOrganizationWebhookDelete(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return unconvertibleIdErr(d.Id(), err)

--- a/github/resource_github_organization_webhook_test.go
+++ b/github/resource_github_organization_webhook_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestAccGithubOrganizationWebhook_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var hook github.Hook
 
 	rn := "github_organization_webhook.foo"
@@ -58,6 +62,9 @@ func TestAccGithubOrganizationWebhook_basic(t *testing.T) {
 }
 
 func TestAccGithubOrganizationWebhook_secret(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
 
 	rn := "github_organization_webhook.foo"
 
@@ -91,7 +98,7 @@ func testAccCheckGithubOrganizationWebhookExists(n string, hook *github.Hook) re
 			return fmt.Errorf("No repository name is set")
 		}
 
-		org := testAccProvider.Meta().(*Organization)
+		org := testAccProvider.Meta().(*Owner)
 		conn := org.v3client
 		getHook, _, err := conn.Organizations.GetHook(context.TODO(), org.name, hookID)
 		if err != nil {
@@ -144,8 +151,8 @@ func testAccCheckGithubOrganizationWebhookSecret(r, secret string) resource.Test
 }
 
 func testAccCheckGithubOrganizationWebhookDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
-	orgName := testAccProvider.Meta().(*Organization).name
+	conn := testAccProvider.Meta().(*Owner).v3client
+	orgName := testAccProvider.Meta().(*Owner).name
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_organization_webhook" {

--- a/github/resource_github_project_column.go
+++ b/github/resource_github_project_column.go
@@ -45,7 +45,7 @@ func resourceGithubProjectColumnCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	options := github.ProjectColumnOptions{
 		Name: d.Get("name").(string),
@@ -58,7 +58,7 @@ func resourceGithubProjectColumnCreate(d *schema.ResourceData, meta interface{})
 	}
 	ctx := context.Background()
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	log.Printf("[DEBUG] Creating project column (%s) in project %d (%s)", options.Name, projectID, orgName)
 	column, _, err := client.Projects.CreateProjectColumn(ctx,
 		projectID,
@@ -73,7 +73,7 @@ func resourceGithubProjectColumnCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceGithubProjectColumnRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	columnID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -106,7 +106,7 @@ func resourceGithubProjectColumnRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGithubProjectColumnUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	options := github.ProjectColumnOptions{
 		Name: d.Get("name").(string),
@@ -128,7 +128,7 @@ func resourceGithubProjectColumnUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceGithubProjectColumnDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	columnID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/github/resource_github_project_column_test.go
+++ b/github/resource_github_project_column_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestAccGithubProjectColumn_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var column github.ProjectColumn
 
 	rn := "github_project_column.column"
@@ -49,7 +53,7 @@ func TestAccGithubProjectColumn_basic(t *testing.T) {
 }
 
 func testAccGithubProjectColumnDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_project_column" {
@@ -87,7 +91,7 @@ func testAccCheckGithubProjectColumnExists(n string, project *github.ProjectColu
 			return err
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
+		conn := testAccProvider.Meta().(*Owner).v3client
 		gotColumn, _, err := conn.Projects.GetProjectColumn(context.TODO(), columnID)
 		if err != nil {
 			return err

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -201,14 +201,14 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	if branchName, hasDefaultBranch := d.GetOk("default_branch"); hasDefaultBranch && (branchName != "master") {
 		return fmt.Errorf("Cannot set the default branch on a new repository to something other than 'master'.")
 	}
 
 	repoReq := resourceGithubRepositoryObject(d)
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := repoReq.GetName()
 	ctx := context.Background()
 
@@ -270,8 +270,8 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	repoName := d.Id()
 
 	log.Printf("[DEBUG] Reading repository: %s/%s", orgName, repoName)
@@ -342,7 +342,7 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	repoReq := resourceGithubRepositoryObject(d)
 	// Can only set `default_branch` on an already created repository with the target branches ref already in-place
@@ -355,7 +355,7 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	repoName := d.Id()
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	log.Printf("[DEBUG] Updating repository: %s/%s", orgName, repoName)
@@ -382,9 +382,9 @@ func resourceGithubRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	repoName := d.Id()
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	log.Printf("[DEBUG] Deleting repository: %s/%s", orgName, repoName)

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -54,9 +54,9 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta int
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	username := d.Get("username").(string)
 	repoName := d.Get("repository").(string)
 	ctx := context.Background()
@@ -89,9 +89,9 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName, username, err := parseTwoPartID(d.Id(), "repository", "username")
 	if err != nil {
 		return err
@@ -177,9 +177,9 @@ func resourceGithubRepositoryCollaboratorDelete(d *schema.ResourceData, meta int
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	username := d.Get("username").(string)
 	repoName := d.Get("repository").(string)
 

--- a/github/resource_github_repository_collaborator_test.go
+++ b/github/resource_github_repository_collaborator_test.go
@@ -18,6 +18,9 @@ func TestAccGithubRepositoryCollaborator_basic(t *testing.T) {
 	if testCollaborator == "" {
 		t.Skip("Skipping because `GITHUB_TEST_COLLABORATOR` is not set")
 	}
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
 
 	rn := "github_repository_collaborator.test_repo_collaborator"
 	repoName := fmt.Sprintf("tf-acc-test-collab-%s", acctest.RandString(5))
@@ -81,6 +84,9 @@ func TestAccGithubRepositoryCollaborator_caseInsensitive(t *testing.T) {
 	if testCollaborator == "" {
 		t.Skip("Skipping because `GITHUB_TEST_COLLABORATOR` is not set")
 	}
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
 
 	rn := "github_repository_collaborator.test_repo_collaborator"
 	repoName := fmt.Sprintf("tf-acc-test-collab-%s", acctest.RandString(5))
@@ -125,14 +131,14 @@ func TestAccGithubRepositoryCollaborator_caseInsensitive(t *testing.T) {
 }
 
 func testAccCheckGithubRepositoryCollaboratorDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository_collaborator" {
 			continue
 		}
 
-		o := testAccProvider.Meta().(*Organization).name
+		o := testAccProvider.Meta().(*Owner).name
 		r, u, err := parseTwoPartID(rs.Primary.ID, "repository", "username")
 		if err != nil {
 			return err
@@ -165,8 +171,8 @@ func testAccCheckGithubRepositoryCollaboratorExists(n string) resource.TestCheck
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgName := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgName := testAccProvider.Meta().(*Owner).name
 		repoName, username, err := parseTwoPartID(rs.Primary.ID, "repository", "username")
 		if err != nil {
 			return err
@@ -205,8 +211,8 @@ func testAccCheckGithubRepositoryCollaboratorPermission(n, permission string) re
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgName := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgName := testAccProvider.Meta().(*Owner).name
 		repoName, username, err := parseTwoPartID(rs.Primary.ID, "repository", "username")
 		if err != nil {
 			return err
@@ -256,8 +262,8 @@ func testAccCheckGithubRepositoryCollaboratorInvited(repoName, username string, 
 	return func(s *terraform.State) error {
 		opt := &github.ListOptions{PerPage: maxPerPage}
 
-		client := testAccProvider.Meta().(*Organization).v3client
-		org := testAccProvider.Meta().(*Organization).name
+		client := testAccProvider.Meta().(*Owner).v3client
+		org := testAccProvider.Meta().(*Owner).name
 
 		for {
 			invitations, resp, err := client.Repositories.ListInvitations(context.TODO(), org, repoName, opt)

--- a/github/resource_github_repository_deploy_key.go
+++ b/github/resource_github_repository_deploy_key.go
@@ -59,13 +59,13 @@ func resourceGithubRepositoryDeployKeyCreate(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	repoName := d.Get("repository").(string)
 	key := d.Get("key").(string)
 	title := d.Get("title").(string)
 	readOnly := d.Get("read_only").(bool)
-	owner := meta.(*Organization).name
+	owner := meta.(*Owner).name
 	ctx := context.Background()
 
 	log.Printf("[DEBUG] Creating repository deploy key: %s (%s/%s)", title, owner, repoName)
@@ -92,9 +92,9 @@ func resourceGithubRepositoryDeployKeyRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	owner := meta.(*Organization).name
+	owner := meta.(*Owner).name
 	repoName, idString, err := parseTwoPartID(d.Id(), "repository", "ID")
 	if err != nil {
 		return err
@@ -141,9 +141,9 @@ func resourceGithubRepositoryDeployKeyDelete(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	owner := meta.(*Organization).name
+	owner := meta.(*Owner).name
 	repoName, idString, err := parseTwoPartID(d.Id(), "repository", "ID")
 	if err != nil {
 		return err

--- a/github/resource_github_repository_deploy_key_test.go
+++ b/github/resource_github_repository_deploy_key_test.go
@@ -53,6 +53,10 @@ func TestSuppressDeployKeyDiff(t *testing.T) {
 }
 
 func TestAccGithubRepositoryDeployKey_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	testUserEmail := os.Getenv("GITHUB_TEST_USER_EMAIL")
 	if testUserEmail == "" {
 		t.Skip("Skipping because `GITHUB_TEST_USER_EMAIL` is not set")
@@ -92,14 +96,14 @@ func TestAccGithubRepositoryDeployKey_basic(t *testing.T) {
 }
 
 func testAccCheckGithubRepositoryDeployKeyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository_deploy_key" {
 			continue
 		}
 
-		orgName := testAccProvider.Meta().(*Organization).name
+		orgName := testAccProvider.Meta().(*Owner).name
 		repoName, idString, err := parseTwoPartID(rs.Primary.ID, "repository", "ID")
 		if err != nil {
 			return err
@@ -132,8 +136,8 @@ func testAccCheckGithubRepositoryDeployKeyExists(n string) resource.TestCheckFun
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgName := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgName := testAccProvider.Meta().(*Owner).name
 		repoName, idString, err := parseTwoPartID(rs.Primary.ID, "repository", "ID")
 		if err != nil {
 			return err

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -31,8 +31,8 @@ func resourceGithubRepositoryFile() *schema.Resource {
 					branch = parts[1]
 				}
 
-				client := meta.(*Organization).v3client
-				org := meta.(*Organization).name
+				client := meta.(*Owner).v3client
+				org := meta.(*Owner).name
 				repo, file := splitRepoFilePath(parts[0])
 				if err := checkRepositoryFileExists(client, org, repo, file, branch); err != nil {
 					return nil, err
@@ -139,8 +139,8 @@ func resourceGithubRepositoryFileCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	org := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	org := meta.(*Owner).name
 	ctx := context.Background()
 
 	repo := d.Get("repository").(string)
@@ -181,8 +181,8 @@ func resourceGithubRepositoryFileRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	org := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	org := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	repo, file := splitRepoFilePath(d.Id())
@@ -220,8 +220,8 @@ func resourceGithubRepositoryFileUpdate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	org := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	org := meta.(*Owner).name
 	ctx := context.Background()
 
 	repo := d.Get("repository").(string)
@@ -260,8 +260,8 @@ func resourceGithubRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	org := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	org := meta.(*Owner).name
 	ctx := context.Background()
 
 	repo := d.Get("repository").(string)

--- a/github/resource_github_repository_file_test.go
+++ b/github/resource_github_repository_file_test.go
@@ -48,8 +48,8 @@ func testSweepRepositoryFiles(region string) error {
 }
 
 func testSweepDeleteRepositoryFiles(meta interface{}, branch string) error {
-	client := meta.(*Organization).v3client
-	org := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	org := meta.(*Owner).name
 
 	_, files, _, err := client.Repositories.GetContents(
 		context.TODO(), org, "test-repo", "", &github.RepositoryContentGetOptions{Ref: branch})
@@ -77,6 +77,10 @@ func TestAccGithubRepositoryFile_basic(t *testing.T) {
 
 	if userEmail == "" {
 		t.Skip("This test requires you to set the test user's email address (set it by exporting GITHUB_TEST_USER_EMAIL)")
+	}
+
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
 	}
 
 	var content github.RepositoryContent
@@ -157,6 +161,10 @@ func TestAccGithubRepositoryFile_branch(t *testing.T) {
 		t.Skip("This test requires you to set the test user's email address (set it by exporting GITHUB_TEST_USER_EMAIL)")
 	}
 
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var content github.RepositoryContent
 	var commit github.RepositoryCommit
 
@@ -228,6 +236,10 @@ func TestAccGithubRepositoryFile_branch(t *testing.T) {
 }
 
 func TestAccGithubRepositoryFile_committer(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var content github.RepositoryContent
 	var commit github.RepositoryCommit
 
@@ -309,8 +321,8 @@ func testAccCheckGithubRepositoryFileExists(n, path, branch string, content *git
 			return fmt.Errorf("No repository file path set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		org := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		org := testAccProvider.Meta().(*Owner).name
 
 		opts := &github.RepositoryContentGetOptions{Ref: branch}
 		gotContent, _, _, err := conn.Repositories.GetContents(context.TODO(), org, "test-repo", path, opts)
@@ -382,8 +394,8 @@ func testAccCheckGithubRepositoryFileCommitAttributes(commit *github.RepositoryC
 }
 
 func testAccCheckGithubRepositoryFileDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
-	org := testAccProvider.Meta().(*Organization).name
+	conn := testAccProvider.Meta().(*Owner).v3client
+	org := testAccProvider.Meta().(*Owner).name
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository_file" {

--- a/github/resource_github_repository_project.go
+++ b/github/resource_github_repository_project.go
@@ -62,9 +62,9 @@ func resourceGithubRepositoryProjectCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	name := d.Get("name").(string)
 	body := d.Get("body").(string)
@@ -92,8 +92,8 @@ func resourceGithubRepositoryProjectRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 
 	projectID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -131,7 +131,7 @@ func resourceGithubRepositoryProjectRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceGithubRepositoryProjectUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	name := d.Get("name").(string)
 	body := d.Get("body").(string)
@@ -157,7 +157,7 @@ func resourceGithubRepositoryProjectUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceGithubRepositoryProjectDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	projectID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/github/resource_github_repository_project_test.go
+++ b/github/resource_github_repository_project_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestAccGithubRepositoryProject_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	randRepoName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	var project github.Project
 
@@ -47,7 +51,7 @@ func TestAccGithubRepositoryProject_basic(t *testing.T) {
 }
 
 func testAccGithubRepositoryProjectDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository_project" {
@@ -86,7 +90,7 @@ func testAccCheckGithubRepositoryProjectExists(n string, project *github.Project
 			return err
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
+		conn := testAccProvider.Meta().(*Owner).v3client
 		gotProject, _, err := conn.Projects.GetProject(context.TODO(), projectID)
 		if err != nil {
 			return err

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -702,13 +702,12 @@ func testAccCheckGithubRepositoryDestroy(s *terraform.State) error {
 
 func testAccCreateRepositoryBranch(branch, repository string) error {
 	baseURL := os.Getenv("GITHUB_BASE_URL")
-	org := os.Getenv("GITHUB_ORGANIZATION")
 	token := os.Getenv("GITHUB_TOKEN")
 
 	config := Config{
 		BaseURL: baseURL,
 		Token:   token,
-		Owner:   org,
+		Owner:   testOwner,
 	}
 
 	c, err := config.Clients()
@@ -717,7 +716,7 @@ func testAccCreateRepositoryBranch(branch, repository string) error {
 	}
 	client := c.(*Owner).v3client
 
-	refs, _, err := client.Git.GetRefs(context.TODO(), org, repository, "heads")
+	refs, _, err := client.Git.GetRefs(context.TODO(), testOwner, repository, "heads")
 	if err != nil {
 		return fmt.Errorf("Error getting reference commit: %s", err)
 	}
@@ -730,7 +729,7 @@ func testAccCreateRepositoryBranch(branch, repository string) error {
 		},
 	}
 
-	_, _, err = client.Git.CreateRef(context.TODO(), org, repository, newRef)
+	_, _, err = client.Git.CreateRef(context.TODO(), testOwner, repository, newRef)
 	if err != nil {
 		return fmt.Errorf("Error creating git reference: %s", err)
 	}
@@ -885,8 +884,6 @@ resource "github_repository" "foo" {
 }
 
 func testAccGithubRepositoryCreateFromTemplate(randString string) string {
-
-	owner := os.Getenv("GITHUB_ORGANIZATION")
 	repository := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
 
 	return fmt.Sprintf(`
@@ -912,7 +909,7 @@ resource "github_repository" "foo" {
   has_downloads      = true
 
 }
-`, randString, randString, owner, repository)
+`, randString, randString, testOwner, repository)
 }
 
 func testAccGithubRepositoryConfigTopics(randString string, topicList string) string {

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -30,9 +30,9 @@ func testSweepRepositories(region string) error {
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	repos, _, err := client.Repositories.List(context.TODO(), meta.(*Organization).name, nil)
+	repos, _, err := client.Repositories.List(context.TODO(), meta.(*Owner).name, nil)
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func testSweepRepositories(region string) error {
 		if name := r.GetName(); strings.HasPrefix(name, "tf-acc-") || strings.HasPrefix(name, "foo-") {
 			log.Printf("Destroying Repository %s", name)
 
-			if _, err := client.Repositories.Delete(context.TODO(), meta.(*Organization).name, name); err != nil {
+			if _, err := client.Repositories.Delete(context.TODO(), meta.(*Owner).name, name); err != nil {
 				return err
 			}
 		}
@@ -51,6 +51,10 @@ func testSweepRepositories(region string) error {
 }
 
 func TestAccGithubRepository_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var repo github.Repository
 
 	rn := "github_repository.foo"
@@ -116,6 +120,10 @@ func TestAccGithubRepository_basic(t *testing.T) {
 }
 
 func TestAccGithubRepository_archive(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var repo github.Repository
 
 	rn := "github_repository.foo"
@@ -160,6 +168,10 @@ func TestAccGithubRepository_archive(t *testing.T) {
 }
 
 func TestAccGithubRepository_archiveUpdate(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var repo github.Repository
 
 	rn := "github_repository.foo"
@@ -220,6 +232,10 @@ func TestAccGithubRepository_archiveUpdate(t *testing.T) {
 }
 
 func TestAccGithubRepository_hasProjects(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	rn := "github_repository.foo"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
@@ -244,6 +260,10 @@ func TestAccGithubRepository_hasProjects(t *testing.T) {
 }
 
 func TestAccGithubRepository_defaultBranch(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var repo github.Repository
 
 	rn := "github_repository.foo"
@@ -314,6 +334,10 @@ func TestAccGithubRepository_defaultBranch(t *testing.T) {
 }
 
 func TestAccGithubRepository_templates(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var repo github.Repository
 
 	rn := "github_repository.foo"
@@ -361,6 +385,10 @@ func TestAccGithubRepository_templates(t *testing.T) {
 }
 
 func TestAccGithubRepository_topics(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var repo github.Repository
 
 	rn := "github_repository.foo"
@@ -452,6 +480,10 @@ func TestAccGithubRepository_topics(t *testing.T) {
 }
 
 func TestAccGithubRepository_createFromTemplate(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var repo github.Repository
 
 	rn := "github_repository.foo"
@@ -493,7 +525,7 @@ func testAccCheckGithubRepositoryExists(n string, repo *github.Repository) resou
 			return fmt.Errorf("No repository name is set")
 		}
 
-		org := testAccProvider.Meta().(*Organization)
+		org := testAccProvider.Meta().(*Owner)
 		conn := org.v3client
 		gotRepo, _, err := conn.Repositories.Get(context.TODO(), org.name, repoName)
 		if err != nil {
@@ -646,8 +678,8 @@ func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testA
 }
 
 func testAccCheckGithubRepositoryDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
-	orgName := testAccProvider.Meta().(*Organization).name
+	conn := testAccProvider.Meta().(*Owner).v3client
+	orgName := testAccProvider.Meta().(*Owner).name
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository" {
@@ -674,16 +706,16 @@ func testAccCreateRepositoryBranch(branch, repository string) error {
 	token := os.Getenv("GITHUB_TOKEN")
 
 	config := Config{
-		BaseURL:      baseURL,
-		Token:        token,
-		Organization: org,
+		BaseURL: baseURL,
+		Token:   token,
+		Owner:   org,
 	}
 
 	c, err := config.Clients()
 	if err != nil {
 		return fmt.Errorf("Error creating github client: %s", err)
 	}
-	client := c.(*Organization).v3client
+	client := c.(*Owner).v3client
 
 	refs, _, err := client.Git.GetRefs(context.TODO(), org, repository, "heads")
 	if err != nil {

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -103,9 +103,9 @@ func resourceGithubRepositoryWebhookCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	hk := resourceGithubRepositoryWebhookObject(d)
 	ctx := context.Background()
@@ -137,9 +137,9 @@ func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -195,9 +195,9 @@ func resourceGithubRepositoryWebhookUpdate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	hk := resourceGithubRepositoryWebhookObject(d)
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
@@ -216,9 +216,9 @@ func resourceGithubRepositoryWebhookUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceGithubRepositoryWebhookDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/github/resource_github_repository_webhook_test.go
+++ b/github/resource_github_repository_webhook_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestAccGithubRepositoryWebhook_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	rn := "github_repository_webhook.foo"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	var hook github.Hook
@@ -65,6 +69,10 @@ func TestAccGithubRepositoryWebhook_basic(t *testing.T) {
 }
 
 func TestAccGithubRepositoryWebhook_secret(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	rn := "github_repository_webhook.foo"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	var hook github.Hook
@@ -116,7 +124,7 @@ func testAccCheckGithubRepositoryWebhookExists(n string, repoName string, hook *
 			return fmt.Errorf("No repository name is set")
 		}
 
-		org := testAccProvider.Meta().(*Organization)
+		org := testAccProvider.Meta().(*Owner)
 		conn := org.v3client
 		getHook, _, err := conn.Repositories.GetHook(context.TODO(), org.name, repoName, hookID)
 		if err != nil {
@@ -154,8 +162,8 @@ func testAccCheckGithubRepositoryWebhookAttributes(hook *github.Hook, want *test
 }
 
 func testAccCheckGithubRepositoryWebhookDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
-	orgName := testAccProvider.Meta().(*Organization).name
+	conn := testAccProvider.Meta().(*Owner).v3client
+	orgName := testAccProvider.Meta().(*Owner).name
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository_webhook" {

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -65,9 +65,9 @@ func resourceGithubTeamCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	name := d.Get("name").(string)
 	newTeam := github.NewTeam{
 		Name:        name,
@@ -107,8 +107,8 @@ func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -158,8 +158,8 @@ func resourceGithubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 
 	editedTeam := github.NewTeam{
 		Name:        d.Get("name").(string),
@@ -204,8 +204,8 @@ func resourceGithubTeamDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -49,8 +49,8 @@ func resourceGithubTeamMembership() *schema.Resource {
 }
 
 func resourceGithubTeamMembershipCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 
 	teamIdString := d.Get("team_id").(string)
 	teamId, err := strconv.ParseInt(teamIdString, 10, 64)
@@ -81,8 +81,8 @@ func resourceGithubTeamMembershipCreateOrUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 	teamIdString, username, err := parseTwoPartID(d.Id(), "team_id", "username")
 	if err != nil {
 		return err
@@ -129,8 +129,8 @@ func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceGithubTeamMembershipDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 	teamIdString := d.Get("team_id").(string)
 	teamId, err := strconv.ParseInt(teamIdString, 10, 64)
 	if err != nil {

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -17,6 +17,9 @@ func TestAccGithubTeamMembership_basic(t *testing.T) {
 	if testCollaborator == "" {
 		t.Skip("Skipping because `GITHUB_TEST_COLLABORATOR` is not set")
 	}
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
 
 	var membership github.Membership
 
@@ -54,6 +57,9 @@ func TestAccGithubTeamMembership_basic(t *testing.T) {
 func TestAccGithubTeamMembership_caseInsensitive(t *testing.T) {
 	if testCollaborator == "" {
 		t.Skip("Skipping because `GITHUB_TEST_COLLABORATOR` is not set")
+	}
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
 	}
 
 	var membership github.Membership
@@ -96,8 +102,8 @@ func TestAccGithubTeamMembership_caseInsensitive(t *testing.T) {
 }
 
 func testAccCheckGithubTeamMembershipDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
-	orgId := testAccProvider.Meta().(*Organization).id
+	conn := testAccProvider.Meta().(*Owner).v3client
+	orgId := testAccProvider.Meta().(*Owner).id
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team_membership" {
@@ -140,8 +146,8 @@ func testAccCheckGithubTeamMembershipExists(n string, membership *github.Members
 			return fmt.Errorf("No team membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgId := testAccProvider.Meta().(*Organization).id
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgId := testAccProvider.Meta().(*Owner).id
 		teamIdString, username, err := parseTwoPartID(rs.Primary.ID, "team_id", "username")
 		if err != nil {
 			return err
@@ -173,8 +179,8 @@ func testAccCheckGithubTeamMembershipRoleState(n, expected string, membership *g
 			return fmt.Errorf("No team membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgId := testAccProvider.Meta().(*Organization).id
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgId := testAccProvider.Meta().(*Owner).id
 		teamIdString, username, err := parseTwoPartID(rs.Primary.ID, "team_id", "username")
 		if err != nil {
 			return err

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -52,15 +52,15 @@ func resourceGithubTeamRepositoryCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 
 	teamIdString := d.Get("team_id").(string)
 	teamId, err := strconv.ParseInt(teamIdString, 10, 64)
 	if err != nil {
 		return unconvertibleIdErr(teamIdString, err)
 	}
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	permission := d.Get("permission").(string)
 	ctx := context.Background()
@@ -92,8 +92,8 @@ func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 
 	teamIdString, repoName, err := parseTwoPartID(d.Id(), "team_id", "repository")
 	if err != nil {
@@ -104,7 +104,7 @@ func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return unconvertibleIdErr(teamIdString, err)
 	}
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
@@ -147,15 +147,15 @@ func resourceGithubTeamRepositoryUpdate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 
 	teamIdString := d.Get("team_id").(string)
 	teamId, err := strconv.ParseInt(teamIdString, 10, 64)
 	if err != nil {
 		return unconvertibleIdErr(teamIdString, err)
 	}
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	permission := d.Get("permission").(string)
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
@@ -187,8 +187,8 @@ func resourceGithubTeamRepositoryDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgId := meta.(*Organization).id
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
 
 	teamIdString := d.Get("team_id").(string)
 
@@ -196,7 +196,7 @@ func resourceGithubTeamRepositoryDelete(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return unconvertibleIdErr(teamIdString, err)
 	}
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 

--- a/github/resource_github_team_repository_test.go
+++ b/github/resource_github_team_repository_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestAccGithubTeamRepository_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var repository github.Repository
 
 	rn := "github_team_repository.test_team_test_repo"
@@ -111,7 +115,7 @@ func testAccCheckGithubTeamRepositoryExists(n string, repository *github.Reposit
 			return fmt.Errorf("No team repository ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
+		conn := testAccProvider.Meta().(*Owner).v3client
 
 		teamIdString, repoName, err := parseTwoPartID(rs.Primary.ID, "team_id", "repository")
 		if err != nil {
@@ -123,9 +127,9 @@ func testAccCheckGithubTeamRepositoryExists(n string, repository *github.Reposit
 		}
 
 		repo, _, err := conn.Teams.IsTeamRepoByID(context.TODO(),
-			testAccProvider.Meta().(*Organization).id,
+			testAccProvider.Meta().(*Owner).id,
 			teamId,
-			testAccProvider.Meta().(*Organization).name,
+			testAccProvider.Meta().(*Owner).name,
 			repoName)
 
 		if err != nil {
@@ -137,8 +141,8 @@ func testAccCheckGithubTeamRepositoryExists(n string, repository *github.Reposit
 }
 
 func testAccCheckGithubTeamRepositoryDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
-	orgId := testAccProvider.Meta().(*Organization).id
+	conn := testAccProvider.Meta().(*Owner).v3client
+	orgId := testAccProvider.Meta().(*Owner).id
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team_repository" {
@@ -157,7 +161,7 @@ func testAccCheckGithubTeamRepositoryDestroy(s *terraform.State) error {
 		repo, resp, err := conn.Teams.IsTeamRepoByID(context.TODO(),
 			orgId,
 			teamId,
-			testAccProvider.Meta().(*Organization).name,
+			testAccProvider.Meta().(*Owner).name,
 			repoName)
 
 		if err == nil {

--- a/github/resource_github_team_sync_group_mapping.go
+++ b/github/resource_github_team_sync_group_mapping.go
@@ -64,9 +64,9 @@ func resourceGithubTeamSyncGroupMappingCreate(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 	ctx := context.Background()
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	slug := d.Get("team_slug").(string)
 
 	idpGroupList := expandTeamSyncGroups(d)
@@ -87,8 +87,8 @@ func resourceGithubTeamSyncGroupMappingRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	slug := d.Get("team_slug").(string)
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
@@ -132,8 +132,8 @@ func resourceGithubTeamSyncGroupMappingUpdate(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	slug := d.Get("team_slug").(string)
 
@@ -153,8 +153,8 @@ func resourceGithubTeamSyncGroupMappingDelete(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	slug := d.Get("team_slug").(string)
 

--- a/github/resource_github_team_sync_group_mapping_test.go
+++ b/github/resource_github_team_sync_group_mapping_test.go
@@ -144,8 +144,8 @@ func TestAccGithubTeamSyncGroupMapping_empty(t *testing.T) {
 }
 
 func testAccCheckGithubTeamSyncGroupMappingDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
-	orgName := testAccProvider.Meta().(*Organization).name
+	conn := testAccProvider.Meta().(*Owner).v3client
+	orgName := testAccProvider.Meta().(*Owner).name
 	ctx := context.TODO()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team_sync_group_mapping" {
@@ -172,8 +172,8 @@ func testAccCheckGithubTeamSyncGroupMappingDisappears(resourceName string) resou
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgName := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgName := testAccProvider.Meta().(*Owner).name
 		slug := rs.Primary.Attributes["team_slug"]
 
 		emptyGroupList := github.IDPGroupList{Groups: []*github.IDPGroup{}}

--- a/github/resource_github_team_test.go
+++ b/github/resource_github_team_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestAccGithubTeam_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var team github.Team
 
 	rn := "github_team.foo"
@@ -63,6 +67,10 @@ func TestAccGithubTeam_basic(t *testing.T) {
 }
 
 func TestAccGithubTeam_slug(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var team github.Team
 
 	rn := "github_team.foo"
@@ -99,6 +107,10 @@ func TestAccGithubTeam_slug(t *testing.T) {
 }
 
 func TestAccGithubTeam_hierarchical(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	var parent, child github.Team
 
 	rn := "github_team.parent"
@@ -140,13 +152,13 @@ func testAccCheckGithubTeamExists(n string, team *github.Team) resource.TestChec
 			return fmt.Errorf("No Team ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).v3client
+		conn := testAccProvider.Meta().(*Owner).v3client
 		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
 		if err != nil {
 			return unconvertibleIdErr(rs.Primary.ID, err)
 		}
 
-		githubTeam, _, err := conn.Teams.GetTeamByID(context.TODO(), testAccProvider.Meta().(*Organization).id, id)
+		githubTeam, _, err := conn.Teams.GetTeamByID(context.TODO(), testAccProvider.Meta().(*Owner).id, id)
 		if err != nil {
 			return err
 		}
@@ -178,8 +190,8 @@ func testAccCheckGithubTeamAttributes(team *github.Team, name, description strin
 }
 
 func testAccCheckGithubTeamDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
-	orgId := testAccProvider.Meta().(*Organization).id
+	conn := testAccProvider.Meta().(*Owner).v3client
+	orgId := testAccProvider.Meta().(*Owner).id
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team" {

--- a/github/resource_github_user_gpg_key.go
+++ b/github/resource_github_user_gpg_key.go
@@ -35,7 +35,7 @@ func resourceGithubUserGpgKey() *schema.Resource {
 }
 
 func resourceGithubUserGpgKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	pubKey := d.Get("armored_public_key").(string)
 	ctx := context.Background()
@@ -52,7 +52,7 @@ func resourceGithubUserGpgKeyCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubUserGpgKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -86,7 +86,7 @@ func resourceGithubUserGpgKeyRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceGithubUserGpgKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/github/resource_github_user_gpg_key_test.go
+++ b/github/resource_github_user_gpg_key_test.go
@@ -49,7 +49,7 @@ func testAccCheckGithubUserGpgKeyExists(n string, key *github.GPGKey) resource.T
 			return unconvertibleIdErr(rs.Primary.ID, err)
 		}
 
-		org := testAccProvider.Meta().(*Organization)
+		org := testAccProvider.Meta().(*Owner)
 		receivedKey, _, err := org.v3client.Users.GetGPGKey(context.TODO(), id)
 		if err != nil {
 			return err
@@ -60,7 +60,7 @@ func testAccCheckGithubUserGpgKeyExists(n string, key *github.GPGKey) resource.T
 }
 
 func testAccCheckGithubUserGpgKeyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_user_gpg_key" {

--- a/github/resource_github_user_invitation_accepter.go
+++ b/github/resource_github_user_invitation_accepter.go
@@ -26,7 +26,7 @@ func resourceGithubUserInvitationAccepter() *schema.Resource {
 }
 
 func resourceGithubUserInvitationAccepterCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	invitationIdString := d.Get("invitation_id").(string)
 	invitationId, err := strconv.Atoi(invitationIdString)

--- a/github/resource_github_user_ssh_key.go
+++ b/github/resource_github_user_ssh_key.go
@@ -48,7 +48,7 @@ func resourceGithubUserSshKey() *schema.Resource {
 }
 
 func resourceGithubUserSshKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	title := d.Get("title").(string)
 	key := d.Get("key").(string)
@@ -69,7 +69,7 @@ func resourceGithubUserSshKeyCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubUserSshKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -105,7 +105,7 @@ func resourceGithubUserSshKeyRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceGithubUserSshKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/github/resource_github_user_ssh_key_test.go
+++ b/github/resource_github_user_ssh_key_test.go
@@ -57,7 +57,7 @@ func testAccCheckGithubUserSshKeyExists(n string, key *github.Key) resource.Test
 			return unconvertibleIdErr(rs.Primary.ID, err)
 		}
 
-		org := testAccProvider.Meta().(*Organization)
+		org := testAccProvider.Meta().(*Owner)
 		receivedKey, _, err := org.v3client.Users.GetKey(context.TODO(), id)
 		if err != nil {
 			return err
@@ -68,7 +68,7 @@ func testAccCheckGithubUserSshKeyExists(n string, key *github.Key) resource.Test
 }
 
 func testAccCheckGithubUserSshKeyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
+	conn := testAccProvider.Meta().(*Owner).v3client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_user_ssh_key" {

--- a/github/resource_organization_block.go
+++ b/github/resource_organization_block.go
@@ -39,8 +39,8 @@ func resourceOrganizationBlockCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 	ctx := context.Background()
 	username := d.Get("username").(string)
 
@@ -55,8 +55,8 @@ func resourceOrganizationBlockCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceOrganizationBlockRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
-	orgName := meta.(*Organization).name
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
 
 	username := d.Id()
 
@@ -95,9 +95,9 @@ func resourceOrganizationBlockRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceOrganizationBlockDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).v3client
+	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Organization).name
+	orgName := meta.(*Owner).name
 	username := d.Id()
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 

--- a/github/resource_organization_block_test.go
+++ b/github/resource_organization_block_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAccOrganizationBlock_basic(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	rn := "github_organization_block.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -33,8 +37,8 @@ func TestAccOrganizationBlock_basic(t *testing.T) {
 }
 
 func testAccOrganizationBlockDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).v3client
-	orgName := testAccProvider.Meta().(*Organization).name
+	conn := testAccProvider.Meta().(*Owner).v3client
+	orgName := testAccProvider.Meta().(*Owner).name
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_organization_block" {
@@ -60,8 +64,8 @@ func testAccCheckOrganizationBlockExists(n string) resource.TestCheckFunc {
 		}
 
 		username := rs.Primary.ID
-		conn := testAccProvider.Meta().(*Organization).v3client
-		orgName := testAccProvider.Meta().(*Organization).name
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgName := testAccProvider.Meta().(*Owner).name
 
 		blocked, _, err := conn.Organizations.IsBlocked(context.TODO(), orgName, username)
 		if err != nil {

--- a/github/sweeper_test.go
+++ b/github/sweeper_test.go
@@ -17,14 +17,14 @@ func sharedConfigForRegion(region string) (interface{}, error) {
 		return nil, fmt.Errorf("empty GITHUB_TOKEN")
 	}
 
-	if os.Getenv("GITHUB_ORGANIZATION") == "" {
-		return nil, fmt.Errorf("empty GITHUB_ORGANIZATION")
+	if os.Getenv("GITHUB_OWNER") == "" {
+		return nil, fmt.Errorf("empty GITHUB_OWNER")
 	}
 
 	config := Config{
-		Token:        os.Getenv("GITHUB_TOKEN"),
-		Organization: os.Getenv("GITHUB_ORGANIZATION"),
-		BaseURL:      "",
+		Token:   os.Getenv("GITHUB_TOKEN"),
+		Owner:   os.Getenv("GITHUB_OWNER"),
+		BaseURL: "",
 	}
 
 	client, err := config.Clients()

--- a/github/util.go
+++ b/github/util.go
@@ -17,8 +17,8 @@ const (
 )
 
 func checkOrganization(meta interface{}) error {
-	if meta.(*Organization).name == "" {
-		return fmt.Errorf("This resource requires GitHub organization to be set on the provider.")
+	if !meta.(*Owner).IsOrganization {
+		return fmt.Errorf("This resource can only be used in the context of an organization, %q is a user.", meta.(*Owner).name)
 	}
 
 	return nil

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -2,12 +2,12 @@
 layout: "github"
 page_title: "Provider: GitHub"
 description: |-
-  The GitHub provider is used to interact with GitHub organization resources.
+  The GitHub provider is used to interact with GitHub resources.
 ---
 
 # GitHub Provider
 
-The GitHub provider is used to interact with GitHub organization resources.
+The GitHub provider is used to interact with GitHub resources.
 
 The provider allows you to manage your GitHub organization's members and teams easily.
 It needs to be configured with the proper credentials before it can be used.
@@ -19,8 +19,8 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Configure the GitHub Provider
 provider "github" {
-  token        = "${var.github_token}"
-  organization = "${var.github_organization}"
+  token = "${var.github_token}"
+  owner = "${var.github_owner}"
 }
 
 # Add a user to the organization
@@ -33,33 +33,17 @@ resource "github_membership" "membership_for_user_x" {
 
 The following arguments are supported in the `provider` block:
 
-* `token` - (Optional) This is the GitHub personal access token. It can also be
-  sourced from the `GITHUB_TOKEN` environment variable. If `anonymous` is false,
-  `token` is required.
+* `token` - (Required) This is the GitHub personal access token. It must be provided, but
+  it can also be sourced from the `GITHUB_TOKEN` environment variable.
 
-* `organization` - (Optional) This is the target GitHub organization to manage.
-  The account corresponding to the token will need "owner" privileges for this
-  organization. It can also be sourced from the `GITHUB_ORGANIZATION`
-  environment variable. If `individual` is set to `false`, organization is required.
+* `owner` - (Optional) This is the target GitHub organization or a user to manage. The account
+  corresponding to the token will need "owner" privileges for this organization. It must be provided, but
+  it can also be sourced from the `GITHUB_OWNER` environment variable.
+
+* `organization` - (DEPRECATED) This is the target GitHub organization or a user to manage. The account
+  corresponding to the token will need "organization" privileges for this organization. It must be provided, but
+  it can also be sourced from the `GITHUB_ORGANIZATION` environment variable.
 
 * `base_url` - (Optional) This is the target GitHub base API endpoint. Providing a value is a
   requirement when working with GitHub Enterprise.  It is optional to provide this value and
   it can also be sourced from the `GITHUB_BASE_URL` environment variable.  The value must end with a slash.
-  `https://github.someorg.example/api/`.
-
-* `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate.
-  As the name suggests **this is insecure** and should not be used beyond experiments,
-  accessing local (non-production) GHE instance etc.
-  There is a number of ways to obtain trusted certificate for free, e.g. from [Let's Encrypt](https://letsencrypt.org/).
-  Such trusted certificate *does not require* this option to be enabled.
-  Defaults to `false`.
-
-* `individual`: (Optional) Run outside an organization.  When `individual` is true, the provider will run outside
-  the scope of an organization. Defaults to `false`.
-
-* `anonymous`: (Optional) Authenticate without a token.  When `anonymous` is true, the provider will not be able to
-  access resources that require authentication. Setting to true will lead the GitHub provider to work in an anonymous
-  mode with the corresponding API [rate limits](https://developer.github.com/v3/#rate-limiting).  Defaults to `false`.
-
-* `id`: (Computed) This is the ID of the target GitHub organization which is being managed. The value of this is set by
-  provider based on the name specified in `organization`.


### PR DESCRIPTION
Continuing the work done by @elislusarczyk in #96 to support individual github accounts for repos

Changes here address last review comments in #96 : 
* transition off of `GITHUB_ORGANIZATION` to `GITHUB_OWNER` (across acctests as well)
* check whether the owner is org and if not, return a user-friendly error (#checkOrganization in`util.go`)
* deprecate `organization` in `provider.go`
* skip acctests where organization is needed 
* add `IsOrganization` to `Owner` struct

Output of acceptance tests with `owner` set as Github User:
```
--- PASS: TestEtagTransport (0.00s)
--- PASS: TestRateLimitTransport_abuseLimit_get (0.00s)
--- PASS: TestRateLimitTransport_abuseLimit_post (0.00s)
--- PASS: TestRateLimitTransport_abuseLimit_post_error (0.00s)
--- PASS: TestAccValidateTeamIDFunc (0.00s)
--- PASS: TestAccGithubUtilRole_validation (0.00s)
--- PASS: TestAccGithubUtilTwoPartID (0.00s)
--- PASS: TestAccGithubReleaseDataSource_invalidRetrieveMethodReturnsError (0.03s)
--- PASS: TestAccGithubReleaseDataSource_fetchByTagNoTagReturnsError (1.57s)
--- PASS: TestAccGithubReleaseDataSource_fetchByIdWithNoIdReturnsError (1.62s)
--- PASS: TestAccGithubUserDataSource_noMatchReturnsError (1.72s)
--- PASS: TestAccGithubReleaseDataSource_fetchByLatestNoReleaseReturnsError (2.01s)
--- PASS: TestAccGithubMembershipDataSource_noMatchReturnsError (2.06s)
--- PASS: TestAccGithubIpRangesDataSource_existing (8.22s)
--- PASS: TestAccGithubUserGpgKey_basic (11.04s)
--- PASS: TestAccGithubUserSshKey_basic (11.17s)
--- PASS: TestAccGithubUserDataSource_existing (12.14s)
--- PASS: TestAccProvider_individual (12.56s)

* remaining tests are skipped
```