### PR TITLE
Add Vulnerability Alert Fixes & Testing

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -302,7 +302,7 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 		createVulnerabilityAlerts = client.Repositories.DisableVulnerabilityAlerts
 	}
 	if createVulnerabilityAlerts != nil {
-		_, err = createVulnerabilityAlerts(ctx, orgName, repoName)
+		_, err := createVulnerabilityAlerts(ctx, owner, repoName)
 		if err != nil {
 			return err
 		}
@@ -376,7 +376,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("template", []interface{}{})
 	}
 
-	vulnerabilityAlerts, _, err := client.Repositories.GetVulnerabilityAlerts(ctx, orgName, repoName)
+	vulnerabilityAlerts, _, err := client.Repositories.GetVulnerabilityAlerts(ctx, owner, repoName)
 	if err != nil {
 		return fmt.Errorf("Error reading repository vulnerability alerts: %v", err)
 	}
@@ -446,7 +446,7 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 			updateVulnerabilityAlerts = client.Repositories.EnableVulnerabilityAlerts
 		}
 
-		_, err = updateVulnerabilityAlerts(ctx, orgName, repoName)
+		_, err = updateVulnerabilityAlerts(ctx, owner, repoName)
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -491,6 +491,130 @@ func TestAccGithubRepositories(t *testing.T) {
 
 	})
 
+	t.Run("configures vulnerability alerts", func(t *testing.T) {
+
+		t.Run("for a public repository", func(t *testing.T) {
+
+			config := fmt.Sprintf(`
+				resource "github_repository" "test" {
+					name       = "tf-acc-test-pub-vuln-%s"
+					visibility = "public"
+				}
+			`, randomID)
+
+			checks := map[string]resource.TestCheckFunc{
+				"before": resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"github_repository.test", "vulnerability_alerts",
+						"false",
+					),
+				),
+				"after": resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"github_repository.test", "vulnerability_alerts",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"github_repository.test", "visibility",
+						"public",
+					),
+				),
+			}
+
+			testCase := func(t *testing.T, mode string) {
+				resource.Test(t, resource.TestCase{
+					PreCheck:  func() { skipUnlessMode(t, mode) },
+					Providers: testAccProviders,
+					Steps: []resource.TestStep{
+						{
+							Config: config,
+							Check:  checks["before"],
+						},
+						{
+							Config: strings.Replace(config,
+								`}`,
+								"vulnerability_alerts = true\n}", 1),
+							Check: checks["after"],
+						},
+					},
+				})
+			}
+
+			t.Run("with an anonymous account", func(t *testing.T) {
+				t.Skip("anonymous account not supported for this operation")
+			})
+
+			t.Run("with an individual account", func(t *testing.T) {
+				testCase(t, individual)
+			})
+
+			t.Run("with an organization account", func(t *testing.T) {
+				testCase(t, organization)
+			})
+		})
+
+		t.Run("for a private repository", func(t *testing.T) {
+
+			config := fmt.Sprintf(`
+				resource "github_repository" "test" {
+					name       = "tf-acc-test-prv-vuln-%s"
+					visibility = "private"
+				}
+			`, randomID)
+
+			checks := map[string]resource.TestCheckFunc{
+				"before": resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"github_repository.test", "vulnerability_alerts",
+						"false",
+					),
+				),
+				"after": resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"github_repository.test", "vulnerability_alerts",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"github_repository.test", "visibility",
+						"private",
+					),
+				),
+			}
+
+			testCase := func(t *testing.T, mode string) {
+				resource.Test(t, resource.TestCase{
+					PreCheck:  func() { skipUnlessMode(t, mode) },
+					Providers: testAccProviders,
+					Steps: []resource.TestStep{
+						{
+							Config: config,
+							Check:  checks["before"],
+						},
+						{
+							Config: strings.Replace(config,
+								`}`,
+								"vulnerability_alerts = true\n}", 1),
+							Check: checks["after"],
+						},
+					},
+				})
+			}
+
+			t.Run("with an anonymous account", func(t *testing.T) {
+				t.Skip("anonymous account not supported for this operation")
+			})
+
+			t.Run("with an individual account", func(t *testing.T) {
+				testCase(t, individual)
+			})
+
+			t.Run("with an organization account", func(t *testing.T) {
+				testCase(t, organization)
+			})
+		})
+
+	})
+
 }
 
 func testSweepRepositories(region string) error {


### PR DESCRIPTION
Follow up to https://github.com/terraform-providers/terraform-provider-github/pull/444 which adds testing and corrects compiler errors.

Tests are passing [here](https://github.com/terraformtesting/terraform-provider-github/actions/runs/266900277) until this repo is set up.