### PR TITLE
Added `allowsDeletions`and `allowsForcePushes`settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.1.0 (Unreleased)
+## 4.1.0 (December 01, 2020)
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 4.1.0 (Unreleased)
+
+ENHANCEMENTS:
+
+- Add `github_actions_organization_secret` resource ([#261](https://github.com/terraform-providers/terraform-provider-github/pull/261))
+- Add `github_repository_milestone` resource ([#470](https://github.com/terraform-providers/terraform-provider-github/pull/470))
+- Add `github_repository_milestone` data source ([#470](https://github.com/terraform-providers/terraform-provider-github/pull/470))
+- Add `github_project_card` resource ([#460](https://github.com/terraform-providers/terraform-provider-github/pull/460))
+- Add `github_branch_default` resource ([#194](https://github.com/terraform-providers/terraform-provider-github/pull/194))
+
+
 ## 4.0.1 (November 18, 2020)
 
 BUG FIXES:

--- a/github/provider.go
+++ b/github/provider.go
@@ -66,6 +66,7 @@ func Provider() terraform.ResourceProvider {
 			"github_user_gpg_key":                resourceGithubUserGpgKey(),
 			"github_user_invitation_accepter":    resourceGithubUserInvitationAccepter(),
 			"github_user_ssh_key":                resourceGithubUserSshKey(),
+			"github_branch_default":              resourceGithubBranchDefault(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/github/resource_github_branch_default.go
+++ b/github/resource_github_branch_default.go
@@ -1,0 +1,126 @@
+package github
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceGithubBranchDefault() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubBranchDefaultCreate,
+		Read:   resourceGithubBranchDefaultRead,
+		Delete: resourceGithubBranchDefaultDelete,
+		Update: resourceGithubBranchDefaultUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"branch": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGithubBranchDefaultCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	repoName := d.Get("repository").(string)
+	defaultBranch := d.Get("branch").(string)
+
+	ctx := context.Background()
+
+	repository, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return err
+	}
+
+	repository.DefaultBranch = &defaultBranch
+
+	log.Printf("[DEBUG] Creating branch default: %s (%s/%s)", defaultBranch, owner, repoName)
+	if _, _, err := client.Repositories.Edit(ctx, owner, repoName, repository); err != nil {
+		return err
+	}
+
+	d.SetId(repoName)
+
+	return resourceGithubBranchDefaultRead(d, meta)
+}
+
+func resourceGithubBranchDefaultRead(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	repoName := d.Id()
+
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+
+	repository, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return err
+	}
+
+	if repository.DefaultBranch == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("branch", *repository.DefaultBranch)
+	d.Set("repository", *repository.Name)
+	return nil
+}
+
+func resourceGithubBranchDefaultDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	repoName := d.Id()
+	defaultBranch := d.Get("branch").(string)
+
+	ctx := context.Background()
+
+	repository, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return err
+	}
+
+	repository.DefaultBranch = nil
+
+	log.Printf("[DEBUG] Removing branch default: %s (%s/%s)", defaultBranch, owner, repoName)
+	_, _, err = client.Repositories.Edit(ctx, owner, repoName, repository)
+	return err
+}
+
+func resourceGithubBranchDefaultUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	repoName := d.Id()
+	defaultBranch := d.Get("branch").(string)
+
+	ctx := context.Background()
+
+	repository, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return err
+	}
+
+	repository.DefaultBranch = &defaultBranch
+
+	log.Printf("[DEBUG] Updating branch default: %s (%s/%s)", defaultBranch, owner, repoName)
+	if _, _, err := client.Repositories.Edit(ctx, owner, repoName, repository); err != nil {
+		return err
+	}
+
+	return resourceGithubBranchDefaultRead(d, meta)
+}

--- a/github/resource_github_branch_default_test.go
+++ b/github/resource_github_branch_default_test.go
@@ -1,0 +1,121 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubBranchDefault(t *testing.T) {
+
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("creates and manages branch defaults", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+
+			resource "github_repository" "test" {
+				name      = "tf-acc-test-%s"
+				auto_init = true
+			}
+
+			resource "github_branch_default" "test" {
+				repository     = github_repository.test.name
+				branch         = "main"
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_branch_default.test", "branch",
+				"main",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_default.test", "repository",
+				fmt.Sprintf("tf-acc-test-%s", randomID),
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
+	t.Run("can be configured to override the default_branch of the repository", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name      = "tf-acc-test-%s"
+				default_branch = "main"
+				auto_init = true
+			}
+
+			resource "github_branch_default" "test" {
+				repository     = github_repository.test.name
+				branch         = "override"
+			}
+
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_branch_default.test", "branch",
+				"override",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_default.test", "repository",
+				fmt.Sprintf("tf-acc-test-%s", randomID),
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+}

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -28,6 +28,16 @@ func resourceGithubBranchProtection() *schema.Resource {
 				Required:    true,
 				Description: "",
 			},
+			PROTECTION_ALLOWS_DELETIONS: {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			PROTECTION_ALLOWS_FORCE_PUSHES: {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			PROTECTION_IS_ADMIN_ENFORCED: {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -121,6 +131,8 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 		return err
 	}
 	input := githubv4.CreateBranchProtectionRuleInput{
+		AllowsDeletions:              githubv4.NewBoolean(githubv4.Boolean(data.AllowsDeletions)),
+		AllowsForcePushes:            githubv4.NewBoolean(githubv4.Boolean(data.AllowsForcePushes)),
 		DismissesStaleReviews:        githubv4.NewBoolean(githubv4.Boolean(data.DismissesStaleReviews)),
 		IsAdminEnforced:              githubv4.NewBoolean(githubv4.Boolean(data.IsAdminEnforced)),
 		Pattern:                      githubv4.String(data.Pattern),
@@ -180,6 +192,16 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[WARN] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_PATTERN, protection.Repository.Name, protection.Pattern, d.Id())
 	}
 
+	err = d.Set(PROTECTION_ALLOWS_DELETIONS, protection.AllowsDeletions)
+	if err != nil {
+		log.Printf("[WARN] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_ALLOWS_DELETIONS, protection.Repository.Name, protection.Pattern, d.Id())
+	}
+
+	err = d.Set(PROTECTION_ALLOWS_FORCE_PUSHES, protection.AllowsForcePushes)
+	if err != nil {
+		log.Printf("[WARN] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_ALLOWS_FORCE_PUSHES, protection.Repository.Name, protection.Pattern, d.Id())
+	}
+
 	err = d.Set(PROTECTION_IS_ADMIN_ENFORCED, protection.IsAdminEnforced)
 	if err != nil {
 		log.Printf("[WARN] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_IS_ADMIN_ENFORCED, protection.Repository.Name, protection.Pattern, d.Id())
@@ -225,6 +247,8 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 	}
 	input := githubv4.UpdateBranchProtectionRuleInput{
 		BranchProtectionRuleID:       d.Id(),
+		AllowsDeletions:              githubv4.NewBoolean(githubv4.Boolean(data.AllowsDeletions)),
+		AllowsForcePushes:            githubv4.NewBoolean(githubv4.Boolean(data.AllowsForcePushes)),
 		DismissesStaleReviews:        githubv4.NewBoolean(githubv4.Boolean(data.DismissesStaleReviews)),
 		IsAdminEnforced:              githubv4.NewBoolean(githubv4.Boolean(data.IsAdminEnforced)),
 		Pattern:                      githubv4.NewString(githubv4.String(data.Pattern)),

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -102,6 +102,7 @@ func resourceGithubRepository() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "Can only be set after initial repository creation, and only if the target branch exists",
+				Deprecated:  "Use the github_branch_default resource instead",
 			},
 			"license_template": {
 				Type:     schema.TypeString,

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -31,6 +31,8 @@ type BranchProtectionRule struct {
 	ReviewDismissalAllowances struct {
 		Nodes []ActorTypes
 	} `graphql:"reviewDismissalAllowances(first: 100)"`
+	AllowsDeletions              githubv4.Boolean
+	AllowsForcePushes            githubv4.Boolean
 	DismissesStaleReviews        githubv4.Boolean
 	ID                           githubv4.ID
 	IsAdminEnforced              githubv4.Boolean
@@ -47,6 +49,8 @@ type BranchProtectionRule struct {
 }
 
 type BranchProtectionResourceData struct {
+	AllowsDeletions              bool
+	AllowsForcePushes            bool
 	BranchProtectionRuleID       string
 	DismissesStaleReviews        bool
 	IsAdminEnforced              bool
@@ -78,6 +82,14 @@ func branchProtectionResourceData(d *schema.ResourceData, meta interface{}) (Bra
 
 	if v, ok := d.GetOk(PROTECTION_PATTERN); ok {
 		data.Pattern = v.(string)
+	}
+
+	if v, ok := d.GetOk(PROTECTION_ALLOWS_DELETIONS); ok {
+		data.AllowsDeletions = v.(bool)
+	}
+
+	if v, ok := d.GetOk(PROTECTION_ALLOWS_FORCE_PUSHES); ok {
+		data.AllowsForcePushes = v.(bool)
 	}
 
 	if v, ok := d.GetOk(PROTECTION_IS_ADMIN_ENFORCED); ok {

--- a/github/util_v4_consts.go
+++ b/github/util_v4_consts.go
@@ -1,6 +1,8 @@
 package github
 
 const (
+	PROTECTION_ALLOWS_DELETIONS                = "allows_deletions"
+	PROTECTION_ALLOWS_FORCE_PUSHES             = "allows_force_pushes"
 	PROTECTION_DISMISSES_STALE_REVIEWS         = "dismiss_stale_reviews"
 	PROTECTION_IS_ADMIN_ENFORCED               = "enforce_admins"
 	PROTECTION_PATTERN                         = "pattern"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform v0.12.24
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/shurcooL/githubv4 v0.0.0-20191127044304-8f68eb5628d0
+	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -480,6 +480,8 @@ github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lz
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/githubv4 v0.0.0-20191127044304-8f68eb5628d0 h1:T9uus1QvcPgeLShS30YOnnzk3r9Vvygp45muhlrufgY=
 github.com/shurcooL/githubv4 v0.0.0-20191127044304-8f68eb5628d0/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
+github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa h1:jozR3igKlnYCj9IVHOVump59bp07oIRoLQ/CcjMYIUA=
+github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e h1:MZM7FHLqUHYI0Y/mQAt3d2aYa0SiNms/hFqC9qJYolM=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041 h1:llrF3Fs4018ePo4+G/HV/uQUqEI1HMDjCeOf2V6puPc=

--- a/website/docs/r/branch_default.html.markdown
+++ b/website/docs/r/branch_default.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "github"
+page_title: "GitHub: github_branch_default"
+description: |-
+  Provides a GitHub branch default for a given repository.
+---
+
+# github_branch_default
+
+Provides a GitHub branch default resource.
+
+This resource allows you to set the default branch for a given repository. 
+
+## Example Usage
+
+```hcl
+resource "github_repository" "example" {
+  name        = "example"
+  description = "My awesome codebase"
+
+  private = true
+
+  template {
+    owner = "github"
+    repository = "terraform-module-template"
+  }
+}
+
+resource "github_branch" "development" {
+  repository = github_repository.example.name
+  branch     = "development"
+}
+
+resource "github_branch_default" "default"{
+  repository = github_repository.example.name
+  branch     = github_branch.development.branch
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository` - (Required) The GitHub repository
+* `branch` - (Required) The branch (e.g. `main`)
+
+## Import
+
+GitHub Branch Defaults can be imported using an ID made up of `repository`, e.g.
+
+```
+$ terraform import github_branch_default.branch_default my-repo
+```

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -24,8 +24,9 @@ resource "github_branch_protection" "example" {
   # also accepts repository name
   # repository_id  = github_repository.example.name
 
-  pattern        = "main"
-  enforce_admins = true
+  pattern          = "main"
+  enforce_admins   = true
+  allows_deletions = true
 
   required_status_checks {
     strict   = false
@@ -74,6 +75,8 @@ The following arguments are supported:
 * `required_status_checks` - (Optional) Enforce restrictions for required status checks. See [Required Status Checks](#required-status-checks) below for details.
 * `required_pull_request_reviews` - (Optional) Enforce restrictions for pull request reviews. See [Required Pull Request Reviews](#required-pull-request-reviews) below for details.
 * `push_restrictions` - (Optional) The list of actor IDs that may push to the branch.
+* `allows_deletions` - (Optional) Boolean, setting this to `true` to allow the branch to be deleted.
+* `allows_force_pushes` - (Optional) Boolean, setting this to `true` to allow force pushes on the branch.
 
 ### Required Status Checks
 

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `license_template` - (Optional) Use the [name of the template](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses) without the extension. For example, "mit" or "mpl-2.0".
 
-* `default_branch` - (Optional) The name of the default branch of the repository. **NOTE:** This can only be set after a repository has already been created,
+* `default_branch` - (Optional) (Deprecated: Use `github_branch_default` resource instead) The name of the default branch of the repository. **NOTE:** This can only be set after a repository has already been created,
 and after a correct reference has been created for the target branch inside the repository. This means a user will have to omit this parameter from the
 initial repository creation and create the target branch inside of the repository prior to setting this attribute.
 


### PR DESCRIPTION

In the latest Github GraphQL schema  https://developer.github.com/v4/changelog/2020-11-13-schema-changes/ we can manage the rules applied to everyone including administrators.

I have updated https://github.com/shurcooL/githubv4 to add `allowsDeletions`and `allowsForcePushes`settings.

And now I would like to suggest adding it to the related Terraform provider.