### PR TITLE
Deprecate `anonymous` Flag For Provider Configuration

### DIFF
--- a/github/config_test.go
+++ b/github/config_test.go
@@ -1,0 +1,62 @@
+package github
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConfigClients(t *testing.T) {
+
+	t.Run("returns a client for the v3 REST API", func(t *testing.T) {
+		config := Config{
+			Token:      os.Getenv("GITHUB_TOKEN"),
+			Individual: true,
+		}
+
+		meta, err := config.Clients()
+		if err != nil {
+			t.Fatalf("failed to return clients without error: %s", err.Error())
+		}
+
+		if client := meta.(*Organization).v3client; client == nil {
+			t.Fatalf("failed to return a v3 client")
+		}
+	})
+
+	t.Run("returns a client for the v4 GraphQL API", func(t *testing.T) {
+		config := Config{
+			Token:      os.Getenv("GITHUB_TOKEN"),
+			Individual: true,
+		}
+
+		meta, err := config.Clients()
+		if err != nil {
+			t.Fatalf("failed to return clients without error: %s", err.Error())
+		}
+
+		if client := meta.(*Organization).v4client; client == nil {
+			t.Fatalf("failed to return a v4 client")
+		}
+	})
+
+	t.Run("returns clients configured as anonymous", func(t *testing.T) {
+		config := Config{
+			Token:      "",
+			Anonymous:  true,
+			Individual: true,
+		}
+
+		meta, err := config.Clients()
+		if err != nil {
+			t.Fatalf("failed to return clients without error: %s", err.Error())
+		}
+
+		if client := meta.(*Organization).v4client; client == nil {
+			t.Fatalf("failed to return a v4 client")
+		}
+
+		if client := meta.(*Organization).v3client; client == nil {
+			t.Fatalf("failed to return a v3 client")
+		}
+	})
+}

--- a/github/config_test.go
+++ b/github/config_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"os"
 	"testing"
 )
 
@@ -9,7 +8,7 @@ func TestConfigClients(t *testing.T) {
 
 	t.Run("returns a client for the v3 REST API", func(t *testing.T) {
 		config := Config{
-			Token:      os.Getenv("GITHUB_TOKEN"),
+			Token:      "token",
 			Individual: true,
 		}
 
@@ -25,7 +24,7 @@ func TestConfigClients(t *testing.T) {
 
 	t.Run("returns a client for the v4 GraphQL API", func(t *testing.T) {
 		config := Config{
-			Token:      os.Getenv("GITHUB_TOKEN"),
+			Token:      "token",
 			Individual: true,
 		}
 

--- a/github/provider.go
+++ b/github/provider.go
@@ -42,6 +42,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: descriptions["anonymous"],
+				Deprecated:  "Provide a token instead",
 			},
 		},
 

--- a/github/provider.go
+++ b/github/provider.go
@@ -42,7 +42,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: descriptions["anonymous"],
-				Deprecated:  "Provide a token instead",
+				Deprecated:  "For versions later than 3.0.0, absense of a token enables this mode",
 			},
 		},
 
@@ -118,13 +118,19 @@ func init() {
 
 func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 	return func(d *schema.ResourceData) (interface{}, error) {
+
+		anonymous := true
+		if d.Get("token").(string) != "" {
+			anonymous = false
+		}
+
 		config := Config{
 			Token:        d.Get("token").(string),
 			Organization: d.Get("organization").(string),
 			BaseURL:      d.Get("base_url").(string),
 			Insecure:     d.Get("insecure").(bool),
 			Individual:   d.Get("individual").(bool),
-			Anonymous:    d.Get("anonymous").(bool),
+			Anonymous:    anonymous,
 		}
 
 		meta, err := config.Clients()

--- a/github/provider.go
+++ b/github/provider.go
@@ -42,7 +42,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: descriptions["anonymous"],
-				Deprecated:  "For versions later than 3.0.0, absense of a token enables this mode",
+				Deprecated:  "For versions later than 3.0.0, absence of a token enables this mode",
 			},
 		},
 


### PR DESCRIPTION
Looking for wider feedback on this approach.  Please raise any concerns with this deprecation.  It may be possible to shape `v3.0.0` to include resource-level anonymous access if there are use cases that need better representation.

/cc https://github.com/terraform-providers/terraform-provider-github/issues/502#issuecomment-652399602