### PR TITLE
resource/repository_collaborator: add individual user support

### DIFF
--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -49,22 +49,17 @@ func resourceGithubRepositoryCollaborator() *schema.Resource {
 }
 
 func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Owner).name
+	owner := meta.(*Owner).name
 	username := d.Get("username").(string)
 	repoName := d.Get("repository").(string)
 	ctx := context.Background()
 
 	log.Printf("[DEBUG] Creating repository collaborator: %s (%s/%s)",
-		username, orgName, repoName)
+		username, owner, repoName)
 	_, resp, err := client.Repositories.AddCollaborator(ctx,
-		orgName,
+		owner,
 		repoName,
 		username,
 		&github.RepositoryAddCollaboratorOptions{
@@ -84,14 +79,9 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta int
 }
 
 func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Owner).name
+	owner := meta.(*Owner).name
 	repoName, username, err := parseTwoPartID(d.Id(), "repository", "username")
 	if err != nil {
 		return err
@@ -99,14 +89,14 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	// First, check if the user has been invited but has not yet accepted
-	invitation, err := findRepoInvitation(client, ctx, orgName, repoName, username)
+	invitation, err := findRepoInvitation(client, ctx, owner, repoName, username)
 	if err != nil {
 		if ghErr, ok := err.(*github.ErrorResponse); ok {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
 				// this short circuits the rest of the code because if the
 				// repo is 404, no reason to try to list existing collaborators
 				log.Printf("[WARN] Removing repository collaborator %s/%s %s from state because it no longer exists in GitHub",
-					orgName, repoName, username)
+					owner, repoName, username)
 				d.SetId("")
 				return nil
 			}
@@ -136,7 +126,7 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 
 	for {
 		collaborators, resp, err := client.Repositories.ListCollaborators(ctx,
-			orgName, repoName, opt)
+			owner, repoName, opt)
 		if err != nil {
 			return err
 		}
@@ -165,38 +155,33 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 
 	// The user is neither invited nor a collaborator
 	log.Printf("[WARN] Removing repository collaborator %s (%s/%s) from state because it no longer exists in GitHub",
-		username, orgName, repoName)
+		username, owner, repoName)
 	d.SetId("")
 
 	return nil
 }
 
 func resourceGithubRepositoryCollaboratorDelete(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Owner).name
+	owner := meta.(*Owner).name
 	username := d.Get("username").(string)
 	repoName := d.Get("repository").(string)
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	// Delete any pending invitations
-	invitation, err := findRepoInvitation(client, ctx, orgName, repoName, username)
+	invitation, err := findRepoInvitation(client, ctx, owner, repoName, username)
 	if err != nil {
 		return err
 	} else if invitation != nil {
-		_, err = client.Repositories.DeleteInvitation(ctx, orgName, repoName, invitation.GetID())
+		_, err = client.Repositories.DeleteInvitation(ctx, owner, repoName, invitation.GetID())
 		return err
 	}
 
 	log.Printf("[DEBUG] Deleting repository collaborator: %s (%s/%s)",
-		username, orgName, repoName)
-	_, err = client.Repositories.RemoveCollaborator(ctx, orgName, repoName, username)
+		username, owner, repoName)
+	_, err = client.Repositories.RemoveCollaborator(ctx, owner, repoName, username)
 	return err
 }
 

--- a/website/docs/r/repository_collaborator.html.markdown
+++ b/website/docs/r/repository_collaborator.html.markdown
@@ -10,9 +10,11 @@ description: |-
 Provides a GitHub repository collaborator resource.
 
 This resource allows you to add/remove collaborators from repositories in your
-organization. Collaborators can have explicit (and differing levels of) read,
-write, or administrator access to specific repositories in your organization,
-without giving the user full organization membership.
+organization or personal account. For organization repositories, collaborators can
+have explicit (and differing levels of) read, write, or administrator access to 
+specific repositories, without giving the user full organization membership. 
+For personal repositories, collaborators can only be granted write
+(implictly includes read) permission. 
 
 When applied, an invitation will be sent to the user to become a collaborator
 on a repository. When destroyed, either the invitation will be cancelled or the
@@ -20,6 +22,7 @@ collaborator will be removed from the repository.
 
 Further documentation on GitHub collaborators:
 
+- [Adding outside collaborators to your personal repositories](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/managing-access-to-your-personal-repositories)
 - [Adding outside collaborators to repositories in your organization](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/)
 - [Converting an organization member to an outside collaborator](https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/)
 
@@ -41,7 +44,8 @@ The following arguments are supported:
 * `repository` - (Required) The GitHub repository
 * `username` - (Required) The user to add to the repository as a collaborator.
 * `permission` - (Optional) The permission of the outside collaborator for the repository.
-            Must be one of `pull`, `push`, `maintain`, `triage` or `admin`. Defaults to `push`.
+            Must be one of `pull`, `push`, `maintain`, `triage` or `admin` for organization-owned repositories.
+            Must be `push` for personal repositories. Defaults to `push`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
* Requires #465 (support for personal repositories)

Output of acceptance tests (personal):
```
--- SKIP: TestAccGithubRepositoryCollaborator_caseInsensitive (0.05s)
--- PASS: TestAccGithubRepositoryCollaborator_caseInsensitive_personal (11.38s)
--- PASS: TestAccGithubRepositoryCollaborator_basic_personal (14.09s)
--- SKIP: TestAccGithubRepositoryCollaborator_basic (0.23s)
PASS
```
Output of acceptance tests (organization):
```
--- PASS: TestAccGithubRepositoryCollaborator_basic_personal (16.93s)
--- PASS: TestAccGithubRepositoryCollaborator_caseInsensitive_personal (17.04s)
--- PASS: TestAccGithubRepositoryCollaborator_caseInsensitive (17.27s)
--- PASS: TestAccGithubRepositoryCollaborator_basic (31.12s)
```