### PR TITLE
resource/github_issue_label: add invididual user support

### DIFF
--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -60,11 +60,6 @@ func resourceGithubIssueLabel() *schema.Resource {
 // same function for two schema funcs.
 
 func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
@@ -148,11 +143,6 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 	repoName, name, err := parseTwoPartID(d.Id(), "repository", "name")
 	if err != nil {
@@ -194,11 +184,6 @@ func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceGithubIssueLabelDelete(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 
 	orgName := meta.(*Owner).name
@@ -207,7 +192,7 @@ func resourceGithubIssueLabelDelete(d *schema.ResourceData, meta interface{}) er
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	log.Printf("[DEBUG] Deleting label: %s (%s/%s)", name, orgName, repoName)
-	_, err = client.Issues.DeleteLabel(ctx,
+	_, err := client.Issues.DeleteLabel(ctx,
 		orgName, repoName, name)
 	return err
 }

--- a/github/resource_github_issue_label_test.go
+++ b/github/resource_github_issue_label_test.go
@@ -12,10 +12,6 @@ import (
 )
 
 func TestAccGithubIssueLabel_basic(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
-
 	var label, updatedLabel github.Label
 
 	rn := "github_issue_label.test"
@@ -52,10 +48,6 @@ func TestAccGithubIssueLabel_basic(t *testing.T) {
 }
 
 func TestAccGithubIssueLabel_existingLabel(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
-
 	var label github.Label
 
 	rn := "github_issue_label.test"
@@ -84,10 +76,6 @@ func TestAccGithubIssueLabel_existingLabel(t *testing.T) {
 }
 
 func TestAccGithubIssueLabel_description(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
-
 	var label github.Label
 
 	rn := "github_issue_label.test"


### PR DESCRIPTION
Relates #501 

Output of acceptance tests for individual user:
```
--- PASS: TestAccGithubIssueLabel_existingLabel (12.26s)
--- PASS: TestAccGithubIssueLabel_basic (16.09s)
--- PASS: TestAccGithubIssueLabel_description (21.95s)
```

Output of acceptance test for organization:
```
--- PASS: TestAccGithubIssueLabel_existingLabel (17.64s)
--- PASS: TestAccGithubIssueLabel_basic (22.19s)
--- PASS: TestAccGithubIssueLabel_description (29.38s)
```