### PR TITLE
Add diff suppression function to the branch protection resource

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -68,6 +68,7 @@ func resourceGithubBranchProtection() *schema.Resource {
 			PROTECTION_REQUIRES_STATUS_CHECKS: {
 				Type:     schema.TypeList,
 				Optional: true,
+				DiffSuppressFunc: statusChecksDiffSuppression,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						PROTECTION_REQUIRES_STRICT_STATUS_CHECKS: {

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -274,3 +274,28 @@ func getBranchProtectionID(name string, pattern string, meta interface{}) (githu
 
 	return id, nil
 }
+
+func statusChecksDiffSuppression(k, old, new string, d *schema.ResourceData) bool {
+	data := BranchProtectionResourceData{}
+	checks := false
+
+	if v, ok := d.GetOk(PROTECTION_REQUIRES_STATUS_CHECKS); ok {
+		vL := v.([]interface{})
+		for _, v := range vL {
+			if v == nil {
+				break
+			}
+
+			m := v.(map[string]interface{})
+			data.RequiredStatusCheckContexts = expandNestedSet(m, PROTECTION_REQUIRED_STATUS_CHECK_CONTEXTS)
+			if len(data.RequiredStatusCheckContexts) > 0 {
+				checks = true
+			}
+		}
+	}
+
+	if old == "0" && new == "1" && !checks {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Adding a diff suppression function to the branch protection resource to
ignore the strict status check field if no contexts have been specified.

This resolves the issue with the GraphQL API returning a strict status
check value of "true" by default, regardless of contexts being set or
not.

Resolves: #572 