### PR TITLE
resource/github_actions_secret: skip acctest for non-organization auth

### DIFF
--- a/github/resource_github_actions_secret_test.go
+++ b/github/resource_github_actions_secret_test.go
@@ -50,6 +50,10 @@ func TestAccGithubActionsSecret_basic(t *testing.T) {
 }
 
 func TestAccGithubActionsSecret_disappears(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
 	repo := acctest.RandomWithPrefix("tf-acc-test")
 	secretResourceName := "github_actions_secret.test_secret"
 	secretValue := "super_secret_value"


### PR DESCRIPTION
Closes #516 but could be preceded and closed by PR #520

Output of acceptance tests for individual-user:
```
--- SKIP: TestAccGithubActionsSecret_basic (0.26s)
--- SKIP: TestAccGithubActionsSecret_disappears (0.06s)
```

Output of acceptance tests for organization:
```
--- PASS: TestAccGithubActionsSecret_disappears (109.21s)
--- PASS: TestAccGithubActionsSecret_basic (177.28s)
```