### PR TITLE
Fix unable to resolve node id for branch_protection

### DIFF
--- a/github/util_v4_repository.go
+++ b/github/util_v4_repository.go
@@ -38,11 +38,6 @@ func getRepositoryID(name string, meta interface{}) (githubv4.ID, error) {
 }
 
 func repositoryNodeIDExists(name string, meta interface{}) (bool, error) {
-	// Quick check for node ID length
-	if len(name) != 32 {
-		return false, nil
-	}
-
 	// API check if node ID exists
 	var query struct {
 		Node struct {

--- a/github/util_v4_repository.go
+++ b/github/util_v4_repository.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/shurcooL/githubv4"
 )
@@ -38,6 +39,12 @@ func getRepositoryID(name string, meta interface{}) (githubv4.ID, error) {
 }
 
 func repositoryNodeIDExists(name string, meta interface{}) (bool, error) {
+	// Check if the name is a base 64 encoded node ID
+	_, err := base64.StdEncoding.DecodeString(name)
+	if err != nil {
+		return false, nil
+	}
+
 	// API check if node ID exists
 	var query struct {
 		Node struct {
@@ -49,7 +56,7 @@ func repositoryNodeIDExists(name string, meta interface{}) (bool, error) {
 	}
 	ctx := context.Background()
 	client := meta.(*Owner).v4client
-	err := client.Query(ctx, &query, variables)
+	err = client.Query(ctx, &query, variables)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
After updating to version `4.0.1` we were experiencing issues with the `github_branch_protection` resource, any changes or new created branch protections would fail with the following error:
```
Error: Could not resolve to a Repository with the name 'org-name/MDEwOlJlcG9zaXRvcnkzOTgy'.
```

After looking deeper in the issue we found a check in the code looking for node id of 32 characters in length. To my knowledge the node id is never this long and as it is base64 encoded can be variable in length. Proposing to remove this check and replace it with a check if it is valid base64 instead.

This was only tested on a private hosted Github Enterprise.