### PR TITLE
remove `ForceNew` on `template*` as they are concerns only at creation time

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -105,13 +105,11 @@ func resourceGithubRepository() *schema.Resource {
 			},
 			"license_template": {
 				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Optional: true
 			},
 			"gitignore_template": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 			"archived": {
 				Type:     schema.TypeBool,
@@ -166,7 +164,6 @@ func resourceGithubRepository() *schema.Resource {
 			"template": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
There are a number of parameter resources that have been marked as `ForceNew: true` out of a desire in "correctness" by those that do not actually understand how these resources are used in the real world as well as the damage that can be done. No one wants to blow up a repository to change something like this, if they need to there is a mechanism built into terraform called [taint](https://www.terraform.io/docs/commands/taint.html). While there are some things that make sense for using `ForceNew` a repository for source control on properties that the API will ignore outside of creation is not one of them.

This is applying the same changes as #317 and inspired by https://github.com/terraform-providers/terraform-provider-github/issues/155#issuecomment-729901509

Signed-off-by: Ben Abrams <me@benabrams.it>