### PR TITLE
Add support for importing organization-level webhooks

### DIFF
--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -17,6 +17,9 @@ func resourceGithubOrganizationWebhook() *schema.Resource {
 		Read:   resourceGithubOrganizationWebhookRead,
 		Update: resourceGithubOrganizationWebhookUpdate,
 		Delete: resourceGithubOrganizationWebhookDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		SchemaVersion: 1,
 		MigrateState:  resourceGithubWebhookMigrateState,
@@ -154,6 +157,8 @@ func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interfac
 			hook.Config["secret"] = currentSecret
 		}
 	}
+
+	hook.Config = insecureSslStringToBool(hook.Config)
 
 	d.Set("configuration", []interface{}{hook.Config})
 

--- a/github/resource_github_organization_webhook_test.go
+++ b/github/resource_github_organization_webhook_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v32/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -19,7 +20,7 @@ func TestAccGithubOrganizationWebhook_basic(t *testing.T) {
 	}
 
 	var hook github.Hook
-
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	rn := "github_organization_webhook.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -57,6 +58,12 @@ func TestAccGithubOrganizationWebhook_basic(t *testing.T) {
 					}),
 				),
 			},
+			{
+				ResourceName:        rn,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("foo-%s/", randString),
+			},
 		},
 	})
 }
@@ -67,6 +74,7 @@ func TestAccGithubOrganizationWebhook_secret(t *testing.T) {
 	}
 
 	rn := "github_organization_webhook.foo"
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -78,6 +86,12 @@ func TestAccGithubOrganizationWebhook_secret(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubOrganizationWebhookSecret(rn, "VerySecret"),
 				),
+			},
+			{
+				ResourceName:        rn,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("foo-%s/", randString),
 			},
 		},
 	})

--- a/website/docs/r/organization_webhook.html.markdown
+++ b/website/docs/r/organization_webhook.html.markdown
@@ -44,3 +44,14 @@ The following arguments are supported:
 The following additional attributes are exported:
 
 * `url` - URL of the webhook
+
+## Import
+
+Organization webhooks can be imported using the `id` of the webhook.
+The `id` of the webhook can be found in the URL of the webhook. For example, `"https://github.com/organizations/foo-org/settings/hooks/123456789"`.
+
+```
+$ terraform import github_organization_webhook.terraform 123456789
+```
+
+If secret is populated in the webhook's configuration, the value will be imported as "********".


### PR DESCRIPTION
This introduces support for importing webhooks from GitHub organization
objects. This was already supported for repository-level webhooks, and
the implementation is similar with the exception of some changes to ID
handling.