### PR TITLE
Fix documentation for `dismissal_restrictions`

### DIFF
--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 `required_pull_request_reviews` supports the following arguments:
 
 * `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
-* `dismissal_actors`: (Optional) The list of actor IDs with dismissal access.
+* `dismissal_restrictions`: (Optional) The list of actor IDs with dismissal access.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
 * `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches Github's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
 


### PR DESCRIPTION
In the [current documentation for the resource `github_branch_protection`](https://github.com/terraform-providers/terraform-provider-github/blob/52bfa407a0bb9f34f84847f3aaaf57e2c44a8355/website/docs/r/branch_protection.html.markdown), it is noted [under `required_pull_request_reviews`](https://github.com/terraform-providers/terraform-provider-github/blob/52bfa407a0bb9f34f84847f3aaaf57e2c44a8355/website/docs/r/branch_protection.html.markdown) that:

> `dismissal_actors`: (Optional) The list of actor IDs with dismissal access.

This differs from the parameter name `dismissal_restrictions` as defined: https://github.com/terraform-providers/terraform-provider-github/blob/9c532df8193907ff250481be9060290f65bedd66/github/util_v4_consts.go#L15

This PR updates the documentation to reflect the parameter name as defined in `github/util_v4_consts.go`, under the assumption that the intended parameter name was `dismissal_restrictions` rather than `dismissal_actors`.

Relates to #337 and comments in #566 