### PR TITLE
Use commit SHA to lookup commit info in github_repository_file resource

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -71,6 +71,11 @@ func resourceGithubRepositoryFile() *schema.Resource {
 				Description: "The branch name, defaults to \"main\"",
 				Default:     "main",
 			},
+			"commit_sha": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The SHA of the commit that modified the file",
+			},
 			"commit_message": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -193,12 +198,13 @@ func resourceGithubRepositoryFileCreate(d *schema.ResourceData, meta interface{}
 
 	// Create a new or overwritten file
 	log.Printf("[DEBUG] Creating repository file: %s/%s/%s in branch: %s", owner, repo, file, branch)
-	_, _, err = client.Repositories.CreateFile(ctx, owner, repo, file, opts)
+	create, _, err := client.Repositories.CreateFile(ctx, owner, repo, file, opts)
 	if err != nil {
 		return err
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", repo, file))
+	d.Set("commit", create.Commit.GetSHA())
 
 	return resourceGithubRepositoryFileRead(d, meta)
 }
@@ -237,13 +243,24 @@ func resourceGithubRepositoryFileRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("sha", fc.GetSHA())
 
 	log.Printf("[DEBUG] Fetching commit info for repository file: %s/%s/%s", owner, repo, file)
-	commit, err := getFileCommit(client, owner, repo, file, branch)
+	var commit *github.RepositoryCommit
+
+	// Use the SHA to lookup the commit info if we know it, otherwise loop through commits
+	if sha, ok := d.GetOk("commit_sha"); ok {
+		log.Printf("[DEBUG] Using known commit SHA: %s", sha.(string))
+		commit, _, err = client.Repositories.GetCommit(ctx, owner, repo, sha.(string))
+	} else {
+		log.Printf("[DEBUG] Commit SHA unknown for file: %s/%s/%s, looking for commit...", owner, repo, file)
+		commit, err = getFileCommit(client, owner, repo, file, branch)
+		log.Printf("[DEBUG] Found file: %s/%s/%s, in commit SHA: %s ", owner, repo, file, commit.GetSHA())
+	}
 	if err != nil {
 		return err
 	}
 
-	d.Set("commit_author", commit.GetCommit().GetCommitter().GetName())
-	d.Set("commit_email", commit.GetCommit().GetCommitter().GetEmail())
+	d.Set("commit_sha", commit.GetSHA())
+	d.Set("commit_author", commit.GetCommitter().GetName())
+	d.Set("commit_email", commit.GetCommitter().GetEmail())
 	d.Set("commit_message", commit.GetCommit().GetMessage())
 
 	return nil
@@ -274,10 +291,12 @@ func resourceGithubRepositoryFileUpdate(d *schema.ResourceData, meta interface{}
 	}
 
 	log.Printf("[DEBUG] Updating content in repository file: %s/%s/%s", owner, repo, file)
-	_, _, err = client.Repositories.CreateFile(ctx, owner, repo, file, opts)
+	create, _, err := client.Repositories.CreateFile(ctx, owner, repo, file, opts)
 	if err != nil {
 		return err
 	}
+
+	d.Set("commit_sha", create.GetSHA())
 
 	return resourceGithubRepositoryFileRead(d, meta)
 }

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -24,7 +24,7 @@ func resourceGithubRepositoryFile() *schema.Resource {
 				branch := "main"
 
 				if len(parts) > 2 {
-					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<file path> (when branch is \"master\") or <repository>/<file path>:<branch>")
+					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<file path> (when branch is \"main\") or <repository>/<file path>:<branch>")
 				}
 
 				if len(parts) == 2 {
@@ -68,7 +68,7 @@ func resourceGithubRepositoryFile() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "The branch name, defaults to \"master\"",
+				Description: "The branch name, defaults to \"main\"",
 				Default:     "main",
 			},
 			"commit_message": {

--- a/github/resource_github_repository_file_test.go
+++ b/github/resource_github_repository_file_test.go
@@ -43,6 +43,18 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 				"github_repository_file.test", "sha",
 				"ba0e162e1c47469e3fe4b393a8bf8c569f302116",
 			),
+			resource.TestCheckResourceAttrSet(
+				"github_repository_file.test", "commit_author",
+			),
+			resource.TestCheckResourceAttrSet(
+				"github_repository_file.test", "commit_email",
+			),
+			resource.TestCheckResourceAttrSet(
+				"github_repository_file.test", "commit_message",
+			),
+			resource.TestCheckResourceAttrSet(
+				"github_repository_file.test", "commit_sha",
+			),
 		)
 
 		testCase := func(t *testing.T, mode string) {
@@ -98,6 +110,18 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 			resource.TestCheckResourceAttr(
 				"github_repository_file.test", "sha",
 				"67c1a95c2d9bb138aefeaebb319cca82e531736b",
+			),
+			resource.TestCheckResourceAttrSet(
+				"github_repository_file.test", "commit_author",
+			),
+			resource.TestCheckResourceAttrSet(
+				"github_repository_file.test", "commit_email",
+			),
+			resource.TestCheckResourceAttrSet(
+				"github_repository_file.test", "commit_message",
+			),
+			resource.TestCheckResourceAttrSet(
+				"github_repository_file.test", "commit_sha",
 			),
 		)
 

--- a/website/docs/r/repository_file.html.markdown
+++ b/website/docs/r/repository_file.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `content` - (Required) The file content.
 
-* `branch` - (Optional) Git branch (defaults to `master`).
+* `branch` - (Optional) Git branch (defaults to `main`).
   The branch must already exist, it will not be created if it does not already exist.
 
 * `commit_author` - (Optional) Committer author name to use.
@@ -70,7 +70,7 @@ Repository files can be imported using a combination of the `repo` and `file`, e
 $ terraform import github_repository_file.gitignore example/.gitignore
 ```
 
-To import a file from a branch other than master, append `:` and the branch name, e.g.
+To import a file from a branch other than main, append `:` and the branch name, e.g.
 
 ```
 $ terraform import github_repository_file.gitignore example/.gitignore:dev

--- a/website/docs/r/repository_file.html.markdown
+++ b/website/docs/r/repository_file.html.markdown
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 The following additional attributes are exported:
 
+* `commit_sha` - The SHA of the commit that modified the file.
+
 * `sha` - The SHA blob of the file.
 
 


### PR DESCRIPTION
Currently the provider loops through commits in a repo until it finds the most recent commit containing the managed file. This is inefficient and could lead to you being rate limited if managing a few files that were updated a long time ago.

This PR fixes that by storing the commit SHA when updating the file and using that SHA to lookup the commit info instead of looping through all commits.