### PR TITLE
update go-github import

### DIFF
--- a/github/util.go
+++ b/github/util.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v31/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 


### PR DESCRIPTION
* addresses CI failing with references to go-github module missing 