### PR TITLE
Update Default Branch References From "master" To "main"

### DIFF
--- a/examples/repository_delete_branch_on_merge/main.tf
+++ b/examples/repository_delete_branch_on_merge/main.tf
@@ -1,7 +1,7 @@
 resource "github_repository" "delete_branch_on_merge" {
   name                   = "delete_branch_on_merge"
   description            = "A repository with delete-branch-on-merge configured"
-  default_branch         = "master"
+  default_branch         = "main"
   private                = true
   delete_branch_on_merge = true
 }

--- a/github/data_source_github_branch_test.go
+++ b/github/data_source_github_branch_test.go
@@ -23,7 +23,7 @@ func TestAccGithubBranchDataSource(t *testing.T) {
 
 			data "github_branch" "test" {
 				repository = github_repository.test.id
-				branch = "master"
+				branch = "main"
 			}
 		`, randomID)
 

--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -33,7 +33,7 @@ func resourceGithubBranch() *schema.Resource {
 			},
 			"source_branch": {
 				Type:     schema.TypeString,
-				Default:  "master",
+				Default:  "main",
 				Optional: true,
 				ForceNew: true,
 			},
@@ -172,7 +172,7 @@ func resourceGithubBranchImport(d *schema.ResourceData, meta interface{}) ([]*sc
 		return nil, err
 	}
 
-	sourceBranch := "master"
+	sourceBranch := "main"
 	if strings.Contains(branchName, ":") {
 		branchName, sourceBranch, err = parseTwoPartID(branchName, "branch", "source_branch")
 		if err != nil {

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -24,7 +24,7 @@ func TestAccGithubBranchProtection(t *testing.T) {
 		resource "github_branch_protection" "test" {
 
 		  repository_id  = github_repository.test.node_id
-		  pattern        = "master"
+		  pattern        = "main"
 
 		}
 
@@ -32,7 +32,7 @@ func TestAccGithubBranchProtection(t *testing.T) {
 
 		check := resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttr(
-				"github_branch_protection.test", "pattern", "master",
+				"github_branch_protection.test", "pattern", "main",
 			),
 			resource.TestCheckResourceAttr(
 				"github_branch_protection.test", "require_signed_commits", "false",
@@ -87,7 +87,7 @@ func TestAccGithubBranchProtection(t *testing.T) {
 			resource "github_branch_protection" "test" {
 
 			  repository_id  = github_repository.test.node_id
-			  pattern        = "master"
+			  pattern        = "main"
 
 				required_status_checks {
 			    strict   = true
@@ -143,7 +143,7 @@ func TestAccGithubBranchProtection(t *testing.T) {
 			resource "github_branch_protection" "test" {
 
 			  repository_id  = github_repository.test.node_id
-			  pattern        = "master"
+			  pattern        = "main"
 
 				required_pull_request_reviews {
 						dismiss_stale_reviews      = true
@@ -211,7 +211,7 @@ func TestAccGithubBranchProtection(t *testing.T) {
 			resource "github_branch_protection" "test" {
 
 			  repository_id = github_repository.test.node_id
-			  pattern       = "master"
+			  pattern       = "main"
 
 			  push_restrictions = [
 			    data.github_user.test.node_id,

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -216,8 +216,8 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Owner).v3client
 
-	if branchName, hasDefaultBranch := d.GetOk("default_branch"); hasDefaultBranch && (branchName != "master") {
-		return fmt.Errorf("Cannot set the default branch on a new repository to something other than 'master'.")
+	if branchName, hasDefaultBranch := d.GetOk("default_branch"); hasDefaultBranch && (branchName != "main") {
+		return fmt.Errorf("Cannot set the default branch on a new repository to something other than 'main'.")
 	}
 
 	repoReq := resourceGithubRepositoryObject(d)
@@ -406,8 +406,8 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 	// Can only set `default_branch` on an already created repository with the target branches ref already in-place
 	if v, ok := d.GetOk("default_branch"); ok {
 		branch := v.(string)
-		// If branch is "master", and the repository hasn't been initialized yet, setting this value will fail
-		if branch != "master" {
+		// If branch is "main", and the repository hasn't been initialized yet, setting this value will fail
+		if branch != "main" {
 			repoReq.DefaultBranch = &branch
 		}
 	}

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -21,7 +21,7 @@ func resourceGithubRepositoryFile() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), ":")
-				branch := "master"
+				branch := "main"
 
 				if len(parts) > 2 {
 					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<file path> (when branch is \"master\") or <repository>/<file path>:<branch>")
@@ -69,7 +69,7 @@ func resourceGithubRepositoryFile() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Description: "The branch name, defaults to \"master\"",
-				Default:     "master",
+				Default:     "main",
 			},
 			"commit_message": {
 				Type:        schema.TypeString,

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -236,7 +236,7 @@ func TestAccGithubRepositories(t *testing.T) {
 			resource "github_repository" "test" {
 			  name           = "tf-acc-test-%[1]s"
 			  description    = "Terraform acceptance tests %[1]s"
-				default_branch = "master"
+				default_branch = "main"
 			}
 		`, randomID)
 
@@ -244,7 +244,7 @@ func TestAccGithubRepositories(t *testing.T) {
 			"before": resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr(
 					"github_repository.test", "default_branch",
-					"master",
+					"main",
 				),
 			),
 			// FIXME: Deferred until https://github.com/terraform-providers/terraform-provider-github/issues/513
@@ -268,7 +268,7 @@ func TestAccGithubRepositories(t *testing.T) {
 					},
 					// {
 					// 	Config: strings.Replace(config,
-					// 		`default_branch = "master"`,
+					// 		`default_branch = "main"`,
 					// 		`default_branch = "default"`, 1),
 					// 	Check: checks["after"],
 					// },

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -19,7 +19,7 @@ This resource allows you to configure branch protection for repositories in your
 # to the branch.
 resource "github_branch_protection" "example" {
   repository_id  = github_repository.example.node_id
-  pattern        = "master"
+  pattern        = "main"
   enforce_admins = true
 
   required_status_checks {


### PR DESCRIPTION
New repositories no longer come pre-configured with the "master" branch.  All references to that string have been updated with "main".  This will help with a few broken tests and will clear the way for assigning the default branch to any value on repo creation.

/cc 
https://github.com/github/renaming#new-repositories-use-main-as-default-branch-name
/cc https://github.com/terraform-providers/terraform-provider-github/issues/513