### PR TITLE
[Docs] dismissal_actors has been replaced by dismissal_restrictions in github_branch_protection

### DIFF
--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 `required_pull_request_reviews` supports the following arguments:
 
 * `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
-* `dismissal_actors`: (Optional) The list of actor IDs with dismissal access.
+* `dismissal_restrictions`: (Optional) The list of actor IDs with dismissal access.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
 * `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches Github's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
 


### PR DESCRIPTION
The example in the docs was good but not the reference