### PR TITLE
Revert Config Changes To `github_branch_protection`

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -17,16 +17,26 @@ func resourceGithubBranchProtection() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			// Input
+			REPOSITORY: {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			REPOSITORY_ID: {
 				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "GraphQL `node_id` of a repository",
+			},
+			PROTECTION_BRANCH: {
+				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: "",
+				Description: "`pattern` for a `BranchProtectionRule`",
+				Deprecated:  "use `pattern` after v4.0.0 instead",
 			},
 			PROTECTION_PATTERN: {
 				Type:        schema.TypeString,
-				Required:    true,
-				Description: "",
+				Computed:    true,
+				Description: "`pattern` for a `BranchProtectionRule`",
 			},
 			PROTECTION_IS_ADMIN_ENFORCED: {
 				Type:     schema.TypeBool,
@@ -178,6 +188,12 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 	err = d.Set(PROTECTION_PATTERN, protection.Pattern)
 	if err != nil {
 		log.Printf("[WARN] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_PATTERN, protection.Repository.Name, protection.Pattern, d.Id())
+	}
+
+	// FIXME: Remove in favour of PROTECTION_PATTERN on next major release
+	err = d.Set(PROTECTION_BRANCH, protection.Pattern)
+	if err != nil {
+		log.Printf("[WARN] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_BRANCH, protection.Repository.Name, protection.Pattern, d.Id())
 	}
 
 	err = d.Set(PROTECTION_IS_ADMIN_ENFORCED, protection.IsAdminEnforced)

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -15,22 +15,21 @@ func TestAccGithubBranchProtection(t *testing.T) {
 	t.Run("configures default settings when empty", func(t *testing.T) {
 
 		config := fmt.Sprintf(`
-
 		resource "github_repository" "test" {
 		  name      = "tf-acc-test-%s"
 		  auto_init = true
 		}
 
 		resource "github_branch_protection" "test" {
-
-		  repository_id  = github_repository.test.node_id
-		  pattern        = "main"
-
+		  repository = github_repository.test.name
+		  branch     = "main"
 		}
-
 	`, randomID)
 
 		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_branch_protection.test", "branch", "main",
+			),
 			resource.TestCheckResourceAttr(
 				"github_branch_protection.test", "pattern", "main",
 			),
@@ -78,7 +77,6 @@ func TestAccGithubBranchProtection(t *testing.T) {
 	t.Run("configures required status checks", func(t *testing.T) {
 
 		config := fmt.Sprintf(`
-
 			resource "github_repository" "test" {
 			  name      = "tf-acc-test-%s"
 			  auto_init = true
@@ -86,16 +84,15 @@ func TestAccGithubBranchProtection(t *testing.T) {
 
 			resource "github_branch_protection" "test" {
 
-			  repository_id  = github_repository.test.node_id
-			  pattern        = "main"
+			  repository = github_repository.test.name
+			  branch     = "main"
 
-				required_status_checks {
+			  required_status_checks {
 			    strict   = true
 			    contexts = ["github/foo"]
 			  }
 
 			}
-
 	`, randomID)
 
 		check := resource.ComposeAggregateTestCheckFunc(
@@ -134,7 +131,6 @@ func TestAccGithubBranchProtection(t *testing.T) {
 	t.Run("configures required pull request reviews", func(t *testing.T) {
 
 		config := fmt.Sprintf(`
-
 			resource "github_repository" "test" {
 			  name      = "tf-acc-test-%s"
 			  auto_init = true
@@ -142,16 +138,15 @@ func TestAccGithubBranchProtection(t *testing.T) {
 
 			resource "github_branch_protection" "test" {
 
-			  repository_id  = github_repository.test.node_id
-			  pattern        = "main"
+			  repository = github_repository.test.name
+			  branch     = "main"
 
-				required_pull_request_reviews {
-						dismiss_stale_reviews      = true
-						require_code_owner_reviews = true
-				}
+			  required_pull_request_reviews {
+			    dismiss_stale_reviews      = true
+			    require_code_owner_reviews = true
+			  }
 
 			}
-
 	`, randomID)
 
 		check := resource.ComposeAggregateTestCheckFunc(
@@ -210,8 +205,8 @@ func TestAccGithubBranchProtection(t *testing.T) {
 
 			resource "github_branch_protection" "test" {
 
-			  repository_id = github_repository.test.node_id
-			  pattern       = "main"
+			  repository = github_repository.test.name
+			  branch       = "main"
 
 			  push_restrictions = [
 			    data.github_user.test.node_id,

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/shurcooL/githubv4"
 )
@@ -67,11 +68,16 @@ type BranchProtectionResourceData struct {
 func branchProtectionResourceData(d *schema.ResourceData, meta interface{}) (BranchProtectionResourceData, error) {
 	data := BranchProtectionResourceData{}
 
-	if v, ok := d.GetOk(REPOSITORY_ID); ok {
-		data.RepositoryID = v.(string)
+	if v, ok := d.GetOk(REPOSITORY); ok {
+		repoID, err := getRepositoryID(v.(string), meta)
+		if err != nil {
+			return data, err
+		}
+		data.RepositoryID = repoID.(string)
 	}
 
-	if v, ok := d.GetOk(PROTECTION_PATTERN); ok {
+	// FIXME: Re-instate to PROTECTION_PATTERN on next major release
+	if v, ok := d.GetOk(PROTECTION_BRANCH); ok {
 		data.Pattern = v.(string)
 	}
 

--- a/github/util_v4_consts.go
+++ b/github/util_v4_consts.go
@@ -4,6 +4,7 @@ const (
 	PROTECTION_DISMISSES_STALE_REVIEWS         = "dismiss_stale_reviews"
 	PROTECTION_IS_ADMIN_ENFORCED               = "enforce_admins"
 	PROTECTION_PATTERN                         = "pattern"
+	PROTECTION_BRANCH                          = "branch"
 	PROTECTION_REQUIRED_APPROVING_REVIEW_COUNT = "required_approving_review_count"
 	PROTECTION_REQUIRED_STATUS_CHECK_CONTEXTS  = "contexts"
 	PROTECTION_REQUIRES_APPROVING_REVIEWS      = "required_pull_request_reviews"
@@ -14,5 +15,6 @@ const (
 	PROTECTION_RESTRICTS_PUSHES                = "push_restrictions"
 	PROTECTION_RESTRICTS_REVIEW_DISMISSALS     = "dismissal_restrictions"
 
+	REPOSITORY    = "repository"
 	REPOSITORY_ID = "repository_id"
 )

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -61,7 +61,7 @@ resource "github_team_repository" "example" {
 The following arguments are supported:
 
 * `repository` - (Required) The repository associated with this branch protection rule.
-* `branch` - (Deprecated) Identifies the protection rule pattern.
+* `branch` - (Deprecated) Identifies the protection rule pattern. In v4.0.0, will become `pattern`.
 * `enforce_admins` - (Optional) Boolean, setting this to `true` enforces status checks for repository administrators.
 * `require_signed_commits` - (Optional) Boolean, setting this to `true` requires all commits to be signed with GPG.
 * `required_status_checks` - (Optional) Enforce restrictions for required status checks. See [Required Status Checks](#required-status-checks) below for details.

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -18,8 +18,8 @@ This resource allows you to configure branch protection for repositories in your
 # the "ci/travis" context to be passing and only allow the engineers team merge
 # to the branch.
 resource "github_branch_protection" "example" {
-  repository_id  = github_repository.example.node_id
-  pattern        = "main"
+  repository     = github_repository.example.name
+  branch         = "main"
   enforce_admins = true
 
   required_status_checks {
@@ -60,8 +60,8 @@ resource "github_team_repository" "example" {
 
 The following arguments are supported:
 
-* `repository_id` - (Required) The repository associated with this branch protection rule.
-* `pattern` - (Required) Identifies the protection rule pattern.
+* `repository` - (Required) The repository associated with this branch protection rule.
+* `branch` - (Deprecated) Identifies the protection rule pattern.
 * `enforce_admins` - (Optional) Boolean, setting this to `true` enforces status checks for repository administrators.
 * `require_signed_commits` - (Optional) Boolean, setting this to `true` requires all commits to be signed with GPG.
 * `required_status_checks` - (Optional) Enforce restrictions for required status checks. See [Required Status Checks](#required-status-checks) below for details.


### PR DESCRIPTION
`repository` was previously removed in favour of `repository_id`.  We 
revert to `repository` here and transition `repository_id` to a computed 
value that is derived from a GraphQL lookup against the provided 
`repository`.

`branch` was previously removed in favour of `pattern`.  Similarly, 
`pattern` becomes computed and takes the value of `branch`.  `branch` 
now becomes deprecated for removal in the next major release.

Fixes https://github.com/terraform-providers/terraform-provider-github/issues/566