### PR TITLE
resource/github_branch and data-source/github_branch: invididual user support

### DIFF
--- a/github/data_source_github_branch.go
+++ b/github/data_source_github_branch.go
@@ -40,11 +40,6 @@ func dataSourceGithubBranch() *schema.Resource {
 }
 
 func dataSourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)

--- a/github/data_source_github_branch_test.go
+++ b/github/data_source_github_branch_test.go
@@ -8,10 +8,6 @@ import (
 )
 
 func TestAccGithubBranchDataSource_basic(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
-
 	var (
 		name = "main"
 		repo = "test-repo"

--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -60,11 +60,6 @@ func resourceGithubBranch() *schema.Resource {
 }
 
 func resourceGithubBranchCreate(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	ctx := context.Background()
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxId, d.Id())
@@ -92,7 +87,7 @@ func resourceGithubBranchCreate(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] Creating GitHub branch reference %s/%s (%s)",
 		orgName, repoName, branchRefName)
-	_, _, err = client.Git.CreateRef(ctx, orgName, repoName, &github.Reference{
+	_, _, err := client.Git.CreateRef(ctx, orgName, repoName, &github.Reference{
 		Ref:    &branchRefName,
 		Object: &github.GitObject{SHA: &sourceBranchSHA},
 	})
@@ -107,11 +102,6 @@ func resourceGithubBranchCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
@@ -155,11 +145,6 @@ func resourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGithubBranchDelete(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	client := meta.(*Owner).v3client

--- a/github/resource_github_branch_test.go
+++ b/github/resource_github_branch_test.go
@@ -12,10 +12,6 @@ import (
 )
 
 func TestAccGithubBranch_basic(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
-
 	var (
 		reference github.Reference
 
@@ -71,10 +67,6 @@ func TestAccGithubBranch_basic(t *testing.T) {
 	})
 }
 func TestAccGithubBranch_withSourceBranch(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
-
 	var (
 		reference github.Reference
 


### PR DESCRIPTION
Relates #501 

Output of acceptance tests for individual user:
```
--- PASS: TestAccGithubBranch_withSourceBranch (5.71s)
--- PASS: TestAccGithubBranch_basic (5.79s)
--- PASS: TestAccGithubBranchDataSource_basic (2.54s)
```
Output of acceptance tests for organization:
```
--- PASS: TestAccGithubBranchDataSource_basic (4.37s)
--- PASS: TestAccGithubBranch_basic (6.27s)
--- PASS: TestAccGithubBranch_withSourceBranch (19.10s)
```