### PR TITLE
repo webhook url is sensitive

### DIFF
--- a/github/schema_webhook_configuration.go
+++ b/github/schema_webhook_configuration.go
@@ -12,8 +12,9 @@ func webhookConfigurationSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"url": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:      schema.TypeString,
+					Required:  true,
+					Sensitive: true,
 				},
 				"content_type": {
 					Type:     schema.TypeString,

--- a/website/docs/r/repository_webhook.html.markdown
+++ b/website/docs/r/repository_webhook.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 The following additional attributes are exported:
 
-* `url` - URL of the webhook
+* `url` - URL of the webhook.  This is a sensitive attribute because it may include basic auth credentials.
 
 ## Import
 


### PR DESCRIPTION
This marks URL of repo webhook as sensitive.  A use case is for atlantis server where URL contains basic auth credentials.