### PR TITLE
resource/actions_secret and data-source/actions_public_key: add individual user support

### DIFF
--- a/github/data_source_github_actions_public_key.go
+++ b/github/data_source_github_actions_public_key.go
@@ -29,11 +29,6 @@ func dataSourceGithubActionsPublicKey() *schema.Resource {
 }
 
 func dataSourceGithubActionsPublicKeyRead(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	repository := d.Get("repository").(string)
 	owner := meta.(*Owner).name
 	log.Printf("[INFO] Refreshing GitHub Actions Public Key from: %s/%s", owner, repository)

--- a/github/data_source_github_actions_public_key_test.go
+++ b/github/data_source_github_actions_public_key_test.go
@@ -10,10 +10,6 @@ import (
 )
 
 func TestAccGithubActionsPublicKeyDataSource_noMatchReturnsError(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
-
 	repo := "non-existent"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -30,10 +26,6 @@ func TestAccGithubActionsPublicKeyDataSource_noMatchReturnsError(t *testing.T) {
 }
 
 func TestAccCheckGithubActionsPublicKeyDataSource_existing(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
-
 	repo := os.Getenv("GITHUB_TEMPLATE_REPOSITORY")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/github/resource_github_actions_secret.go
+++ b/github/resource_github_actions_secret.go
@@ -46,11 +46,6 @@ func resourceGithubActionsSecret() *schema.Resource {
 }
 
 func resourceGithubActionsSecretCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
 	ctx := context.Background()
@@ -86,11 +81,6 @@ func resourceGithubActionsSecretCreateOrUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceGithubActionsSecretRead(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
 	ctx := context.Background()
@@ -121,11 +111,6 @@ func resourceGithubActionsSecretRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGithubActionsSecretDelete(d *schema.ResourceData, meta interface{}) error {
-	err := checkOrganization(meta)
-	if err != nil {
-		return err
-	}
-
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())

--- a/github/resource_github_actions_secret_test.go
+++ b/github/resource_github_actions_secret_test.go
@@ -11,10 +11,6 @@ import (
 )
 
 func TestAccGithubActionsSecret_basic(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
-
 	repo := acctest.RandomWithPrefix("tf-acc-test")
 
 	secretResourceName := "github_actions_secret.test_secret"


### PR DESCRIPTION
Closes #422 

Output of acceptance tests for individual-user:
```
--- PASS: TestAccGithubActionsSecret_disappears (13.30s)
--- PASS: TestAccGithubActionsSecret_basic (19.61s)
--- PASS: TestAccGithubActionsPublicKeyDataSource_noMatchReturnsError (0.31s)
```
Output of acceptance tests for organization:
```
--- PASS: TestAccGithubActionsPublicKeyDataSource_noMatchReturnsError (0.36s)
--- PASS: TestAccGithubActionsSecret_disappears (10.39s)
--- PASS: TestAccGithubActionsSecret_basic (15.68s)
```