### PR TITLE
Add in `github_actions_organization_secret`

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -106,6 +106,10 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"repo_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -158,6 +162,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("http_clone_url", repo.GetCloneURL())
 	d.Set("archived", repo.GetArchived())
 	d.Set("node_id", repo.GetNodeID())
+	d.Set("repo_id", repo.GetID())
 
 	err = d.Set("topics", flattenStringList(repo.Topics))
 	if err != nil {

--- a/github/provider.go
+++ b/github/provider.go
@@ -41,28 +41,29 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"github_actions_secret":           resourceGithubActionsSecret(),
-			"github_branch":                   resourceGithubBranch(),
-			"github_branch_protection":        resourceGithubBranchProtection(),
-			"github_issue_label":              resourceGithubIssueLabel(),
-			"github_membership":               resourceGithubMembership(),
-			"github_organization_block":       resourceOrganizationBlock(),
-			"github_organization_project":     resourceGithubOrganizationProject(),
-			"github_organization_webhook":     resourceGithubOrganizationWebhook(),
-			"github_project_column":           resourceGithubProjectColumn(),
-			"github_repository_collaborator":  resourceGithubRepositoryCollaborator(),
-			"github_repository_deploy_key":    resourceGithubRepositoryDeployKey(),
-			"github_repository_file":          resourceGithubRepositoryFile(),
-			"github_repository_project":       resourceGithubRepositoryProject(),
-			"github_repository_webhook":       resourceGithubRepositoryWebhook(),
-			"github_repository":               resourceGithubRepository(),
-			"github_team_membership":          resourceGithubTeamMembership(),
-			"github_team_repository":          resourceGithubTeamRepository(),
-			"github_team_sync_group_mapping":  resourceGithubTeamSyncGroupMapping(),
-			"github_team":                     resourceGithubTeam(),
-			"github_user_gpg_key":             resourceGithubUserGpgKey(),
-			"github_user_invitation_accepter": resourceGithubUserInvitationAccepter(),
-			"github_user_ssh_key":             resourceGithubUserSshKey(),
+			"github_actions_organization_secret": resourceGithubActionsOrganizationSecret(),
+			"github_actions_secret":              resourceGithubActionsSecret(),
+			"github_branch":                      resourceGithubBranch(),
+			"github_branch_protection":           resourceGithubBranchProtection(),
+			"github_issue_label":                 resourceGithubIssueLabel(),
+			"github_membership":                  resourceGithubMembership(),
+			"github_organization_block":          resourceOrganizationBlock(),
+			"github_organization_project":        resourceGithubOrganizationProject(),
+			"github_organization_webhook":        resourceGithubOrganizationWebhook(),
+			"github_project_column":              resourceGithubProjectColumn(),
+			"github_repository_collaborator":     resourceGithubRepositoryCollaborator(),
+			"github_repository_deploy_key":       resourceGithubRepositoryDeployKey(),
+			"github_repository_file":             resourceGithubRepositoryFile(),
+			"github_repository_project":          resourceGithubRepositoryProject(),
+			"github_repository_webhook":          resourceGithubRepositoryWebhook(),
+			"github_repository":                  resourceGithubRepository(),
+			"github_team_membership":             resourceGithubTeamMembership(),
+			"github_team_repository":             resourceGithubTeamRepository(),
+			"github_team_sync_group_mapping":     resourceGithubTeamSyncGroupMapping(),
+			"github_team":                        resourceGithubTeam(),
+			"github_user_gpg_key":                resourceGithubUserGpgKey(),
+			"github_user_invitation_accepter":    resourceGithubUserInvitationAccepter(),
+			"github_user_ssh_key":                resourceGithubUserSshKey(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -107,7 +108,6 @@ func init() {
 
 func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 	return func(d *schema.ResourceData) (interface{}, error) {
-
 		anonymous := true
 		if d.Get("token").(string) != "" {
 			anonymous = false

--- a/github/resource_github_actions_organization_secret.go
+++ b/github/resource_github_actions_organization_secret.go
@@ -1,0 +1,159 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceGithubActionsOrganizationSecret() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubActionsOrganizationSecretCreateOrUpdate,
+		Read:   resourceGithubActionsOrganizationSecretRead,
+		Update: resourceGithubActionsOrganizationSecretCreateOrUpdate,
+		Delete: resourceGithubActionsOrganizationSecretDelete,
+
+		Schema: map[string]*schema.Schema{
+			"secret_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"plaintext_value": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
+			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateValueFunc([]string{"all", "private", "selected"}),
+				ForceNew:     true,
+			},
+			"selected_repository_ids": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+				Set:      schema.HashInt,
+				Optional: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGithubActionsOrganizationSecretCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	ctx := context.Background()
+
+	secretName := d.Get("secret_name").(string)
+	plaintextValue := d.Get("plaintext_value").(string)
+
+	visibility := d.Get("visibility").(string)
+	selectedRepositories, hasSelectedRepositories := d.GetOk("selected_repository_ids")
+
+	if visibility == "selected" && !hasSelectedRepositories {
+		return fmt.Errorf("Cannot use visbility set to selected without selected_repository_ids")
+	} else if visibility != "selected" && hasSelectedRepositories {
+		return fmt.Errorf("Cannot use selected_repository_ids without visibility being set to selected")
+	}
+
+	selectedRepositoryIDs := []int64{}
+
+	if hasSelectedRepositories {
+		ids := selectedRepositories.(*schema.Set).List()
+
+		for _, id := range ids {
+			selectedRepositoryIDs = append(selectedRepositoryIDs, int64(id.(int)))
+		}
+	}
+
+	keyId, publicKey, err := getOrganizationPublicKeyDetails(owner, meta)
+	if err != nil {
+		return err
+	}
+
+	encryptedText, err := encryptPlaintext(plaintextValue, publicKey)
+	if err != nil {
+		return err
+	}
+
+	// Create an EncryptedSecret and encrypt the plaintext value into it
+	eSecret := &github.EncryptedSecret{
+		Name:                  secretName,
+		KeyID:                 keyId,
+		Visibility:            visibility,
+		SelectedRepositoryIDs: selectedRepositoryIDs,
+		EncryptedValue:        base64.StdEncoding.EncodeToString(encryptedText),
+	}
+
+	_, err = client.Actions.CreateOrUpdateOrgSecret(ctx, owner, eSecret)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(secretName)
+	return resourceGithubActionsOrganizationSecretRead(d, meta)
+}
+
+func resourceGithubActionsOrganizationSecretRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	ctx := context.Background()
+
+	secret, _, err := client.Actions.GetOrgSecret(ctx, owner, d.Id())
+	if err != nil {
+		if ghErr, ok := err.(*github.ErrorResponse); ok {
+			if ghErr.Response.StatusCode == http.StatusNotFound {
+				log.Printf("[WARN] Removing actions secret %s from state because it no longer exists in GitHub",
+					d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	d.Set("plaintext_value", d.Get("plaintext_value"))
+	d.Set("updated_at", secret.UpdatedAt.String())
+	d.Set("created_at", secret.CreatedAt.String())
+
+	return nil
+}
+
+func resourceGithubActionsOrganizationSecretDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+
+	log.Printf("[DEBUG] Deleting secret: %s", d.Id())
+	_, err := client.Actions.DeleteOrgSecret(ctx, orgName, d.Id())
+	return err
+}
+
+func getOrganizationPublicKeyDetails(owner string, meta interface{}) (keyId, pkValue string, err error) {
+	client := meta.(*Owner).v3client
+	ctx := context.Background()
+
+	publicKey, _, err := client.Actions.GetOrgPublicKey(ctx, owner)
+	if err != nil {
+		return keyId, pkValue, err
+	}
+
+	return publicKey.GetKeyID(), publicKey.GetKey(), err
+}

--- a/github/resource_github_actions_organization_secret_test.go
+++ b/github/resource_github_actions_organization_secret_test.go
@@ -1,0 +1,119 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubActionsOrganizationSecret(t *testing.T) {
+	t.Run("creates and updates secrets without error", func(t *testing.T) {
+		secretValue := "super_secret_value"
+		updatedSecretValue := "updated_super_secret_value"
+
+		config := fmt.Sprintf(`
+			resource "github_actions_organization_secret" "test_secret" {
+			  secret_name      = "test_secret_name"
+			  plaintext_value  = "%s"
+			  visibility       = "private"
+			}
+		`, secretValue)
+
+		checks := map[string]resource.TestCheckFunc{
+			"before": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_actions_organization_secret.test_secret", "plaintext_value",
+					secretValue,
+				),
+				resource.TestCheckResourceAttrSet(
+					"github_actions_organization_secret.test_secret", "created_at",
+				),
+				resource.TestCheckResourceAttrSet(
+					"github_actions_organization_secret.test_secret", "updated_at",
+				),
+			),
+			"after": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_actions_organization_secret.test_secret", "plaintext_value",
+					updatedSecretValue,
+				),
+				resource.TestCheckResourceAttrSet(
+					"github_actions_organization_secret.test_secret", "created_at",
+				),
+				resource.TestCheckResourceAttrSet(
+					"github_actions_organization_secret.test_secret", "updated_at",
+				),
+			),
+		}
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  checks["before"],
+					},
+					{
+						Config: strings.Replace(config,
+							secretValue,
+							updatedSecretValue, 1),
+						Check: checks["after"],
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
+	t.Run("deletes secrets without error", func(t *testing.T) {
+		secretValue := "super_secret_value"
+
+		config := fmt.Sprintf(`
+				resource "github_actions_organization_secret" "test_secret" {
+					secret_name      = "test_secret_name"
+					plaintext_value  = "%s"
+					visibility       = "private"
+				}
+			`, secretValue)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config:  config,
+						Destroy: true,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}

--- a/github/resource_github_actions_secret.go
+++ b/github/resource_github_actions_secret.go
@@ -105,8 +105,8 @@ func resourceGithubActionsSecretRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("plaintext_value", d.Get("plaintext_value"))
-	d.Set("updated_at", secret.UpdatedAt.Format("default"))
-	d.Set("created_at", secret.CreatedAt.Format("default"))
+	d.Set("updated_at", secret.UpdatedAt.String())
+	d.Set("created_at", secret.CreatedAt.String())
 
 	return nil
 }

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -185,6 +185,10 @@ func resourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"repo_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -256,7 +260,6 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 				templateRepo,
 				&templateRepoReq,
 			)
-
 			if err != nil {
 				return err
 			}
@@ -272,7 +275,6 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 		} else {
 			// Create repository within authenticated user's account
 			repo, _, err = client.Repositories.Create(ctx, "", repoReq)
-
 		}
 		if err != nil {
 			return err
@@ -364,6 +366,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("archived", repo.GetArchived())
 	d.Set("topics", flattenStringList(repo.Topics))
 	d.Set("node_id", repo.GetNodeID())
+	d.Set("repo_id", repo.GetID())
 
 	if repo.TemplateRepository != nil {
 		d.Set("template", []interface{}{
@@ -386,7 +389,6 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
-
 	// Can only update a repository if it is not archived or the update is to
 	// archive the repository (unarchiving is not supported by the Github API)
 	if d.Get("archived").(bool) && !d.HasChange("archived") {

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -66,3 +66,7 @@ The following arguments are supported:
 * `git_clone_url` - URL that can be provided to `git clone` to clone the repository anonymously via the git protocol.
 
 * `svn_url` - URL that can be provided to `svn checkout` to check out the repository via GitHub's Subversion protocol emulation.
+
+* `node_id` - GraphQL global node id for use with v4 API
+
+* `repo_id` - Github ID for the repository

--- a/website/docs/r/actions_organization_secret.html.markdown
+++ b/website/docs/r/actions_organization_secret.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "github"
+page_title: "GitHub: github_actions_organization_secret"
+description: |-
+  Creates and manages an Action Secret within a GitHub organization
+---
+
+# github_actions_organization_secret
+
+This resource allows you to create and manage GitHub Actions secrets within your GitHub organization.
+You must have write access to a repository to use this resource.
+
+Secret values are encrypted using the [Go '/crypto/box' module](https://godoc.org/golang.org/x/crypto/nacl/box) which is
+interoperable with [libsodium](https://libsodium.gitbook.io/doc/). Libsodium is used by Github to decrypt secret values. 
+
+For the purposes of security, the contents of the `plaintext_value` field have been marked as `sensitive` to Terraform,
+but it is important to note that **this does not hide it from state files**. You should treat state as sensitive always.
+It is also advised that you do not store plaintext values in your code but rather populate the `plaintext_value`
+using fields from a resource, data source or variable as, while encrypted in state, these will be easily accessible
+in your code. See below for an example of this abstraction.
+
+## Example Usage
+
+```hcl
+resource "github_actions_organization_secret" "example_secret" {
+  secret_name      = "example_secret_name"
+  visiblity        = "private"
+  plaintext_value  = var.some_secret_string
+}
+```
+
+```hcl
+data "github_repository" "repo" {
+  full_name = "my-org/repo"
+}
+
+resource "github_actions_organization_secret" "example_secret" {
+  secret_name             = "example_secret_name"
+  visiblity               = "selected"
+  plaintext_value         = var.some_secret_string
+  selected_repository_ids = [data.github_repository.repo.repo_id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `secret_name`             - (Required) Name of the secret
+* `plaintext_value`         - (Required) Plaintext value of the secret to be encrypted
+* `visiblity`               - (Required) Configures the access that repositories have to the organization secret.
+                              Must be one of `all`, `private`, `selected`. `selected_repository_ids` is required if set to `selected`.
+* `selected_repository_ids` - (Optional) An array of repository ids that can access the organization secret.
+
+## Attributes Reference
+
+* `created_at`      - Date of actions_secret creation.
+* `updated_at`      - Date of actions_secret update.

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -106,6 +106,9 @@ The following additional attributes are exported:
 
 * `svn_url` - URL that can be provided to `svn checkout` to check out the repository via GitHub's Subversion protocol emulation.
 
+* `node_id` - GraphQL global node id for use with v4 API
+
+* `repo_id` - Github ID for the repository
 
 ## Import
 

--- a/website/github.erb
+++ b/website/github.erb
@@ -56,6 +56,9 @@
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
             <li>
+              <a href="/docs/providers/github/r/actions_organization_secret.html">github_actions_organization_secret</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/actions_secret.html">github_actions_secret</a>
             </li>
             <li>


### PR DESCRIPTION
This fixes #468. 

This almost exclusively follows the same patterns as `github_actions_secret`, but happy to address any feedback!

I also fixed the `updated_at` and `created_at` fields on `github_actions_secret` from the string `"default"` to being a proper timestamp. 