### PR TITLE
changelog: add breaking change to 2.5.0 for GHE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ BUG FIXES:
 
 BREAKING CHANGES:
 
-* `go-github` `v29.03` is incompatible with all currently known versions of GitHub Enterprise Server ([[#404](https://github.com/terraform-providers/terraform-provider-github/issues/404)])
+* `go-github` `v29.03` is incompatible with versions of GitHub Enterprise Server prior to `v2.21.5`. ([[#404](https://github.com/terraform-providers/terraform-provider-github/issues/404)])
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ BUG FIXES:
 
 ## 2.5.0 (March 30, 2020)
 
-BREAKING CHANGES:
+REGRESSION:
 
 * `go-github` `v29.03` is incompatible with versions of GitHub Enterprise Server prior to `v2.21.5`. ([[#404](https://github.com/terraform-providers/terraform-provider-github/issues/404)])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ BUG FIXES:
 
 ## 2.5.0 (March 30, 2020)
 
+BREAKING CHANGES:
+
+* `go-github` `v29.03` is incompatible with all currently known versions of GitHub Enterprise Server ([[#404](https://github.com/terraform-providers/terraform-provider-github/issues/404)])
+
 ENHANCEMENTS:
 
 * Add `apps` To `github_branch_protection` Restrictions


### PR DESCRIPTION
This is to document #404 in the changelog so nobody else has to deal with this.