### PR TITLE
resource/github_repository_file: Add path parameter to reduce Github API calls

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -342,7 +342,7 @@ func checkRepositoryFileExists(client *github.Client, owner, repo, file, branch 
 func getFileCommit(client *github.Client, owner, repo, file, branch string) (*github.RepositoryCommit, error) {
 	ctx := context.WithValue(context.Background(), ctxId, fmt.Sprintf("%s/%s", repo, file))
 	opts := &github.CommitsListOptions{
-		SHA: branch,
+		SHA:  branch,
 		Path: file,
 	}
 	allCommits := []*github.RepositoryCommit{}

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -343,6 +343,7 @@ func getFileCommit(client *github.Client, owner, repo, file, branch string) (*gi
 	ctx := context.WithValue(context.Background(), ctxId, fmt.Sprintf("%s/%s", repo, file))
 	opts := &github.CommitsListOptions{
 		SHA: branch,
+		Path: file,
 	}
 	allCommits := []*github.RepositoryCommit{}
 	for {


### PR DESCRIPTION
If you have a repository with a very high number of commits, and you try to add a managed file using this provider, you will hit the Github API limit before the state for the file can be refreshed. The code currently returns ALL repository commits (https://github.com/terraform-providers/terraform-provider-github/blob/900aa92730cea0f5438063bfd410330749e89be3/github/resource_github_repository_file.go#L342), and then iterates through them to see if the commit has the managed file in its tree, and if so, returns the commit info. Since Github limits API calls to 5,000 per hour, any repository with ~5,000 commits in its history will not be able to complete even one state refresh before hitting the limit.

Luckily, the Github API supports a path parameter (/repos/:owner/:repo/commits?path=path/to/file), which will only return commits for that file. This will significantly reduce the number of API calls that the provider needs to make to return the correct information for state.