### PR TITLE
resource/repository_collaborator: revert response handling introduced in #424

### DIFF
--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -58,7 +58,7 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta int
 
 	log.Printf("[DEBUG] Creating repository collaborator: %s (%s/%s)",
 		username, owner, repoName)
-	_, resp, err := client.Repositories.AddCollaborator(ctx,
+	_, _, err := client.Repositories.AddCollaborator(ctx,
 		owner,
 		repoName,
 		username,
@@ -68,9 +68,6 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta int
 
 	if err != nil {
 		return err
-	}
-	if resp.StatusCode == http.StatusNoContent {
-		return fmt.Errorf("User %s is already a collaborator", username)
 	}
 
 	d.SetId(buildTwoPartID(repoName, username))


### PR DESCRIPTION
Closes #469 

### Notes 
* Previously, handling was added to validate the response returned from the Github API when an attempt was made to add a collaborator but this proved to be problematic and breaking 

Output of acceptance tests:
```
--- PASS: TestAccGithubRepositoryCollaborator_basic_personal (13.40s)
--- PASS: TestAccGithubRepositoryCollaborator_basic (26.76s)
--- PASS: TestAccGithubRepositoryCollaborator_caseInsensitive_personal (27.61s)
--- PASS: TestAccGithubRepositoryCollaborator_caseInsensitive (23.75s)
```